### PR TITLE
feat: census/school-district enrichment, pixel analytics bot/data-qua…

### DIFF
--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -48,13 +48,25 @@ export async function POST(req: Request) {
     if (shopId) {
       const { data: shopRow } = await supabase
         .from('agent_barbershop_leads')
-        .select('id, shop_name, city, latitude, longitude, rent_rate')
+        .select('id, shop_name, city, latitude, longitude, rent_rate, census_median_household_income, census_population, school_district_name')
         .eq('id', shopId)
-        .single() as { data: { id: string; shop_name: string; city: string | null; latitude: number | null; longitude: number | null; rent_rate: string | null } | null };
+        .single() as { data: { id: string; shop_name: string; city: string | null; latitude: number | null; longitude: number | null; rent_rate: string | null; census_median_household_income: number | null; census_population: number | null; school_district_name: string | null } | null };
       if (shopRow) {
         const report = await computeShopEcosystemReport(supabase as any, shopRow);
         if (report) {
-          shopEcosystemContext = { shop_name: shopRow.shop_name, city: shopRow.city, profile_url: `/shop/${shopRow.id}`, ...report };
+          shopEcosystemContext = {
+            shop_name: shopRow.shop_name,
+            city: shopRow.city,
+            profile_url: `/shop/${shopRow.id}`,
+            // Direct properties of the shop's own location, not a radius
+            // computation — median_household_income is Census ACS 5-Year
+            // data for the shop's tract, used for pricing-vs-local-income
+            // reasoning; school_district is a community/cultural anchor.
+            local_census_tract_median_household_income: shopRow.census_median_household_income,
+            local_census_tract_population: shopRow.census_population,
+            school_district: shopRow.school_district_name,
+            ...report,
+          };
         }
       }
     }
@@ -99,6 +111,7 @@ export async function POST(req: Request) {
       platformTools,
       testingLeaderboard,
       cosmetologyTestingLeaderboard,
+      districtBarbershopRankings,
     ] = await Promise.all([
       rpcCall('search_barbershops_ranked', {
         query_text: latestMessage,
@@ -205,6 +218,10 @@ export async function POST(req: Request) {
           .sort((a: any, b: any) => (b.cosmetology_written_test_takers_2026 || 0) - (a.cosmetology_written_test_takers_2026 || 0))
           .slice(0, 8);
       })(),
+      // "Which school district has the best barbershops" is an aggregate
+      // across ALL shops grouped by district — a top-3 similarity search
+      // can't answer that, same reasoning as the exam leaderboards above.
+      rpcCall('get_school_district_barbershop_rankings', {}),
     ]);
 
     // search_schools_ranked also returns 2026 pass-rate/test-taker fields
@@ -232,6 +249,7 @@ export async function POST(req: Request) {
       ...(shopEcosystemContext ? { my_shop_ecosystem_report: shopEcosystemContext } : {}),
       texas_2026_exam_school_leaderboard: withProfileUrl(testingLeaderboard, '/schools'),
       texas_2026_cosmetology_exam_school_leaderboard: withProfileUrl(cosmetologyTestingLeaderboard, '/schools'),
+      school_district_barbershop_rankings: districtBarbershopRankings,
       barbershops: withProfileUrl(shops, '/shop'),
       professionals: withProfileUrl(barbers, '/barbers'),
       barber_and_cosmetology_schools: withProfileUrl(schoolsForLookup, '/schools'),
@@ -253,6 +271,16 @@ The ONE exception is articles_and_videos: each entry's "url" field IS meant to b
 Use each link only once per response.
 
 MY_SHOP_ECOSYSTEM_REPORT RULE: If my_shop_ecosystem_report is present, the user is that shop's owner asking about their own local market — it has real computed stats (talent pipeline, labor supply, competition, supply chain, rent) within a radius of their shop, not a search result. Given the 100-word limit, lead with the single most decision-relevant insight (e.g. a tight labor market, a standout nearby school, or rent well above/below the local median) rather than listing every number. If they ask a strategic follow-up (e.g. "should I raise my rent," "should I hire now") that the report's numbers directly speak to, give a concrete, data-grounded answer using those numbers (e.g. rent sitting well below the local median directly supports room to raise it) — don't deflect to "I don't have enough information" when the relevant number is already in my_shop_ecosystem_report. Only decline if the question needs information genuinely outside this data (e.g. their specific finances, lease terms, or customer base).
+local_census_tract_median_household_income and school_district (also inside my_shop_ecosystem_report, when present — some shops haven't been enriched yet) are two more direct signals about the shop's own location, not a radius computation. Use school_district only when it's actually relevant to what they're asking (e.g. marketing, target clientele, "who are my customers") — Texas barbershops are neighborhood/community hubs, so being in a specific ISD is a real identity signal, but don't force it into every answer.
+
+INCOME/POPULATION: my_shop_ecosystem_report has TWO distinct pairs of figures — don't conflate them. (1) local_census_tract_median_household_income and local_census_tract_population describe ONLY the shop's own immediate census tract, a small area (often just a couple thousand people) — the single most precise figure for its exact block, but not representative of its full trade area. (2) marketDemographics.weightedAvgMedianHouseholdIncome and marketDemographics.estimatedPopulation are aggregated across every census tract found within the SAME radiusMiles as the rest of this report (see marketDemographics.tractsSampled for how many tracts that covers) — this is the right figure for "how many people/what income level is in my market" since it matches the scope of every other stat in this report (competition, labor supply, schools). Prefer marketDemographics for general "my market/my area" questions; use the tract-level figure only when they're specifically asking about their immediate block. If marketDemographics values are null (tractsSampled is 0), fall back to the tract-level figures and say so.
+Outside of my_shop_ecosystem_report entirely (no shop context at all), there is no general area/city-wide income or population lookup. Say clearly that you have income/population data scoped to a specific shop's market (via its profile page) but not as a standalone general lookup — don't just say "I don't have information on income data" as if the concept doesn't exist at all, since that's misleading about what the platform can actually do.
+
+RADIUS IS FIXED: my_shop_ecosystem_report.radiusMiles is a fixed value computed once for this report (10 miles by default) — you cannot recompute it at a different radius, and there is no live tool call available to do so mid-conversation. If asked for a different radius (e.g. "what about a 5-mile radius"), say plainly that this report is fixed at radiusMiles and you don't have the ability to recompute it at a different distance — do NOT say "we can adjust this" or otherwise imply that's possible.
+
+SCHOOL_DISTRICT_NAME RULE: barbershops, salons, professionals, and cosmetologists in the general lookup context (not just my_shop_ecosystem_report) may include a school_district_name field — mention it when relevant (e.g. comparing two shops' neighborhoods, or a "what area is this in" question), same community-identity framing as above.
+
+SCHOOL_DISTRICT_BARBERSHOP_RANKINGS RULE: This is a direct ranked list of school districts by average barbershop rating (shop_count and hiring_shop_count are also included), already sorted best-to-worst, for "which school district/area has the best barbershops" style questions — only districts with at least 3 rated shops are included, so small-sample outliers aren't cherry-picked. Use this instead of trying to infer district quality from the handful of individual barbershops elsewhere in the context. IMPORTANT: entries here have NO profile_url — there is no page on this site for browsing by school district. Mention district names as plain text only, exactly like any other item without a profile_url per the LINKING RULE above — do not invent, guess, or construct a URL for a school district under any circumstances (e.g. never write something like "/school-districts/...").
 
 Context Data (JSON):
 ${JSON.stringify(mergedContext).substring(0, 120000)}

--- a/app/barbers/[id]/page.tsx
+++ b/app/barbers/[id]/page.tsx
@@ -18,6 +18,7 @@ import {
   Users,
   Clock,
   Navigation,
+  Landmark,
 } from "lucide-react";
 
 export const revalidate = 3600;
@@ -55,6 +56,7 @@ const PUBLIC_COLUMNS = [
   "booksy_rating",
   "booksy_review_count",
   "booksy_hours",
+  "school_district_name",
 ].join(", ");
 
 async function getBarber(id: string) {
@@ -198,6 +200,12 @@ export default async function BarberProfilePage(props: { params: Promise<{ id: s
                 <p className="text-sm text-slate-500 font-medium mt-1 flex items-center gap-1.5">
                   <MapPin className="w-3.5 h-3.5" />
                   {barber.address}
+                </p>
+              )}
+              {barber.school_district_name && (
+                <p className="text-sm text-slate-500 font-medium mt-1 flex items-center gap-1.5">
+                  <Landmark className="w-3.5 h-3.5" />
+                  Located in {barber.school_district_name}
                 </p>
               )}
 

--- a/app/cosmetologists/[id]/page.tsx
+++ b/app/cosmetologists/[id]/page.tsx
@@ -15,6 +15,7 @@ import {
   Music2,
   Users,
   Navigation,
+  Landmark,
 } from "lucide-react";
 
 export const revalidate = 3600;
@@ -44,6 +45,7 @@ const PUBLIC_COLUMNS = [
   "booksy_price_range",
   "booksy_rating",
   "booksy_review_count",
+  "school_district_name",
 ].join(", ");
 
 async function getCosmetologist(id: string) {
@@ -178,6 +180,12 @@ export default async function CosmetologistProfilePage(props: { params: Promise<
                 <p className="text-sm text-slate-500 font-medium mt-1 flex items-center gap-1.5">
                   <MapPin className="w-3.5 h-3.5" />
                   {person.address}
+                </p>
+              )}
+              {person.school_district_name && (
+                <p className="text-sm text-slate-500 font-medium mt-1 flex items-center gap-1.5">
+                  <Landmark className="w-3.5 h-3.5" />
+                  Located in {person.school_district_name}
                 </p>
               )}
 

--- a/app/houston/insights/market-analysis/[shop_slug]/page.tsx
+++ b/app/houston/insights/market-analysis/[shop_slug]/page.tsx
@@ -25,11 +25,19 @@ export async function generateMetadata(
   const resolvedParams = await params;
   const slug = resolvedParams.shop_slug;
 
+  // city is stored as "Houston 77023" (city + zip) for the vast majority of
+  // rows, not a bare "Houston" — an exact match here silently missed 95% of
+  // shops (confirmed: 28 of 584 Houston shops match exactly, vs 584 with
+  // ilike), falling back to the generic title for nearly every page.
+  // No "state" column exists on this table (this feature is Houston/Texas-
+  // only, so it's hardcoded below) — selecting it errored on every request,
+  // silently masking the fallback title regardless of whether the shop
+  // lookup itself succeeded.
   const { data: shop } = await supabase
     .from('agent_barbershop_leads')
-    .select('shop_name, city, state')
+    .select('shop_name, city')
     .ilike('chair_pricing_tool_url', `%/${slug}%`)
-    .eq('city', 'Houston')
+    .ilike('city', '%houston%')
     .limit(1)
     .single();
 
@@ -37,7 +45,7 @@ export async function generateMetadata(
 
   return {
     title: `${shop.shop_name} - Houston Barbershop Market Analysis & Foot Traffic`,
-    description: `Deep market analysis and foot traffic radar for ${shop.shop_name} in ${shop.city}, ${shop.state}. See hiring status, booth rent pricing, and competitor density.`,
+    description: `Deep market analysis and foot traffic radar for ${shop.shop_name} in ${shop.city}, TX. See hiring status, booth rent pricing, and competitor density.`,
   }
 }
 

--- a/app/pixel-analytics/actions.ts
+++ b/app/pixel-analytics/actions.ts
@@ -13,6 +13,7 @@ export type AnalyticsData = {
   activeUsers: number
   engagedUsers: number
   returningUsers: number
+  qualifiedVisitors: number
   totalSearches: number
   uniqueSearchers: number
   outboundLeads: number
@@ -47,7 +48,7 @@ export async function fetchAnalyticsData(days?: number): Promise<AnalyticsData> 
     console.error("Error fetching pixel RPC summary:", summaryError);
     // Return empty fallback if the RPC fails
     return {
-      totalViews: 0, totalClicks: 0, activeUsers: 0, engagedUsers: 0, returningUsers: 0,
+      totalViews: 0, totalClicks: 0, activeUsers: 0, engagedUsers: 0, returningUsers: 0, qualifiedVisitors: 0,
       totalSearches: 0, uniqueSearchers: 0, outboundLeads: 0, shopClaims: 0,
       aiModeActivations: 0, aiMessagesSent: 0, aiRateLimitHits: 0,
       topPages: [], topInsights: [], topReferrers: [], topFilters: [], recentEvents: []
@@ -74,6 +75,7 @@ export async function fetchAnalyticsData(days?: number): Promise<AnalyticsData> 
     activeUsers: summary.activeUsers || 0,
     engagedUsers: summary.engagedUsers || 0,
     returningUsers: summary.returningUsers || 0,
+    qualifiedVisitors: summary.qualifiedVisitors || 0,
     totalSearches: summary.totalSearches || 0,
     uniqueSearchers: summary.uniqueSearchers || 0,
     outboundLeads: summary.outboundLeads || 0,

--- a/app/pixel-analytics/page.tsx
+++ b/app/pixel-analytics/page.tsx
@@ -1,6 +1,6 @@
 import Link from "next/link"
 import { fetchAnalyticsData } from "./actions"
-import { BarChart3, Users, MousePointerClick, Activity, Globe, Link as LinkIcon, Zap, RefreshCw, Target } from "lucide-react"
+import { BarChart3, Users, MousePointerClick, Activity, Globe, Link as LinkIcon, Zap, RefreshCw, Target, ShieldCheck } from "lucide-react"
 import { Navbar } from "@/components/layout/navbar"
 import { Footer } from "@/components/layout/footer"
 
@@ -35,7 +35,7 @@ export default async function PixelAnalyticsPage(
                 Pixel <span className="text-transparent bg-clip-text bg-gradient-to-r from-primary to-blue-500">Analytics</span>
               </h1>
               <p className="text-slate-500 dark:text-slate-400 max-w-2xl text-lg">
-                Real-time domain intelligence and visitor telemetry. Showing data exclusively for <code className="bg-slate-200 dark:bg-slate-800 px-2 py-0.5 rounded text-sm">localhost</code> and <code className="bg-slate-200 dark:bg-slate-800 px-2 py-0.5 rounded text-sm">innergcomplete.com</code>.
+                Real-time domain intelligence and visitor telemetry. Showing data exclusively for <code className="bg-slate-200 dark:bg-slate-800 px-2 py-0.5 rounded text-sm">innergcomplete.com</code>.
               </p>
             </div>
 
@@ -68,7 +68,7 @@ export default async function PixelAnalyticsPage(
         </header>
 
         {/* KPI Cards */}
-        <div className="grid grid-cols-2 lg:grid-cols-5 gap-4 md:gap-6 mb-12">
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4 md:gap-6 mb-12">
           <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-5 shadow-sm hover:shadow-md transition-shadow">
             <div className="flex items-center gap-3 mb-3">
               <div className="p-2.5 bg-blue-50 dark:bg-blue-900/20 rounded-xl text-blue-600 dark:text-blue-400">
@@ -87,6 +87,16 @@ export default async function PixelAnalyticsPage(
               <h3 className="font-semibold text-sm text-slate-600 dark:text-slate-400">Unique Browsers</h3>
             </div>
             <p className="text-3xl font-black">{data.activeUsers.toLocaleString()}</p>
+          </div>
+
+          <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-5 shadow-sm hover:shadow-md transition-shadow">
+            <div className="flex items-center gap-3 mb-3">
+              <div className="p-2.5 bg-teal-50 dark:bg-teal-900/20 rounded-xl text-teal-600 dark:text-teal-400">
+                <ShieldCheck className="w-5 h-5" />
+              </div>
+              <h3 className="font-semibold text-sm text-slate-600 dark:text-slate-400">Qualified Visitors</h3>
+            </div>
+            <p className="text-3xl font-black">{data.qualifiedVisitors.toLocaleString()}</p>
           </div>
 
           <div className="bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-800 rounded-2xl p-5 shadow-sm hover:shadow-md transition-shadow relative overflow-hidden">

--- a/app/salons/[id]/page.tsx
+++ b/app/salons/[id]/page.tsx
@@ -13,6 +13,7 @@ import {
   Navigation,
   Users,
   ExternalLink,
+  Landmark,
 } from "lucide-react";
 
 export const revalidate = 3600;
@@ -36,6 +37,7 @@ const PUBLIC_COLUMNS = [
   "business_status",
   "google_images",
   "site_config",
+  "school_district_name",
 ].join(", ");
 
 async function getSalon(id: string) {
@@ -147,6 +149,12 @@ export default async function SalonProfilePage(props: { params: Promise<{ id: st
                 <p className="text-sm text-slate-500 font-medium mt-1 flex items-center gap-1.5">
                   <MapPin className="w-3.5 h-3.5" />
                   {salon.formatted_address}
+                </p>
+              )}
+              {salon.school_district_name && (
+                <p className="text-sm text-slate-500 font-medium mt-1 flex items-center gap-1.5">
+                  <Landmark className="w-3.5 h-3.5" />
+                  Located in {salon.school_district_name}
                 </p>
               )}
 

--- a/app/shop/[id]/page.tsx
+++ b/app/shop/[id]/page.tsx
@@ -3,7 +3,7 @@ import { Metadata, ResolvingMetadata } from "next";
 import { Footer } from "@/components/layout/footer";
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { MapPin, Star, Scissors, CheckCircle2, ShieldCheck, Lock, Award, Users, ChevronLeft, Map as MapIcon, Mail, Phone, Info, GraduationCap, TrendingUp, TrendingDown, ShoppingBag, Sparkles } from "lucide-react";
+import { MapPin, Star, Scissors, CheckCircle2, ShieldCheck, Lock, Award, Users, ChevronLeft, Map as MapIcon, Mail, Phone, Info, GraduationCap, TrendingUp, TrendingDown, ShoppingBag, Sparkles, Landmark } from "lucide-react";
 import { computeShopEcosystemReport } from "@/lib/shop-ecosystem";
 import Image from "next/image";
 import { RequestShopDayButton } from "@/components/shared/request-shop-day-button";
@@ -151,6 +151,12 @@ export default async function ShopProfilePage({ params }: Props) {
                 <span className="font-bold text-slate-900">{shop.rating || "4.8"}</span>
                 <span className="text-slate-500 underline decoration-slate-300 underline-offset-4 cursor-pointer">({shop.total_reviews || 0} reviews)</span>
               </span>
+              {shop.school_district_name && (
+                <span className="flex items-center gap-1.5">
+                  <Landmark className="w-4 h-4" />
+                  Located in {shop.school_district_name}
+                </span>
+              )}
             </div>
           </div>
 

--- a/app/tools/barbershop-search/page.tsx
+++ b/app/tools/barbershop-search/page.tsx
@@ -72,6 +72,13 @@ function SearchContent() {
   const [chatMessages, setChatMessages] = useState<{role: string, content: string}[]>([]);
   const [chatInput, setChatInput] = useState("");
   const [isAiLoading, setIsAiLoading] = useState(false);
+  // Sticks for the rest of the conversation once an "Ask AI About This
+  // Market" session starts — without this, only the kickoff message
+  // included shopId (it's passed explicitly there), so every follow-up
+  // question lost access to that shop's ecosystem report (rent, labor
+  // supply, income, school district) even though the conversation was
+  // still clearly about the same shop.
+  const [activeEcosystemShopId, setActiveEcosystemShopId] = useState<string | undefined>(undefined);
   
   const { setTheme } = useTheme();
 
@@ -123,7 +130,7 @@ function SearchContent() {
 
   const handleChatSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    sendChatMessage(chatInput);
+    sendChatMessage(chatInput, activeEcosystemShopId);
   };
 
   const handleTabClick = (tab: string) => {
@@ -163,6 +170,7 @@ function SearchContent() {
     const ecosystemShopName = searchParams.get("ecosystemShopName");
     if (ecosystemShopId && chatMessages.length === 0) {
       setFilterTab("AI Mode");
+      setActiveEcosystemShopId(ecosystemShopId);
       const shopLabel = ecosystemShopName || "my shop";
       sendChatMessage(`Tell me about the market ecosystem around ${shopLabel} — talent pipeline, labor supply, competition, and rent.`, ecosystemShopId);
     }
@@ -207,6 +215,12 @@ function SearchContent() {
           if (!ignore) {
             setResults(parsed.results);
             setTotal(parsed.total);
+            // A cache hit resolves synchronously — nothing is actually
+            // loading. Without this, isLoading can be stuck at whatever a
+            // prior handleTabClick() left it as (it unconditionally sets
+            // isLoading(true) on every tab switch), and this early return
+            // was the one path that never got a chance to clear it.
+            setIsLoading(false);
           }
           return;
         }
@@ -226,6 +240,10 @@ function SearchContent() {
       } else {
         setResults([]);
         setTotal(0);
+        // Same reasoning as the cache-hit branch above: a query that's too
+        // short to search isn't "loading" anything, but handleTabClick()
+        // may have already set isLoading(true) before this ran.
+        setIsLoading(false);
       }
     }, 300);
 

--- a/lib/geo-enrichment.ts
+++ b/lib/geo-enrichment.ts
@@ -1,0 +1,107 @@
+// Backend geo-enrichment: maps a lat/long to its Census tract/block group
+// (+ demographic data) and school district. All three underlying services
+// were validated directly against real shop coordinates before this was
+// written — see the FCC, Census ACS, and ArcGIS-hosted NCES school district
+// FeatureServer calls this wraps.
+
+export interface CensusGeography {
+  stateFips: string;
+  countyFips: string;
+  tractFips: string;
+  blockGroupFips: string;
+  tractGeoid: string; // state+county+tract, 11 digits
+  blockGroupGeoid: string; // state+county+tract+block group, 12 digits
+}
+
+export interface AcsIncomeData {
+  medianHouseholdIncome: number | null;
+  population: number | null;
+}
+
+export interface SchoolDistrict {
+  name: string;
+  geoid: string;
+}
+
+// FCC's block FIPS is state(2) + county(3) + tract(6) + block(4). The block
+// group is just the first digit of the 4-digit block code — not a separate
+// lookup, this is how the Census Bureau defines block groups.
+export async function getCensusGeography(lat: number, lng: number): Promise<CensusGeography | null> {
+  try {
+    const res = await fetch(`https://geo.fcc.gov/api/census/block/find?latitude=${lat}&longitude=${lng}&format=json`);
+    if (!res.ok) return null;
+    const data = await res.json();
+    const fips: string | undefined = data?.Block?.FIPS;
+    if (!fips || fips.length !== 15) return null;
+
+    const stateFips = fips.slice(0, 2);
+    const countyFips = fips.slice(2, 5);
+    const tractFips = fips.slice(5, 11);
+    const blockGroupFips = fips.slice(11, 12);
+
+    return {
+      stateFips,
+      countyFips,
+      tractFips,
+      blockGroupFips,
+      tractGeoid: `${stateFips}${countyFips}${tractFips}`,
+      blockGroupGeoid: `${stateFips}${countyFips}${tractFips}${blockGroupFips}`,
+    };
+  } catch (e) {
+    console.error("getCensusGeography failed:", e);
+    return null;
+  }
+}
+
+// Census ACS suppresses unavailable estimates as -666666666 rather than
+// null/omitting the field — has to be checked for explicitly or it reads as
+// a real (nonsensical) income figure.
+const SUPPRESSED_VALUE = -666666666;
+
+export async function getAcsIncomeData(stateFips: string, countyFips: string, tractFips: string): Promise<AcsIncomeData | null> {
+  const apiKey = process.env.CENSUS_API_KEY;
+  if (!apiKey) return null;
+  try {
+    const url = `https://api.census.gov/data/2023/acs/acs5?get=NAME,B19013_001E,B01003_001E&for=tract:${tractFips}&in=state:${stateFips}+county:${countyFips}&key=${apiKey}`;
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const rows = await res.json();
+    if (!Array.isArray(rows) || rows.length < 2) return null;
+    const [, income, population] = rows[1];
+    const incomeNum = Number(income);
+    const popNum = Number(population);
+    return {
+      medianHouseholdIncome: incomeNum === SUPPRESSED_VALUE || Number.isNaN(incomeNum) ? null : incomeNum,
+      population: popNum === SUPPRESSED_VALUE || Number.isNaN(popNum) ? null : popNum,
+    };
+  } catch (e) {
+    console.error("getAcsIncomeData failed:", e);
+    return null;
+  }
+}
+
+const SCHOOL_DISTRICT_FEATURE_SERVER =
+  "https://services1.arcgis.com/Ua5sjt3LWTPigjyD/arcgis/rest/services/School_Districts_Current/FeatureServer/0/query";
+
+export async function getSchoolDistrict(lat: number, lng: number): Promise<SchoolDistrict | null> {
+  try {
+    const params = new URLSearchParams({
+      geometry: `${lng},${lat}`,
+      geometryType: "esriGeometryPoint",
+      inSR: "4326",
+      spatialRel: "esriSpatialRelIntersects",
+      outFields: "NAME,GEOID",
+      returnGeometry: "false",
+      f: "json",
+    });
+    const res = await fetch(`${SCHOOL_DISTRICT_FEATURE_SERVER}?${params}`);
+    if (!res.ok) return null;
+    const data = await res.json();
+    const feature = data?.features?.[0]?.attributes;
+    if (!feature?.NAME) return null;
+    return { name: feature.NAME, geoid: feature.GEOID };
+  } catch (e) {
+    console.error("getSchoolDistrict failed:", e);
+    return null;
+  }
+}

--- a/lib/shop-ecosystem.ts
+++ b/lib/shop-ecosystem.ts
@@ -70,6 +70,20 @@ export interface ShopEcosystemReport {
     percentDiff: number | null;
     sampleSize: number;
   };
+  marketDemographics: {
+    // Estimated by summing population (and population-weighting income)
+    // across every DISTINCT census tract our tracked shops/salons/barbers/
+    // cosmetologists within the radius happen to fall into — the same
+    // "count what's in our database within the radius" methodology as
+    // every other section here (schoolCount, nearbyShopCount, etc. are
+    // equally just OUR tracked universe, not an independent ground truth).
+    // Not a substitute for the shop's own single-tract income (still the
+    // most precise figure for its immediate block), but this is what
+    // actually matches the 10-mile scope the rest of the report uses.
+    estimatedPopulation: number | null;
+    weightedAvgMedianHouseholdIncome: number | null;
+    tractsSampled: number;
+  };
 }
 
 // Computes a barbershop's local market position: talent pipeline quality,
@@ -105,16 +119,16 @@ export async function computeShopEcosystemReport(
       "id, latitude, longitude, school_name, cosmetology_school_leaderboard_score_2026",
       (q) => q.not("latitude", "is", null).not("longitude", "is", null)),
     fetchAllRows(supabase, "agent_barber_leads",
-      "id, latitude, longitude, status",
+      "id, latitude, longitude, status, census_tract_geoid, census_population, census_median_household_income",
       (q) => q.eq("status", "interested_in_placement").not("latitude", "is", null).not("longitude", "is", null)),
     fetchAllRows(supabase, "agent_cosmetologist_leads",
-      "id, latitude, longitude",
+      "id, latitude, longitude, census_tract_geoid, census_population, census_median_household_income",
       (q) => q.not("latitude", "is", null).not("longitude", "is", null)),
     fetchAllRows(supabase, "agent_barbershop_leads",
-      "id, latitude, longitude, hiring_need, booth_count_available, rent_rate",
+      "id, latitude, longitude, hiring_need, booth_count_available, rent_rate, census_tract_geoid, census_population, census_median_household_income",
       (q) => q.not("latitude", "is", null).not("longitude", "is", null)),
     fetchAllRows(supabase, "agent_salon_leads",
-      "id, latitude, longitude, hiring_need, booth_count_available, rent_rate",
+      "id, latitude, longitude, hiring_need, booth_count_available, rent_rate, census_tract_geoid, census_population, census_median_household_income",
       (q) => q.not("latitude", "is", null).not("longitude", "is", null)),
     fetchAllRows(supabase, "agent_barber_supply_store_leads",
       "id, latitude, longitude, name",
@@ -162,6 +176,25 @@ export async function computeShopEcosystemReport(
     ? ((thisShopWeeklyRent - localMedianWeeklyRent) / localMedianWeeklyRent) * 100
     : null;
 
+  // Aggregate population/income across every DISTINCT census tract that any
+  // tracked shop/salon/barber/cosmetologist within the radius falls into —
+  // gives a population and income figure actually scoped to the same
+  // 10-mile radius as everything else above, instead of just the shop's own
+  // single tract (which stays available separately, still the most precise
+  // figure for its immediate block).
+  const tractMap = new Map<string, { population: number; income: number | null }>();
+  for (const r of [...nearbyShops, ...nearbySalons, ...nearbyBarbers, ...nearbyCosmetologists] as any[]) {
+    if (r.census_tract_geoid && r.census_population != null && !tractMap.has(r.census_tract_geoid)) {
+      tractMap.set(r.census_tract_geoid, { population: r.census_population, income: r.census_median_household_income });
+    }
+  }
+  const tracts = Array.from(tractMap.values());
+  const estimatedPopulation = tracts.length > 0 ? tracts.reduce((sum, t) => sum + t.population, 0) : null;
+  const incomeWeightedPool = tracts.filter((t) => t.income != null);
+  const weightedAvgMedianHouseholdIncome = incomeWeightedPool.length > 0
+    ? incomeWeightedPool.reduce((sum, t) => sum + t.income! * t.population, 0) / incomeWeightedPool.reduce((sum, t) => sum + t.population, 0)
+    : null;
+
   return {
     shopId: shop.id,
     radiusMiles,
@@ -191,6 +224,11 @@ export async function computeShopEcosystemReport(
       localMedianWeeklyRent,
       percentDiff,
       sampleSize: rentPool.length,
+    },
+    marketDemographics: {
+      estimatedPopulation,
+      weightedAvgMedianHouseholdIncome: weightedAvgMedianHouseholdIncome != null ? Math.round(weightedAvgMedianHouseholdIncome) : null,
+      tractsSampled: tracts.length,
     },
   };
 }

--- a/scripts/backfill_census_school_district.js
+++ b/scripts/backfill_census_school_district.js
@@ -1,0 +1,165 @@
+// Backfills census tract/block group + school district onto the 4 entity
+// tables where pricing/community-identity intelligence matters. Idempotent —
+// only processes rows where census_tract_geoid is still null, so it's safe
+// to re-run after a partial failure or to pick up newly-added shops later.
+//
+// ACS median household income is cached per unique tract (not called once
+// per row) since many shops in the same tract would otherwise mean
+// redundant Census Bureau API calls for identical data.
+require("dotenv").config({ path: ".env.local" });
+const { createClient } = require("@supabase/supabase-js");
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const SUPPRESSED_VALUE = -666666666;
+const SCHOOL_DISTRICT_FEATURE_SERVER =
+  "https://services1.arcgis.com/Ua5sjt3LWTPigjyD/arcgis/rest/services/School_Districts_Current/FeatureServer/0/query";
+
+async function getCensusGeography(lat, lng) {
+  const res = await fetch(`https://geo.fcc.gov/api/census/block/find?latitude=${lat}&longitude=${lng}&format=json`);
+  if (!res.ok) return null;
+  const data = await res.json();
+  const fips = data?.Block?.FIPS;
+  if (!fips || fips.length !== 15) return null;
+  const stateFips = fips.slice(0, 2);
+  const countyFips = fips.slice(2, 5);
+  const tractFips = fips.slice(5, 11);
+  const blockGroupFips = fips.slice(11, 12);
+  return {
+    stateFips, countyFips, tractFips, blockGroupFips,
+    tractGeoid: `${stateFips}${countyFips}${tractFips}`,
+    blockGroupGeoid: `${stateFips}${countyFips}${tractFips}${blockGroupFips}`,
+  };
+}
+
+const acsCache = new Map();
+async function getAcsIncomeData(stateFips, countyFips, tractFips) {
+  const key = `${stateFips}-${countyFips}-${tractFips}`;
+  if (acsCache.has(key)) return acsCache.get(key);
+  const apiKey = process.env.CENSUS_API_KEY;
+  if (!apiKey) return null;
+  const url = `https://api.census.gov/data/2023/acs/acs5?get=NAME,B19013_001E,B01003_001E&for=tract:${tractFips}&in=state:${stateFips}+county:${countyFips}&key=${apiKey}`;
+  const res = await fetch(url);
+  if (!res.ok) { acsCache.set(key, null); return null; }
+  const rows = await res.json();
+  if (!Array.isArray(rows) || rows.length < 2) { acsCache.set(key, null); return null; }
+  const [, income, population] = rows[1];
+  const incomeNum = Number(income);
+  const popNum = Number(population);
+  const result = {
+    medianHouseholdIncome: incomeNum === SUPPRESSED_VALUE || Number.isNaN(incomeNum) ? null : incomeNum,
+    population: popNum === SUPPRESSED_VALUE || Number.isNaN(popNum) ? null : popNum,
+  };
+  acsCache.set(key, result);
+  return result;
+}
+
+async function getSchoolDistrict(lat, lng) {
+  const params = new URLSearchParams({
+    geometry: `${lng},${lat}`,
+    geometryType: "esriGeometryPoint",
+    inSR: "4326",
+    spatialRel: "esriSpatialRelIntersects",
+    outFields: "NAME,GEOID",
+    returnGeometry: "false",
+    f: "json",
+  });
+  const res = await fetch(`${SCHOOL_DISTRICT_FEATURE_SERVER}?${params}`);
+  if (!res.ok) return null;
+  const data = await res.json();
+  const feature = data?.features?.[0]?.attributes;
+  if (!feature?.NAME) return null;
+  return { name: feature.NAME, geoid: feature.GEOID };
+}
+
+async function enrichRow(table, idCol, row) {
+  const { lat, lng } = row;
+  const geo = await getCensusGeography(lat, lng);
+  const district = await getSchoolDistrict(lat, lng);
+  let income = null;
+  if (geo) {
+    income = await getAcsIncomeData(geo.stateFips, geo.countyFips, geo.tractFips);
+  }
+
+  const update = {
+    census_tract_geoid: geo?.tractGeoid ?? null,
+    census_block_group_geoid: geo?.blockGroupGeoid ?? null,
+    census_median_household_income: income?.medianHouseholdIncome ?? null,
+    census_population: income?.population ?? null,
+    census_data_updated_at: geo ? new Date().toISOString() : null,
+    school_district_name: district?.name ?? null,
+    school_district_geoid: district?.geoid ?? null,
+    school_district_updated_at: district ? new Date().toISOString() : null,
+  };
+
+  const { error } = await supabase.from(table).update(update).eq("id", row[idCol]);
+  if (error) {
+    console.error(`  FAILED to update ${table} id=${row[idCol]}:`, error.message);
+    return false;
+  }
+  return true;
+}
+
+// Small bounded concurrency — polite to the free FCC/Census/ArcGIS
+// endpoints, and none of them document a formal rate limit worth pushing
+// against.
+async function processBatch(items, worker, concurrency = 5) {
+  let i = 0;
+  let ok = 0, failed = 0;
+  async function next() {
+    while (i < items.length) {
+      const idx = i++;
+      const success = await worker(items[idx]);
+      if (success) ok++; else failed++;
+      if ((ok + failed) % 50 === 0) console.log(`  ...${ok + failed}/${items.length} processed`);
+    }
+  }
+  await Promise.all(Array.from({ length: concurrency }, next));
+  return { ok, failed };
+}
+
+const TABLES = [
+  { table: "agent_barbershop_leads", idCol: "id", cityCol: "city", nameCol: "shop_name" },
+  { table: "agent_salon_leads", idCol: "id", cityCol: "city", nameCol: "shop_name" },
+  { table: "agent_barber_leads", idCol: "id", cityCol: "metro_area", nameCol: "name" },
+  { table: "agent_cosmetologist_leads", idCol: "id", cityCol: "metro_area", nameCol: "name" },
+];
+
+async function fetchAllRows(table, idCol, cityCol) {
+  const pageSize = 1000;
+  let allRows = [];
+  let from = 0;
+  while (true) {
+    const { data, error } = await supabase
+      .from(table)
+      .select(`${idCol}, latitude, longitude`)
+      .ilike(cityCol, "%houston%")
+      .not("latitude", "is", null)
+      .not("longitude", "is", null)
+      .is("census_tract_geoid", null)
+      .range(from, from + pageSize - 1);
+    if (error) throw error;
+    if (!data || data.length === 0) break;
+    allRows = allRows.concat(data);
+    if (data.length < pageSize) break;
+    from += pageSize;
+  }
+  return allRows.map((r) => ({ [idCol]: r[idCol], lat: r.latitude, lng: r.longitude }));
+}
+
+(async () => {
+  if (!process.env.CENSUS_API_KEY) {
+    console.warn("WARNING: CENSUS_API_KEY not set — median household income will be skipped, tract/district still backfilled.");
+  }
+
+  for (const { table, idCol, cityCol } of TABLES) {
+    console.log(`\n=== ${table} ===`);
+    const rows = await fetchAllRows(table, idCol, cityCol);
+    console.log(`${rows.length} Houston rows need enrichment`);
+    if (rows.length === 0) continue;
+    const { ok, failed } = await processBatch(rows, (row) => enrichRow(table, idCol, row));
+    console.log(`Done: ${ok} succeeded, ${failed} failed`);
+  }
+
+  console.log("\nBackfill complete.");
+})();

--- a/supabase/functions/pixel-ingest/index.ts
+++ b/supabase/functions/pixel-ingest/index.ts
@@ -37,7 +37,23 @@ export default createHandler(async ({ adminClient, body, req }) => {
     const city = headers["cf-ipcity"]
 
     logger.info(`Received pixel event: ${body.event} for project: ${body.projectId} | Visitor: ${body.visitorId}`)
-    
+
+    // -- BOT BLOCKLIST LOGIC --
+    // Original patterns matched the one-time pixel_events cleanup DELETE,
+    // but real traffic showed real gaps: "GoogleOther" (Google's secondary
+    // crawler, confirmed via its 66.249.x.x IP range) and
+    // "facebookexternalhit" (Facebook's link-preview fetcher) both slipped
+    // through — neither contains "bot," "crawl," "spider," "headless," or
+    // "lighthouse." Added those plus a few other common non-"bot"-named
+    // crawlers/preview-fetchers as defensive coverage even though they
+    // haven't shown up yet.
+    const BOT_USER_AGENT_PATTERN = /bot|crawl|spider|headless|lighthouse|GoogleOther|Google-InspectionTool|Google-Safety|APIs-Google|bingpreview|facebookexternalhit|WhatsApp|Slack-ImgProxy|TelegramBot|Discordbot/i
+
+    if (userAgent && BOT_USER_AGENT_PATTERN.test(userAgent)) {
+        logger.info(`Blocked pixel ingestion for bot user agent: ${userAgent}`)
+        return okResponse({ success: true, received: true, note: "Bot blocked" })
+    }
+
     // -- DOMAIN BLOCKLIST LOGIC --
     const BLOCKED_DOMAINS = [
         "onlycrypto.io"
@@ -88,14 +104,28 @@ export default createHandler(async ({ adminClient, body, req }) => {
         }
 
         // 3. Upsert Visitor
-        // This ensures the visitor exists and updates their profile information if provided
+        // This ensures the visitor exists and updates their profile information if provided.
+        // Some inbound links carry an unresolved GoHighLevel merge field
+        // (e.g. a campaign template's {{contact.id}} that never got
+        // substituted before the link was sent or crawled) — treating that
+        // literal placeholder text as real identity data pollutes this
+        // table with garbage records (confirmed: 215 existing rows, ~4% of
+        // the table, all with the exact literal email "ghl_{{contact.id}}").
+        // Reject any identity field that still contains an unresolved
+        // {{...}} template rather than storing it verbatim.
+        const hasUnresolvedMergeField = (value: unknown) => typeof value === "string" && /\{\{.*\}\}/.test(value)
+        const rawEmail = body.metadata?.email
+        const rawFullName = body.metadata?.fullName || body.metadata?.name
+        const cleanEmail = hasUnresolvedMergeField(rawEmail) ? undefined : rawEmail
+        const cleanFullName = hasUnresolvedMergeField(rawFullName) ? undefined : rawFullName
+
         const { error: visitorError } = await adminClient
             .from("pixel_visitors")
             .upsert({
                 visitor_id: body.visitorId,
                 project_id: body.projectId,
-                email: body.metadata?.email,
-                full_name: body.metadata?.fullName || body.metadata?.name,
+                email: cleanEmail,
+                full_name: cleanFullName,
                 last_seen: new Date().toISOString()
             }, { 
                 onConflict: "visitor_id, project_id" 

--- a/supabase/migrations/20260707170000_add_census_and_school_district_geo_enrichment.sql
+++ b/supabase/migrations/20260707170000_add_census_and_school_district_geo_enrichment.sql
@@ -1,0 +1,28 @@
+-- Geo-enrichment columns for pricing/community-intelligence features:
+-- census tract + block group (for demographic/income context, kept out of
+-- the UI per design — backend-only signal for AI grounding and future
+-- pricing algorithms) and school district (surfaced in the UI as a
+-- community/cultural anchor, e.g. "Located in Katy ISD").
+--
+-- Scoped to the four entity types where pricing and community identity
+-- actually matter (barbershops, salons, barbers, cosmetologists) — schools
+-- and supply stores were left out for now, easy to extend later.
+
+DO $$
+DECLARE
+  t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY['agent_barbershop_leads', 'agent_salon_leads', 'agent_barber_leads', 'agent_cosmetologist_leads']
+  LOOP
+    EXECUTE format('ALTER TABLE %I ADD COLUMN IF NOT EXISTS census_tract_geoid text', t);
+    EXECUTE format('ALTER TABLE %I ADD COLUMN IF NOT EXISTS census_block_group_geoid text', t);
+    EXECUTE format('ALTER TABLE %I ADD COLUMN IF NOT EXISTS census_median_household_income integer', t);
+    EXECUTE format('ALTER TABLE %I ADD COLUMN IF NOT EXISTS census_population integer', t);
+    EXECUTE format('ALTER TABLE %I ADD COLUMN IF NOT EXISTS census_data_updated_at timestamptz', t);
+    EXECUTE format('ALTER TABLE %I ADD COLUMN IF NOT EXISTS school_district_name text', t);
+    EXECUTE format('ALTER TABLE %I ADD COLUMN IF NOT EXISTS school_district_geoid text', t);
+    EXECUTE format('ALTER TABLE %I ADD COLUMN IF NOT EXISTS school_district_updated_at timestamptz', t);
+    EXECUTE format('CREATE INDEX IF NOT EXISTS idx_%s_census_tract ON %I (census_tract_geoid)', t, t);
+    EXECUTE format('CREATE INDEX IF NOT EXISTS idx_%s_school_district ON %I (school_district_name)', t, t);
+  END LOOP;
+END $$;

--- a/supabase/migrations/20260707180000_add_school_district_to_search_rpcs.sql
+++ b/supabase/migrations/20260707180000_add_school_district_to_search_rpcs.sql
@@ -1,0 +1,409 @@
+-- school_district_name (added to agent_barbershop_leads/salon/barber/
+-- cosmetologist_leads by the census/school-district enrichment backfill)
+-- was invisible to the AI chat's general search context — it only ever
+-- reached the model through the single-shop ecosystem report, which
+-- requires a shopId. Adding it to these four ranked-search RPCs lets the
+-- model reference a shop/salon/barber/cosmetologist's district in ANY
+-- chat answer, not just the "ask about my own shop" flow.
+--
+-- RETURNS TABLE can't be changed via CREATE OR REPLACE — Postgres requires
+-- a DROP first when the output columns change (same pattern already used
+-- in 20260706120000_add_pay_structure_to_barber_search.sql).
+
+DROP FUNCTION IF EXISTS public.search_barbershops_ranked(text, boolean, text, int, int, vector(768));
+
+CREATE FUNCTION public.search_barbershops_ranked(
+  query_text text,
+  is_hiring_filter boolean,
+  rent_type_filter text,
+  limit_val int,
+  offset_val int,
+  query_embedding vector(768) DEFAULT NULL
+)
+RETURNS TABLE (
+  id uuid,
+  shop_name text,
+  city text,
+  formatted_address text,
+  phone text,
+  hiring_need boolean,
+  booth_count_available integer,
+  rent_type text,
+  rent_rate text,
+  ai_culture_summary text,
+  rating numeric,
+  total_reviews integer,
+  opportunity_status text,
+  google_images jsonb,
+  school_district_name text,
+  trust_score numeric,
+  total_matched bigint
+) AS $$
+BEGIN
+  RETURN QUERY
+  WITH search_results AS (
+    SELECT
+      a.*,
+      to_tsvector('english',
+        COALESCE(a.shop_name, '') || ' ' ||
+        COALESCE(a.city, '') || ' ' ||
+        COALESCE(a.ai_culture_summary, '') || ' ' ||
+        COALESCE(a.opportunity_status, '') || ' ' ||
+        COALESCE(a.rent_type, '')
+      ) as search_vector,
+      websearch_to_tsquery('english', query_text) as search_query,
+      (CASE
+        WHEN query_embedding IS NOT NULL AND a.embedding IS NOT NULL
+        THEN (1 - (a.embedding <=> query_embedding))
+        ELSE 0
+      END) as semantic_similarity
+    FROM agent_barbershop_leads a
+  )
+  SELECT
+    s.id,
+    s.shop_name,
+    s.city,
+    s.formatted_address,
+    s.phone,
+    s.hiring_need,
+    s.booth_count_available,
+    s.rent_type,
+    s.rent_rate,
+    s.ai_culture_summary,
+    s.rating,
+    s.total_reviews,
+    s.opportunity_status,
+    s.google_images,
+    s.school_district_name,
+    (
+      -- 80% Weight to AI Semantic Score (Scaled to max 200 originally, so 200 * 0.8 = 160 max base)
+      (CASE WHEN query_embedding IS NOT NULL THEN (s.semantic_similarity * 200 * 0.80) ELSE 0 END) +
+      -- 20% Weight to Keyword Score
+      (CASE WHEN query_text = '' THEN (100 * 0.20)
+            ELSE COALESCE(ts_rank(s.search_vector, s.search_query) * 100 * 0.20, 0)
+       END) +
+      -- Fixed Multipliers
+      (CASE WHEN s.hiring_need = true THEN 500 ELSE 0 END) +
+      (CASE WHEN s.conversation_turns IS NOT NULL OR s.last_conversation_history IS NOT NULL THEN 400 ELSE 0 END) +
+      (CASE WHEN s.email IS NOT NULL AND s.email != '' THEN 100 ELSE 0 END) +
+      (CASE WHEN s.ai_culture_summary IS NOT NULL AND s.ai_culture_summary != '' THEN 200 ELSE 0 END) +
+      (COALESCE(s.rating, 0) * 10) +
+      LEAST((COALESCE(s.total_reviews, 0) / 5), 50)
+    )::numeric AS trust_score,
+    count(*) OVER() AS total_matched
+  FROM search_results s
+  WHERE
+    (is_hiring_filter = false OR (s.hiring_need = true AND s.booth_count_available > 0))
+    AND (rent_type_filter = '' OR rent_type_filter IS NULL OR s.rent_type = rent_type_filter)
+    -- Soft Filter: Must score higher than 10 base points
+    AND (
+      (CASE WHEN query_embedding IS NOT NULL THEN (s.semantic_similarity * 200 * 0.80) ELSE 0 END) +
+      (CASE WHEN query_text = '' THEN 20 ELSE COALESCE(ts_rank(s.search_vector, s.search_query) * 100 * 0.20, 0) END)
+    ) > 10
+  ORDER BY trust_score DESC
+  LIMIT limit_val OFFSET offset_val;
+END;
+$$ LANGUAGE plpgsql;
+
+
+DROP FUNCTION IF EXISTS public.search_barbers_ranked(text, vector(768), int, int);
+
+CREATE FUNCTION public.search_barbers_ranked(
+  query_text text,
+  query_embedding vector(768) DEFAULT NULL,
+  limit_val int DEFAULT 10,
+  offset_val int DEFAULT 0
+)
+RETURNS TABLE (
+  id uuid,
+  name text,
+  profile_url text,
+  passport_image_url text,
+  specialty_type text,
+  metro_area text,
+  status text,
+  is_actively_looking boolean,
+  desired_pay_structure text,
+  booksy_photo_url text,
+  booksy_rating numeric,
+  booksy_review_count integer,
+  school_district_name text,
+  match_score numeric,
+  total_matched bigint
+) AS $$
+BEGIN
+  RETURN QUERY
+  WITH search_results AS (
+    SELECT
+      b.id,
+      b.name,
+      b.profile_url,
+      b.passport_image_url,
+      b.specialty_type,
+      b.metro_area,
+      b.status,
+      b.is_actively_looking,
+      b.desired_pay_structure,
+      b.booksy_photo_url,
+      b.booksy_rating,
+      b.booksy_review_count,
+      b.school_district_name,
+      b.email,
+      b.embedding,
+      to_tsvector('english', coalesce(b.name, '') || ' ' || coalesce(b.specialty_type, '') || ' ' || coalesce(b.metro_area, '')) as search_vector,
+      websearch_to_tsquery('english', query_text) as search_query,
+      (CASE
+        WHEN query_embedding IS NOT NULL AND b.embedding IS NOT NULL
+        THEN (1 - (b.embedding <=> query_embedding))
+        ELSE 0
+      END) as semantic_similarity
+    FROM agent_barber_leads b
+  )
+  SELECT
+    s.id,
+    s.name,
+    s.profile_url,
+    s.passport_image_url,
+    s.specialty_type,
+    s.metro_area,
+    s.status,
+    s.is_actively_looking,
+    s.desired_pay_structure,
+    s.booksy_photo_url,
+    s.booksy_rating,
+    s.booksy_review_count,
+    s.school_district_name,
+    (
+      -- 80% Weight to AI Semantic Score
+      (CASE WHEN query_embedding IS NOT NULL THEN (s.semantic_similarity * 100 * 0.80) ELSE 0 END) +
+      -- 20% Weight to Keyword Score
+      (CASE WHEN query_text = '' THEN (50 * 0.20)
+            ELSE COALESCE(ts_rank(s.search_vector, s.search_query) * 100 * 0.20, 0)
+       END) +
+      -- Engagement Score Modifiers (Fixed Points)
+      (CASE WHEN s.status = 'interested_in_placement' AND s.is_actively_looking = true THEN 15 ELSE 0 END) +
+      (CASE WHEN s.email IS NOT NULL AND trim(s.email) != '' THEN 10 ELSE 0 END)
+    )::numeric AS match_score,
+    count(*) OVER() as total_matched
+  FROM search_results s
+  -- Soft filter: Must score higher than 10 points (blocks pure garbage)
+  WHERE (
+    (CASE WHEN query_embedding IS NOT NULL THEN (s.semantic_similarity * 100 * 0.80) ELSE 0 END) +
+    (CASE WHEN query_text = '' THEN 10 ELSE COALESCE(ts_rank(s.search_vector, s.search_query) * 100 * 0.20, 0) END)
+  ) > 10
+  ORDER BY match_score DESC
+  LIMIT limit_val
+  OFFSET offset_val;
+END;
+$$ LANGUAGE plpgsql;
+
+
+DROP FUNCTION IF EXISTS public.search_salons_ranked(text, vector(768), int, int);
+
+CREATE FUNCTION public.search_salons_ranked(
+  query_text text,
+  query_embedding vector(768) DEFAULT NULL,
+  limit_val int DEFAULT 10,
+  offset_val int DEFAULT 0
+)
+RETURNS TABLE (
+  id uuid,
+  shop_name text,
+  formatted_address text,
+  city text,
+  phone text,
+  website text,
+  rating numeric,
+  total_reviews integer,
+  google_images jsonb,
+  place_types text,
+  business_status text,
+  school_district_name text,
+  match_score numeric,
+  total_matched bigint
+) AS $$
+BEGIN
+  RETURN QUERY
+  WITH search_results AS (
+    SELECT
+      s.id,
+      s.shop_name,
+      s.formatted_address,
+      s.city,
+      s.phone,
+      s.website,
+      s.rating,
+      s.total_reviews,
+      s.google_images,
+      s.place_types,
+      s.business_status,
+      s.school_district_name,
+      s.embedding,
+      to_tsvector('english',
+        COALESCE(s.shop_name, '') || ' ' ||
+        COALESCE(s.city, '') || ' ' ||
+        COALESCE(s.place_types, '')
+      ) as search_vector,
+      websearch_to_tsquery('english', query_text) as search_query,
+      (CASE
+        WHEN query_embedding IS NOT NULL AND s.embedding IS NOT NULL
+        THEN (1 - (s.embedding <=> query_embedding))
+        ELSE 0
+      END) as semantic_similarity
+    FROM agent_salon_leads s
+    WHERE s.business_status IS NULL OR s.business_status != 'CLOSED_PERMANENTLY'
+  )
+  SELECT
+    s.id,
+    s.shop_name,
+    s.formatted_address,
+    s.city,
+    s.phone,
+    s.website,
+    s.rating,
+    s.total_reviews,
+    s.google_images,
+    s.place_types,
+    s.business_status,
+    s.school_district_name,
+    (
+      -- 80% Weight to AI Semantic Score
+      (CASE WHEN query_embedding IS NOT NULL THEN (s.semantic_similarity * 100 * 0.80) ELSE 0 END) +
+      -- 20% Weight to Keyword Score
+      (CASE WHEN query_text = '' THEN (50 * 0.20)
+            ELSE COALESCE(ts_rank(s.search_vector, s.search_query) * 100 * 0.20, 0)
+       END) +
+      -- Rating / review-volume bonus
+      (COALESCE(s.rating, 0) * 10) +
+      LEAST((COALESCE(s.total_reviews, 0) / 5), 50)
+    )::numeric AS match_score,
+    count(*) OVER() as total_matched
+  FROM search_results s
+  -- Soft filter: Must score higher than 10 points (blocks pure garbage)
+  WHERE (
+    (CASE WHEN query_embedding IS NOT NULL THEN (s.semantic_similarity * 100 * 0.80) ELSE 0 END) +
+    (CASE WHEN query_text = '' THEN 10 ELSE COALESCE(ts_rank(s.search_vector, s.search_query) * 100 * 0.20, 0) END)
+  ) > 10
+  ORDER BY match_score DESC
+  LIMIT limit_val
+  OFFSET offset_val;
+END;
+$$ LANGUAGE plpgsql;
+
+
+DROP FUNCTION IF EXISTS public.search_cosmetologists_ranked(text, vector(768), int, int);
+
+CREATE FUNCTION public.search_cosmetologists_ranked(
+  query_text text,
+  query_embedding vector(768) DEFAULT NULL,
+  limit_val int DEFAULT 10,
+  offset_val int DEFAULT 0
+)
+RETURNS TABLE (
+  id uuid,
+  name text,
+  profile_url text,
+  address text,
+  metro_area text,
+  booksy_photo_url text,
+  booksy_gallery_urls jsonb,
+  booksy_services jsonb,
+  booksy_price_range text,
+  booksy_rating numeric,
+  booksy_review_count integer,
+  school_district_name text,
+  match_score numeric,
+  total_matched bigint
+) AS $$
+BEGIN
+  RETURN QUERY
+  WITH search_results AS (
+    SELECT
+      c.id,
+      c.name,
+      c.profile_url,
+      c.address,
+      c.metro_area,
+      c.booksy_photo_url,
+      c.booksy_gallery_urls,
+      c.booksy_services,
+      c.booksy_price_range,
+      c.booksy_rating,
+      c.booksy_review_count,
+      c.school_district_name,
+      c.embedding,
+      to_tsvector('english',
+        coalesce(c.name, '') || ' ' ||
+        coalesce(c.metro_area, '') || ' ' ||
+        coalesce((SELECT string_agg(s->>'name', ' ') FROM jsonb_array_elements(c.booksy_services) s), '')
+      ) as search_vector,
+      websearch_to_tsquery('english', query_text) as search_query,
+      (CASE
+        WHEN query_embedding IS NOT NULL AND c.embedding IS NOT NULL
+        THEN (1 - (c.embedding <=> query_embedding))
+        ELSE 0
+      END) as semantic_similarity
+    FROM agent_cosmetologist_leads c
+  )
+  SELECT
+    s.id,
+    s.name,
+    s.profile_url,
+    s.address,
+    s.metro_area,
+    s.booksy_photo_url,
+    s.booksy_gallery_urls,
+    s.booksy_services,
+    s.booksy_price_range,
+    s.booksy_rating,
+    s.booksy_review_count,
+    s.school_district_name,
+    (
+      -- 80% Weight to AI Semantic Score
+      (CASE WHEN query_embedding IS NOT NULL THEN (s.semantic_similarity * 100 * 0.80) ELSE 0 END) +
+      -- 20% Weight to Keyword Score
+      (CASE WHEN query_text = '' THEN (50 * 0.20)
+            ELSE COALESCE(ts_rank(s.search_vector, s.search_query) * 100 * 0.20, 0)
+       END) +
+      -- Rating / review-volume bonus
+      (COALESCE(s.booksy_rating, 0) * 10) +
+      LEAST((COALESCE(s.booksy_review_count, 0) / 5), 50)
+    )::numeric AS match_score,
+    count(*) OVER() as total_matched
+  FROM search_results s
+  -- Soft filter: Must score higher than 10 points (blocks pure garbage)
+  WHERE (
+    (CASE WHEN query_embedding IS NOT NULL THEN (s.semantic_similarity * 100 * 0.80) ELSE 0 END) +
+    (CASE WHEN query_text = '' THEN 10 ELSE COALESCE(ts_rank(s.search_vector, s.search_query) * 100 * 0.20, 0) END)
+  ) > 10
+  ORDER BY match_score DESC
+  LIMIT limit_val
+  OFFSET offset_val;
+END;
+$$ LANGUAGE plpgsql;
+
+
+-- Direct aggregate, not a similarity search — "which school district has
+-- the best barbershops" can't be answered from a top-3-per-category RAG
+-- result, the same reasoning already applied to the 2026 exam leaderboards.
+-- Requires at least 3 rated shops in a district so a single 5-star outlier
+-- doesn't top the list.
+CREATE OR REPLACE FUNCTION public.get_school_district_barbershop_rankings()
+RETURNS TABLE (
+  school_district_name text,
+  shop_count bigint,
+  avg_rating numeric,
+  hiring_shop_count bigint
+) AS $$
+  SELECT
+    school_district_name,
+    count(*) AS shop_count,
+    round(avg(rating), 2) AS avg_rating,
+    count(*) FILTER (WHERE hiring_need = true) AS hiring_shop_count
+  FROM agent_barbershop_leads
+  WHERE school_district_name IS NOT NULL AND rating IS NOT NULL
+  GROUP BY school_district_name
+  HAVING count(*) >= 3
+  ORDER BY avg(rating) DESC, count(*) DESC
+  LIMIT 15;
+$$ LANGUAGE sql STABLE;

--- a/supabase/migrations/20260707190000_exclude_localhost_from_pixel_analytics.sql
+++ b/supabase/migrations/20260707190000_exclude_localhost_from_pixel_analytics.sql
@@ -1,0 +1,188 @@
+-- Localhost traffic (local dev testing) was intentionally included alongside
+-- innergcomplete.com in every metric here, per the original "Showing data
+-- exclusively for localhost and innergcomplete.com" design. That's no
+-- longer wanted — dev testing noise shouldn't count toward real visitor
+-- metrics. Every subquery below drops the "OR page_url ILIKE '%localhost%'"
+-- branch, leaving innergcomplete.com as the sole scope. Confirmed zero
+-- overlap between the two patterns in existing data, so this is a pure
+-- narrowing with no risk of double-counting or dropping real traffic.
+CREATE OR REPLACE FUNCTION get_pixel_analytics_summary(p_cutoff timestamptz DEFAULT NULL)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_result jsonb;
+  v_views int;
+  v_clicks int;
+  v_active_users int;
+  v_engaged_users int;
+  v_returning_users int;
+
+  v_total_searches int;
+  v_unique_searchers int;
+  v_outbound_leads int;
+  v_shop_claims int;
+
+  v_ai_mode_activations int;
+  v_ai_messages_sent int;
+  v_ai_rate_limit_hits int;
+
+  v_top_pages jsonb;
+  v_top_insights jsonb;
+  v_top_referrers jsonb;
+  v_top_filters jsonb;
+BEGIN
+
+  -- 1. Core KPIs & VC Metrics & AI Metrics
+  SELECT
+    COUNT(*) FILTER (WHERE event_name = 'page_view'),
+    COUNT(*) FILTER (WHERE event_name = 'click'),
+    COUNT(DISTINCT visitor_id),
+    COUNT(DISTINCT visitor_id) FILTER (
+      WHERE event_name = 'click'
+         OR (event_name = 'scroll' AND metadata->>'depth' = '50%')
+         OR (event_name = 'page_leave' AND (metadata->>'duration_seconds')::numeric >= 60)
+    ),
+    COUNT(*) FILTER (WHERE event_name = 'search_executed'),
+    COUNT(DISTINCT visitor_id) FILTER (WHERE event_name = 'search_executed'),
+    COUNT(*) FILTER (WHERE event_name = 'click' AND metadata->>'ig_click' = 'outbound_lead'),
+    COUNT(*) FILTER (WHERE event_name = 'claim_shop_initiated'),
+    COUNT(*) FILTER (WHERE event_name = 'ai_mode_activated'),
+    COUNT(*) FILTER (WHERE event_name = 'ai_chat_message_sent'),
+    COUNT(*) FILTER (WHERE event_name = 'ai_rate_limit_hit')
+  INTO
+    v_views, v_clicks, v_active_users, v_engaged_users,
+    v_total_searches, v_unique_searchers, v_outbound_leads, v_shop_claims,
+    v_ai_mode_activations, v_ai_messages_sent, v_ai_rate_limit_hits
+  FROM pixel_events
+  WHERE page_url ILIKE '%innergcomplete.com%'
+    AND (p_cutoff IS NULL OR created_at >= p_cutoff);
+
+  -- 2. Returning Users — single consistent rule for every timeframe.
+  SELECT COUNT(*) INTO v_returning_users
+  FROM (
+    SELECT visitor_id
+    FROM pixel_events
+    WHERE page_url ILIKE '%innergcomplete.com%'
+      AND visitor_id IS NOT NULL
+      AND (p_cutoff IS NULL OR created_at >= p_cutoff)
+    GROUP BY visitor_id
+    HAVING COUNT(DISTINCT DATE(created_at)) > 1
+  ) sub;
+
+  -- 3. Top Pages
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('url', final_url, 'count', cnt)), '[]'::jsonb)
+  INTO v_top_pages
+  FROM (
+    SELECT
+      CASE WHEN clean_url = '' OR clean_url = '/' THEN 'Home' ELSE clean_url END AS final_url,
+      SUM(cnt) as cnt
+    FROM (
+      SELECT
+        SPLIT_PART(
+          CASE
+            WHEN page_url ILIKE '%innergcomplete.com%' THEN SPLIT_PART(page_url, 'innergcomplete.com', 2)
+            ELSE page_url
+          END,
+          '?', 1
+        ) AS clean_url,
+        COUNT(*) as cnt
+      FROM pixel_events
+      WHERE page_url IS NOT NULL
+        AND page_url ILIKE '%innergcomplete.com%'
+        AND (p_cutoff IS NULL OR created_at >= p_cutoff)
+      GROUP BY 1
+    ) base
+    GROUP BY 1
+    ORDER BY 2 DESC
+    LIMIT 10
+  ) agg;
+
+  -- 4. Top Insights
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('url', final_url, 'count', cnt)), '[]'::jsonb)
+  INTO v_top_insights
+  FROM (
+    SELECT
+      clean_url AS final_url,
+      SUM(cnt) as cnt
+    FROM (
+      SELECT
+        SPLIT_PART(
+          CASE
+            WHEN page_url ILIKE '%innergcomplete.com%' THEN SPLIT_PART(page_url, 'innergcomplete.com', 2)
+            ELSE page_url
+          END,
+          '?', 1
+        ) AS clean_url,
+        COUNT(*) as cnt
+      FROM pixel_events
+      WHERE page_url IS NOT NULL
+        AND page_url ILIKE '%innergcomplete.com%'
+        AND (p_cutoff IS NULL OR created_at >= p_cutoff)
+      GROUP BY 1
+    ) base
+    WHERE clean_url LIKE '/insights%'
+    GROUP BY 1
+    ORDER BY 2 DESC
+    LIMIT 10
+  ) agg;
+
+  -- 5. Top Referrers
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('url', ref, 'count', cnt)), '[]'::jsonb)
+  INTO v_top_referrers
+  FROM (
+    SELECT
+      COALESCE(
+        NULLIF(SPLIT_PART(REPLACE(REPLACE(referrer, 'https://', ''), 'http://', ''), '/', 1), ''),
+        'Direct / Unknown'
+      ) as ref,
+      COUNT(*) as cnt
+    FROM pixel_events
+    WHERE page_url ILIKE '%innergcomplete.com%'
+      AND (p_cutoff IS NULL OR created_at >= p_cutoff)
+    GROUP BY 1
+    ORDER BY 2 DESC
+    LIMIT 10
+  ) agg;
+
+  -- 6. Top Search Filters
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('filter_id', f.val, 'count', f.cnt)), '[]'::jsonb)
+  INTO v_top_filters
+  FROM (
+    SELECT
+      jsonb_array_elements_text(metadata->'filters_used') as val,
+      COUNT(*) as cnt
+    FROM pixel_events
+    WHERE event_name = 'search_executed'
+      AND metadata->'filters_used' IS NOT NULL
+      AND jsonb_typeof(metadata->'filters_used') = 'array'
+      AND page_url ILIKE '%innergcomplete.com%'
+      AND (p_cutoff IS NULL OR created_at >= p_cutoff)
+    GROUP BY 1
+    ORDER BY 2 DESC
+    LIMIT 10
+  ) f;
+
+  v_result := jsonb_build_object(
+    'totalViews', COALESCE(v_views, 0),
+    'totalClicks', COALESCE(v_clicks, 0),
+    'activeUsers', COALESCE(v_active_users, 0),
+    'engagedUsers', COALESCE(v_engaged_users, 0),
+    'returningUsers', COALESCE(v_returning_users, 0),
+    'totalSearches', COALESCE(v_total_searches, 0),
+    'uniqueSearchers', COALESCE(v_unique_searchers, 0),
+    'outboundLeads', COALESCE(v_outbound_leads, 0),
+    'shopClaims', COALESCE(v_shop_claims, 0),
+    'aiModeActivations', COALESCE(v_ai_mode_activations, 0),
+    'aiMessagesSent', COALESCE(v_ai_messages_sent, 0),
+    'aiRateLimitHits', COALESCE(v_ai_rate_limit_hits, 0),
+    'topPages', v_top_pages,
+    'topInsights', v_top_insights,
+    'topReferrers', v_top_referrers,
+    'topFilters', v_top_filters
+  );
+
+  RETURN v_result;
+END;
+$$;

--- a/supabase/migrations/20260707200000_add_pixel_analytics_reset_point.sql
+++ b/supabase/migrations/20260707200000_add_pixel_analytics_reset_point.sql
@@ -1,0 +1,205 @@
+-- Soft reset for pixel analytics: historical pixel_events rows stay in the
+-- database untouched (unlike the earlier localhost cleanup, this is real
+-- production visitor data, not noise — reversible by design), but every
+-- metric is floored at reset_at so the dashboard behaves as if today is
+-- day one. "All Time" effectively becomes "since reset." Re-runnable for
+-- future resets: just UPDATE this row's reset_at, no new migration needed.
+CREATE TABLE IF NOT EXISTS pixel_analytics_settings (
+  id boolean PRIMARY KEY DEFAULT true,
+  reset_at timestamptz,
+  CONSTRAINT pixel_analytics_settings_single_row CHECK (id = true)
+);
+
+INSERT INTO pixel_analytics_settings (id, reset_at)
+VALUES (true, now())
+ON CONFLICT (id) DO UPDATE SET reset_at = now();
+
+CREATE OR REPLACE FUNCTION get_pixel_analytics_summary(p_cutoff timestamptz DEFAULT NULL)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_reset_at timestamptz;
+  v_effective_cutoff timestamptz;
+
+  v_result jsonb;
+  v_views int;
+  v_clicks int;
+  v_active_users int;
+  v_engaged_users int;
+  v_returning_users int;
+
+  v_total_searches int;
+  v_unique_searchers int;
+  v_outbound_leads int;
+  v_shop_claims int;
+
+  v_ai_mode_activations int;
+  v_ai_messages_sent int;
+  v_ai_rate_limit_hits int;
+
+  v_top_pages jsonb;
+  v_top_insights jsonb;
+  v_top_referrers jsonb;
+  v_top_filters jsonb;
+BEGIN
+  SELECT reset_at INTO v_reset_at FROM pixel_analytics_settings WHERE id = true;
+  -- GREATEST treats NULL as "no bound," so this correctly becomes just
+  -- reset_at for "All Time" (p_cutoff NULL) and the later of the two
+  -- for any shorter selected window (Today/7D/30D never reaches back
+  -- past the reset point even if the window itself would).
+  v_effective_cutoff := GREATEST(p_cutoff, v_reset_at);
+
+  -- 1. Core KPIs & VC Metrics & AI Metrics
+  SELECT
+    COUNT(*) FILTER (WHERE event_name = 'page_view'),
+    COUNT(*) FILTER (WHERE event_name = 'click'),
+    COUNT(DISTINCT visitor_id),
+    COUNT(DISTINCT visitor_id) FILTER (
+      WHERE event_name = 'click'
+         OR (event_name = 'scroll' AND metadata->>'depth' = '50%')
+         OR (event_name = 'page_leave' AND (metadata->>'duration_seconds')::numeric >= 60)
+    ),
+    COUNT(*) FILTER (WHERE event_name = 'search_executed'),
+    COUNT(DISTINCT visitor_id) FILTER (WHERE event_name = 'search_executed'),
+    COUNT(*) FILTER (WHERE event_name = 'click' AND metadata->>'ig_click' = 'outbound_lead'),
+    COUNT(*) FILTER (WHERE event_name = 'claim_shop_initiated'),
+    COUNT(*) FILTER (WHERE event_name = 'ai_mode_activated'),
+    COUNT(*) FILTER (WHERE event_name = 'ai_chat_message_sent'),
+    COUNT(*) FILTER (WHERE event_name = 'ai_rate_limit_hit')
+  INTO
+    v_views, v_clicks, v_active_users, v_engaged_users,
+    v_total_searches, v_unique_searchers, v_outbound_leads, v_shop_claims,
+    v_ai_mode_activations, v_ai_messages_sent, v_ai_rate_limit_hits
+  FROM pixel_events
+  WHERE page_url ILIKE '%innergcomplete.com%'
+    AND (v_effective_cutoff IS NULL OR created_at >= v_effective_cutoff);
+
+  -- 2. Returning Users — single consistent rule for every timeframe.
+  SELECT COUNT(*) INTO v_returning_users
+  FROM (
+    SELECT visitor_id
+    FROM pixel_events
+    WHERE page_url ILIKE '%innergcomplete.com%'
+      AND visitor_id IS NOT NULL
+      AND (v_effective_cutoff IS NULL OR created_at >= v_effective_cutoff)
+    GROUP BY visitor_id
+    HAVING COUNT(DISTINCT DATE(created_at)) > 1
+  ) sub;
+
+  -- 3. Top Pages
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('url', final_url, 'count', cnt)), '[]'::jsonb)
+  INTO v_top_pages
+  FROM (
+    SELECT
+      CASE WHEN clean_url = '' OR clean_url = '/' THEN 'Home' ELSE clean_url END AS final_url,
+      SUM(cnt) as cnt
+    FROM (
+      SELECT
+        SPLIT_PART(
+          CASE
+            WHEN page_url ILIKE '%innergcomplete.com%' THEN SPLIT_PART(page_url, 'innergcomplete.com', 2)
+            ELSE page_url
+          END,
+          '?', 1
+        ) AS clean_url,
+        COUNT(*) as cnt
+      FROM pixel_events
+      WHERE page_url IS NOT NULL
+        AND page_url ILIKE '%innergcomplete.com%'
+        AND (v_effective_cutoff IS NULL OR created_at >= v_effective_cutoff)
+      GROUP BY 1
+    ) base
+    GROUP BY 1
+    ORDER BY 2 DESC
+    LIMIT 10
+  ) agg;
+
+  -- 4. Top Insights
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('url', final_url, 'count', cnt)), '[]'::jsonb)
+  INTO v_top_insights
+  FROM (
+    SELECT
+      clean_url AS final_url,
+      SUM(cnt) as cnt
+    FROM (
+      SELECT
+        SPLIT_PART(
+          CASE
+            WHEN page_url ILIKE '%innergcomplete.com%' THEN SPLIT_PART(page_url, 'innergcomplete.com', 2)
+            ELSE page_url
+          END,
+          '?', 1
+        ) AS clean_url,
+        COUNT(*) as cnt
+      FROM pixel_events
+      WHERE page_url IS NOT NULL
+        AND page_url ILIKE '%innergcomplete.com%'
+        AND (v_effective_cutoff IS NULL OR created_at >= v_effective_cutoff)
+      GROUP BY 1
+    ) base
+    WHERE clean_url LIKE '/insights%'
+    GROUP BY 1
+    ORDER BY 2 DESC
+    LIMIT 10
+  ) agg;
+
+  -- 5. Top Referrers
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('url', ref, 'count', cnt)), '[]'::jsonb)
+  INTO v_top_referrers
+  FROM (
+    SELECT
+      COALESCE(
+        NULLIF(SPLIT_PART(REPLACE(REPLACE(referrer, 'https://', ''), 'http://', ''), '/', 1), ''),
+        'Direct / Unknown'
+      ) as ref,
+      COUNT(*) as cnt
+    FROM pixel_events
+    WHERE page_url ILIKE '%innergcomplete.com%'
+      AND (v_effective_cutoff IS NULL OR created_at >= v_effective_cutoff)
+    GROUP BY 1
+    ORDER BY 2 DESC
+    LIMIT 10
+  ) agg;
+
+  -- 6. Top Search Filters
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('filter_id', f.val, 'count', f.cnt)), '[]'::jsonb)
+  INTO v_top_filters
+  FROM (
+    SELECT
+      jsonb_array_elements_text(metadata->'filters_used') as val,
+      COUNT(*) as cnt
+    FROM pixel_events
+    WHERE event_name = 'search_executed'
+      AND metadata->'filters_used' IS NOT NULL
+      AND jsonb_typeof(metadata->'filters_used') = 'array'
+      AND page_url ILIKE '%innergcomplete.com%'
+      AND (v_effective_cutoff IS NULL OR created_at >= v_effective_cutoff)
+    GROUP BY 1
+    ORDER BY 2 DESC
+    LIMIT 10
+  ) f;
+
+  v_result := jsonb_build_object(
+    'totalViews', COALESCE(v_views, 0),
+    'totalClicks', COALESCE(v_clicks, 0),
+    'activeUsers', COALESCE(v_active_users, 0),
+    'engagedUsers', COALESCE(v_engaged_users, 0),
+    'returningUsers', COALESCE(v_returning_users, 0),
+    'totalSearches', COALESCE(v_total_searches, 0),
+    'uniqueSearchers', COALESCE(v_unique_searchers, 0),
+    'outboundLeads', COALESCE(v_outbound_leads, 0),
+    'shopClaims', COALESCE(v_shop_claims, 0),
+    'aiModeActivations', COALESCE(v_ai_mode_activations, 0),
+    'aiMessagesSent', COALESCE(v_ai_messages_sent, 0),
+    'aiRateLimitHits', COALESCE(v_ai_rate_limit_hits, 0),
+    'topPages', v_top_pages,
+    'topInsights', v_top_insights,
+    'topReferrers', v_top_referrers,
+    'topFilters', v_top_filters
+  );
+
+  RETURN v_result;
+END;
+$$;

--- a/supabase/migrations/20260707210000_add_qualified_visitors_metric.sql
+++ b/supabase/migrations/20260707210000_add_qualified_visitors_metric.sql
@@ -1,0 +1,215 @@
+-- "Qualified Visitors": a lightweight ghost-session/bot filter distinct
+-- from engagedUsers (which requires a click, 50% scroll, or 60s+
+-- page_leave — a much higher quality bar). This just asks "did this
+-- visitor do anything beyond a single instantaneous page_view," to catch
+-- bots sophisticated enough to fake a real User-Agent and slip past
+-- pixel-ingest's blocklist.
+--
+-- Deliberately computed from event-timestamp span (MAX(created_at) -
+-- MIN(created_at) > 1 second) rather than page_leave's duration_seconds
+-- metadata specifically — that event doesn't fire reliably for every real
+-- visitor (mobile Safari backgrounding, tab crashes, etc.), so anchoring
+-- the metric to it would risk misclassifying real quick-bounce humans as
+-- ghosts whenever it happens not to fire. Timestamp span only needs
+-- events to exist, not a specific one to have fired.
+CREATE OR REPLACE FUNCTION get_pixel_analytics_summary(p_cutoff timestamptz DEFAULT NULL)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_reset_at timestamptz;
+  v_effective_cutoff timestamptz;
+
+  v_result jsonb;
+  v_views int;
+  v_clicks int;
+  v_active_users int;
+  v_engaged_users int;
+  v_returning_users int;
+  v_qualified_visitors int;
+
+  v_total_searches int;
+  v_unique_searchers int;
+  v_outbound_leads int;
+  v_shop_claims int;
+
+  v_ai_mode_activations int;
+  v_ai_messages_sent int;
+  v_ai_rate_limit_hits int;
+
+  v_top_pages jsonb;
+  v_top_insights jsonb;
+  v_top_referrers jsonb;
+  v_top_filters jsonb;
+BEGIN
+  SELECT reset_at INTO v_reset_at FROM pixel_analytics_settings WHERE id = true;
+  v_effective_cutoff := GREATEST(p_cutoff, v_reset_at);
+
+  -- 1. Core KPIs & VC Metrics & AI Metrics
+  SELECT
+    COUNT(*) FILTER (WHERE event_name = 'page_view'),
+    COUNT(*) FILTER (WHERE event_name = 'click'),
+    COUNT(DISTINCT visitor_id),
+    COUNT(DISTINCT visitor_id) FILTER (
+      WHERE event_name = 'click'
+         OR (event_name = 'scroll' AND metadata->>'depth' = '50%')
+         OR (event_name = 'page_leave' AND (metadata->>'duration_seconds')::numeric >= 60)
+    ),
+    COUNT(*) FILTER (WHERE event_name = 'search_executed'),
+    COUNT(DISTINCT visitor_id) FILTER (WHERE event_name = 'search_executed'),
+    COUNT(*) FILTER (WHERE event_name = 'click' AND metadata->>'ig_click' = 'outbound_lead'),
+    COUNT(*) FILTER (WHERE event_name = 'claim_shop_initiated'),
+    COUNT(*) FILTER (WHERE event_name = 'ai_mode_activated'),
+    COUNT(*) FILTER (WHERE event_name = 'ai_chat_message_sent'),
+    COUNT(*) FILTER (WHERE event_name = 'ai_rate_limit_hit')
+  INTO
+    v_views, v_clicks, v_active_users, v_engaged_users,
+    v_total_searches, v_unique_searchers, v_outbound_leads, v_shop_claims,
+    v_ai_mode_activations, v_ai_messages_sent, v_ai_rate_limit_hits
+  FROM pixel_events
+  WHERE page_url ILIKE '%innergcomplete.com%'
+    AND (v_effective_cutoff IS NULL OR created_at >= v_effective_cutoff);
+
+  -- 2. Returning Users — single consistent rule for every timeframe.
+  SELECT COUNT(*) INTO v_returning_users
+  FROM (
+    SELECT visitor_id
+    FROM pixel_events
+    WHERE page_url ILIKE '%innergcomplete.com%'
+      AND visitor_id IS NOT NULL
+      AND (v_effective_cutoff IS NULL OR created_at >= v_effective_cutoff)
+    GROUP BY visitor_id
+    HAVING COUNT(DISTINCT DATE(created_at)) > 1
+  ) sub;
+
+  -- 2b. Qualified Visitors
+  SELECT COUNT(*) INTO v_qualified_visitors
+  FROM (
+    SELECT visitor_id
+    FROM pixel_events
+    WHERE page_url ILIKE '%innergcomplete.com%'
+      AND visitor_id IS NOT NULL
+      AND (v_effective_cutoff IS NULL OR created_at >= v_effective_cutoff)
+    GROUP BY visitor_id
+    HAVING
+      COUNT(*) FILTER (WHERE event_name != 'page_view') > 0
+      OR (MAX(created_at) - MIN(created_at)) > INTERVAL '1 second'
+  ) sub;
+
+  -- 3. Top Pages
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('url', final_url, 'count', cnt)), '[]'::jsonb)
+  INTO v_top_pages
+  FROM (
+    SELECT
+      CASE WHEN clean_url = '' OR clean_url = '/' THEN 'Home' ELSE clean_url END AS final_url,
+      SUM(cnt) as cnt
+    FROM (
+      SELECT
+        SPLIT_PART(
+          CASE
+            WHEN page_url ILIKE '%innergcomplete.com%' THEN SPLIT_PART(page_url, 'innergcomplete.com', 2)
+            ELSE page_url
+          END,
+          '?', 1
+        ) AS clean_url,
+        COUNT(*) as cnt
+      FROM pixel_events
+      WHERE page_url IS NOT NULL
+        AND page_url ILIKE '%innergcomplete.com%'
+        AND (v_effective_cutoff IS NULL OR created_at >= v_effective_cutoff)
+      GROUP BY 1
+    ) base
+    GROUP BY 1
+    ORDER BY 2 DESC
+    LIMIT 10
+  ) agg;
+
+  -- 4. Top Insights
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('url', final_url, 'count', cnt)), '[]'::jsonb)
+  INTO v_top_insights
+  FROM (
+    SELECT
+      clean_url AS final_url,
+      SUM(cnt) as cnt
+    FROM (
+      SELECT
+        SPLIT_PART(
+          CASE
+            WHEN page_url ILIKE '%innergcomplete.com%' THEN SPLIT_PART(page_url, 'innergcomplete.com', 2)
+            ELSE page_url
+          END,
+          '?', 1
+        ) AS clean_url,
+        COUNT(*) as cnt
+      FROM pixel_events
+      WHERE page_url IS NOT NULL
+        AND page_url ILIKE '%innergcomplete.com%'
+        AND (v_effective_cutoff IS NULL OR created_at >= v_effective_cutoff)
+      GROUP BY 1
+    ) base
+    WHERE clean_url LIKE '/insights%'
+    GROUP BY 1
+    ORDER BY 2 DESC
+    LIMIT 10
+  ) agg;
+
+  -- 5. Top Referrers
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('url', ref, 'count', cnt)), '[]'::jsonb)
+  INTO v_top_referrers
+  FROM (
+    SELECT
+      COALESCE(
+        NULLIF(SPLIT_PART(REPLACE(REPLACE(referrer, 'https://', ''), 'http://', ''), '/', 1), ''),
+        'Direct / Unknown'
+      ) as ref,
+      COUNT(*) as cnt
+    FROM pixel_events
+    WHERE page_url ILIKE '%innergcomplete.com%'
+      AND (v_effective_cutoff IS NULL OR created_at >= v_effective_cutoff)
+    GROUP BY 1
+    ORDER BY 2 DESC
+    LIMIT 10
+  ) agg;
+
+  -- 6. Top Search Filters
+  SELECT COALESCE(jsonb_agg(jsonb_build_object('filter_id', f.val, 'count', f.cnt)), '[]'::jsonb)
+  INTO v_top_filters
+  FROM (
+    SELECT
+      jsonb_array_elements_text(metadata->'filters_used') as val,
+      COUNT(*) as cnt
+    FROM pixel_events
+    WHERE event_name = 'search_executed'
+      AND metadata->'filters_used' IS NOT NULL
+      AND jsonb_typeof(metadata->'filters_used') = 'array'
+      AND page_url ILIKE '%innergcomplete.com%'
+      AND (v_effective_cutoff IS NULL OR created_at >= v_effective_cutoff)
+    GROUP BY 1
+    ORDER BY 2 DESC
+    LIMIT 10
+  ) f;
+
+  v_result := jsonb_build_object(
+    'totalViews', COALESCE(v_views, 0),
+    'totalClicks', COALESCE(v_clicks, 0),
+    'activeUsers', COALESCE(v_active_users, 0),
+    'engagedUsers', COALESCE(v_engaged_users, 0),
+    'returningUsers', COALESCE(v_returning_users, 0),
+    'qualifiedVisitors', COALESCE(v_qualified_visitors, 0),
+    'totalSearches', COALESCE(v_total_searches, 0),
+    'uniqueSearchers', COALESCE(v_unique_searchers, 0),
+    'outboundLeads', COALESCE(v_outbound_leads, 0),
+    'shopClaims', COALESCE(v_shop_claims, 0),
+    'aiModeActivations', COALESCE(v_ai_mode_activations, 0),
+    'aiMessagesSent', COALESCE(v_ai_messages_sent, 0),
+    'aiRateLimitHits', COALESCE(v_ai_rate_limit_hits, 0),
+    'topPages', v_top_pages,
+    'topInsights', v_top_insights,
+    'topReferrers', v_top_referrers,
+    'topFilters', v_top_filters
+  );
+
+  RETURN v_result;
+END;
+$$;


### PR DESCRIPTION
…lity fixes, AI chat radius fix, SEO title bug fix

- Enrich barbershops/salons/barbers/cosmetologists with census tract, block group, median household income, population, and school district (via FCC + Census ACS + NCES/ArcGIS APIs). Surface school district on profile pages and feed both signals into AI chat's shop ecosystem report for pricing/community-context reasoning.
- Fix shop ecosystem report to aggregate population/income across every census tract within the same 10-mile radius as the rest of the report, instead of just the shop's single tract — previous scope mismatch made "how many people are in my market" answers wildly undersized.
- Persist shopId across an entire AI Mode conversation (previously only the kickoff message included it, so every follow-up question silently lost access to the shop's ecosystem report).
- Add school_district_name to the 4 general search RPCs and a new get_school_district_barbershop_rankings aggregate so "which district has the best barbershops" is answerable outside the single-shop flow.
- Pixel analytics: exclude localhost from all metrics, add a soft reset point (historical data preserved, metrics start fresh), add a "Qualified Visitors" ghost-session filter metric.
- pixel-ingest: block additional bot/crawler user agents (GoogleOther, facebookexternalhit, etc.) that slipped past the original blocklist, and sanitize unresolved GoHighLevel merge-field placeholders (e.g. "{{contact.id}}") instead of storing them as real identity data.
- Fix generateMetadata on Houston market-analysis pages: an exact city="Houston" match (real data is "Houston 77023") plus a select on a nonexistent "state" column meant ~95% of pages silently fell back to a generic title instead of a unique, keyword-rich one.
- Fix stuck search-spinner bug: cache-hit and empty-query paths in the debounced search effect never reset isLoading.
- Parallelize the search engine's independent category RPC calls (previously sequential) for ~3x faster "All" tab searches.