### PR TITLE
fix: resolve GSC 'noindex' errors by aligning sitemap and robots meta…

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -44,6 +44,17 @@ export async function generateMetadata(): Promise<Metadata> {
       'Aesthetic Intelligence',
       'Inner G Complete Agency',
     ],
+    robots: {
+      index: true,
+      follow: true,
+      googleBot: {
+        index: true,
+        follow: true,
+        'max-video-preview': -1,
+        'max-image-preview': 'large',
+        'max-snippet': -1,
+      },
+    },
     authors: [{ name: 'Lamont Evans', url: '/about' }],
     creator: tenantName,
     publisher: tenantName,

--- a/app/privacy-policy/layout.tsx
+++ b/app/privacy-policy/layout.tsx
@@ -4,7 +4,7 @@ export const metadata: Metadata = {
   title: 'Privacy Policy | Inner G Complete Agency',
   description: 'Our privacy and data governance framework for handling enterprise intelligence, client data, and site user data.',
   robots: {
-    index: false,
+    index: true,
     follow: true,
   },
 }

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -16,8 +16,6 @@ export default async function robots(): Promise<MetadataRoute.Robots> {
       disallow: [
         '/login/',
         '/select-portal/',
-        '/privacy-policy/',
-        '/terms-of-service/',
         '/api/',
         '/auth/'
       ],

--- a/app/terms-of-service/layout.tsx
+++ b/app/terms-of-service/layout.tsx
@@ -4,7 +4,7 @@ export const metadata: Metadata = {
   title: 'Terms of Service | Inner G Complete Agency',
   description: 'Terms of service and enterprise agreements for Inner G Complete Agency website and ADI deployments.',
   robots: {
-    index: false,
+    index: true,
     follow: true,
   },
 }


### PR DESCRIPTION
…data

Detailed changes:
- Set index: true for Privacy Policy and Terms of Service.
- Removed legal pages from robots.txt disallow list.
- Added explicit global robots indexing directives in root layout.