### PR TITLE
feat: crawlable directory, California exam-prep pages, and advertisin…

### DIFF
--- a/app/california-barber-exam-intelligence-prep/page.tsx
+++ b/app/california-barber-exam-intelligence-prep/page.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import { CaliforniaExamPrep } from "@/components/exam-prep/CaliforniaExamPrep";
+
+export const revalidate = 3600;
+
+const CANONICAL = "https://agency.innergcomplete.com/california-barber-exam-intelligence-prep";
+
+export const metadata: Metadata = {
+  title: "California Barber Exam Intelligence Prep — Real 2026 Pass Rates | Inner G Complete",
+  description:
+    "Real 2026 first-time written pass rates for California barber schools, from the California Board of Barbering & Cosmetology (BBC), ranked by school. Know where you stand before the California barber state board exam. Not available on Google.",
+  keywords: [
+    "california barber exam",
+    "california barber state board",
+    "california barber written exam pass rate",
+    "bbc barber exam california",
+    "california barber school pass rates",
+    "how to pass california barber exam",
+  ],
+  openGraph: {
+    title: "California Barber Exam Intelligence Prep — Real 2026 Pass Rates",
+    description:
+      "Real 2026 first-time written pass rates for California barber schools from the CA Board of Barbering & Cosmetology — not available on Google.",
+    url: CANONICAL,
+    type: "website",
+  },
+  alternates: { canonical: CANONICAL },
+};
+
+export default function Page() {
+  return <CaliforniaExamPrep variant="barber" />;
+}

--- a/app/california-cosmetology-exam-intelligence-prep/page.tsx
+++ b/app/california-cosmetology-exam-intelligence-prep/page.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import { CaliforniaExamPrep } from "@/components/exam-prep/CaliforniaExamPrep";
+
+export const revalidate = 3600;
+
+const CANONICAL = "https://agency.innergcomplete.com/california-cosmetology-exam-intelligence-prep";
+
+export const metadata: Metadata = {
+  title: "California Cosmetology Exam Intelligence Prep — Real 2026 Pass Rates | Inner G Complete",
+  description:
+    "Real 2026 first-time written pass rates for California cosmetology schools, from the California Board of Barbering & Cosmetology (BBC), ranked by school. Know where you stand before the California cosmetology state board exam. Not available on Google.",
+  keywords: [
+    "california cosmetology exam",
+    "california cosmetology state board",
+    "california cosmetology written exam pass rate",
+    "bbc cosmetology exam california",
+    "california cosmetology school pass rates",
+    "how to pass california cosmetology exam",
+  ],
+  openGraph: {
+    title: "California Cosmetology Exam Intelligence Prep — Real 2026 Pass Rates",
+    description:
+      "Real 2026 first-time written pass rates for California cosmetology schools from the CA Board of Barbering & Cosmetology — not available on Google.",
+    url: CANONICAL,
+    type: "website",
+  },
+  alternates: { canonical: CANONICAL },
+};
+
+export default function Page() {
+  return <CaliforniaExamPrep variant="cosmetology" />;
+}

--- a/app/directory/[type]/[[...rest]]/page.tsx
+++ b/app/directory/[type]/[[...rest]]/page.tsx
@@ -1,0 +1,242 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { Navbar } from "@/components/layout/navbar";
+import { MapPin, ChevronLeft, ChevronRight } from "lucide-react";
+import { getDirectoryType, DIRECTORY_TYPES, PAGE_SIZE } from "@/lib/directory-config";
+import { getDirectoryPage, resolveDirectoryCity } from "@/lib/directory-data";
+
+export const revalidate = 3600;
+
+type Props = { params: Promise<{ type: string; rest?: string[] }> };
+
+const ORIGIN = "https://agency.innergcomplete.com";
+
+type Parsed =
+  | { kind: "ok"; citySlug: string | null; cityName: string | null; page: number }
+  | { kind: "redirect"; to: string }
+  | { kind: "notfound" };
+
+// The optional catch-all after /directory/<type> can be:
+//   []                       → national, page 1
+//   ["2"]                    → national, page 2
+//   ["houston"]              → city-scoped, page 1
+//   ["houston","2"]          → city-scoped, page 2
+// A page number of "1" is redirected to the bare canonical so page 1 has one
+// URL. A non-numeric first segment is treated as a city slug and validated
+// against the strict allow-list; anything unrecognized 404s.
+function parseRoute(typeKey: string, rest?: string[]): Parsed {
+  if (!rest || rest.length === 0) return { kind: "ok", citySlug: null, cityName: null, page: 1 };
+  const isNum = (s: string) => /^\d+$/.test(s);
+  const [a, b, ...extra] = rest;
+  if (extra.length > 0) return { kind: "notfound" };
+
+  // /directory/<type>/<a>
+  if (b === undefined) {
+    if (isNum(a)) {
+      const n = parseInt(a, 10);
+      if (n === 1) return { kind: "redirect", to: `/directory/${typeKey}` };
+      if (n < 1) return { kind: "notfound" };
+      return { kind: "ok", citySlug: null, cityName: null, page: n };
+    }
+    const cityName = resolveDirectoryCity(a);
+    if (!cityName) return { kind: "notfound" };
+    return { kind: "ok", citySlug: a, cityName, page: 1 };
+  }
+
+  // /directory/<type>/<a>/<b> — a must be a city slug, b a page number
+  if (isNum(a)) return { kind: "notfound" }; // national lists never have two segments
+  const cityName = resolveDirectoryCity(a);
+  if (!cityName) return { kind: "notfound" };
+  if (!isNum(b)) return { kind: "notfound" };
+  const n = parseInt(b, 10);
+  if (n === 1) return { kind: "redirect", to: `/directory/${typeKey}/${a}` };
+  if (n < 1) return { kind: "notfound" };
+  return { kind: "ok", citySlug: a, cityName, page: n };
+}
+
+function pageUrl(typeKey: string, citySlug: string | null, page: number): string {
+  const base = citySlug ? `/directory/${typeKey}/${citySlug}` : `/directory/${typeKey}`;
+  return page <= 1 ? base : `${base}/${page}`;
+}
+
+export async function generateMetadata(props: Props): Promise<Metadata> {
+  const { type: typeKey, rest } = await props.params;
+  const type = getDirectoryType(typeKey);
+  const parsed = parseRoute(typeKey, rest);
+  if (!type || parsed.kind === "notfound") return { title: "Directory Not Found | Inner G Complete" };
+  if (parsed.kind === "redirect") {
+    return { title: `${type.label} Directory | Inner G Complete`, alternates: { canonical: `${ORIGIN}${parsed.to}` } };
+  }
+
+  const { cityName, citySlug, page } = parsed;
+  const cityLabel = cityName ? `${cityName} ` : "";
+  const pageSuffix = page > 1 ? ` — Page ${page}` : "";
+  const title = `${cityLabel}${type.label} Directory${pageSuffix} | Inner G Complete`;
+  const description = cityName
+    ? `Every ${type.label.toLowerCase()} in ${cityName} in our directory.`
+    : type.description;
+  const canonical = `${ORIGIN}${pageUrl(typeKey, citySlug, page)}`;
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: { title, description, url: canonical, type: "website" },
+  };
+}
+
+// Pre-render national page 1 of each type (linked from /directory and the
+// sitemap). City-scoped pages render on-demand and cache via `revalidate`.
+export function generateStaticParams() {
+  return DIRECTORY_TYPES.map((t) => ({ type: t.key, rest: [] as string[] }));
+}
+
+function titleCase(s: string): string {
+  return s.replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+// First page, last page, and a window of ±2 around the current page, with
+// ellipsis gaps — all rendered as real <a> links so Google can follow them.
+function paginationItems(current: number, totalPages: number): (number | "…")[] {
+  const out: (number | "…")[] = [];
+  const window = new Set<number>([1, totalPages, current - 1, current, current + 1, current - 2, current + 2]);
+  let prev = 0;
+  for (let n = 1; n <= totalPages; n++) {
+    if (!window.has(n)) continue;
+    if (n - prev > 1) out.push("…");
+    out.push(n);
+    prev = n;
+  }
+  return out;
+}
+
+export default async function DirectoryListPage(props: Props) {
+  const { type: typeKey, rest } = await props.params;
+  const type = getDirectoryType(typeKey);
+  if (!type) notFound();
+
+  const parsed = parseRoute(typeKey, rest);
+  if (parsed.kind === "notfound") notFound();
+  if (parsed.kind === "redirect") redirect(parsed.to);
+
+  const { citySlug, cityName, page } = parsed;
+
+  const { entities, total, totalPages } = await getDirectoryPage(type, page, cityName);
+  if (page > totalPages) notFound(); // no infinitely crawlable empty pages
+  // A city with genuinely zero listings for this type shouldn't exist as a page.
+  if (cityName && total === 0) notFound();
+
+  const startIndex = (page - 1) * PAGE_SIZE;
+  const items = paginationItems(page, totalPages);
+  const heading = cityName ? `${cityName} ${type.label}` : `${type.label} Directory`;
+
+  return (
+    <div className="min-h-screen light bg-slate-50">
+      <Navbar />
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 pt-28 pb-16">
+        <nav className="text-xs font-bold text-slate-400 mb-4">
+          <Link href="/directory" className="hover:text-indigo-600">Directory</Link>
+          <span className="mx-1.5">/</span>
+          {cityName ? (
+            <>
+              <Link href={`/directory/${typeKey}`} className="hover:text-indigo-600">{type.label}</Link>
+              <span className="mx-1.5">/</span>
+              <span className="text-slate-600">{cityName}</span>
+            </>
+          ) : (
+            <span className="text-slate-600">{type.label}</span>
+          )}
+        </nav>
+
+        <h1 className="text-3xl sm:text-4xl font-black tracking-tight text-slate-950 leading-tight mb-2">
+          {heading}
+        </h1>
+        <p className="text-slate-600 text-base leading-relaxed mb-8">
+          {total.toLocaleString()} {type.label.toLowerCase()}
+          {cityName ? ` in ${cityName}` : " in our directory"}.
+          {totalPages > 1 && (
+            <span className="text-slate-400 font-medium"> Page {page} of {totalPages}.</span>
+          )}
+          {cityName && (
+            <>
+              {" "}
+              <Link href={`/directory/${typeKey}`} className="text-indigo-600 font-bold hover:underline">
+                View all {type.label.toLowerCase()} →
+              </Link>
+            </>
+          )}
+        </p>
+
+        <ol className="bg-white border border-slate-200 rounded-2xl shadow-sm divide-y divide-slate-100 overflow-hidden">
+          {entities.map((e, i) => (
+            <li key={e.slug}>
+              <Link
+                href={`${type.entityPrefix}/${e.slug}`}
+                className="flex items-center gap-3 px-4 sm:px-5 py-3 hover:bg-indigo-50/60 transition-colors"
+              >
+                <span className="text-xs font-bold text-slate-300 w-8 shrink-0 tabular-nums">
+                  {startIndex + i + 1}
+                </span>
+                <span className="font-bold text-slate-900 text-sm">{titleCase(e.name)}</span>
+                {e.city && (
+                  <span className="ml-auto flex items-center gap-1 text-xs text-slate-400 font-medium shrink-0">
+                    <MapPin className="w-3 h-3" />
+                    {titleCase(e.city)}
+                  </span>
+                )}
+              </Link>
+            </li>
+          ))}
+        </ol>
+
+        {totalPages > 1 && (
+          <nav className="flex flex-wrap items-center justify-center gap-1.5 mt-8" aria-label="Directory pagination">
+            {page > 1 && (
+              <Link
+                href={pageUrl(typeKey, citySlug, page - 1)}
+                rel="prev"
+                className="flex items-center gap-1 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-bold text-slate-600 hover:border-indigo-300 hover:text-indigo-600 transition-colors"
+              >
+                <ChevronLeft className="w-4 h-4" /> Prev
+              </Link>
+            )}
+            {items.map((it, idx) =>
+              it === "…" ? (
+                <span key={`gap-${idx}`} className="px-2 text-slate-400 font-bold">…</span>
+              ) : (
+                <Link
+                  key={it}
+                  href={pageUrl(typeKey, citySlug, it)}
+                  aria-current={it === page ? "page" : undefined}
+                  className={`rounded-lg border px-3 py-2 text-sm font-bold tabular-nums transition-colors ${
+                    it === page
+                      ? "border-indigo-600 bg-indigo-600 text-white"
+                      : "border-slate-200 bg-white text-slate-600 hover:border-indigo-300 hover:text-indigo-600"
+                  }`}
+                >
+                  {it}
+                </Link>
+              )
+            )}
+            {page < totalPages && (
+              <Link
+                href={pageUrl(typeKey, citySlug, page + 1)}
+                rel="next"
+                className="flex items-center gap-1 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-bold text-slate-600 hover:border-indigo-300 hover:text-indigo-600 transition-colors"
+              >
+                Next <ChevronRight className="w-4 h-4" />
+              </Link>
+            )}
+          </nav>
+        )}
+
+        <div className="text-center mt-10">
+          <Link href="/directory" className="text-sm font-bold text-slate-500 hover:text-indigo-600 transition-colors">
+            ← All directory categories
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/directory/page.tsx
+++ b/app/directory/page.tsx
@@ -1,0 +1,72 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { Navbar } from "@/components/layout/navbar";
+import { Library, ArrowRight } from "lucide-react";
+import { DIRECTORY_TYPES } from "@/lib/directory-config";
+import { getDirectoryCounts } from "@/lib/directory-data";
+
+export const revalidate = 3600;
+
+const CANONICAL = "https://agency.innergcomplete.com/directory";
+
+export const metadata: Metadata = {
+  title: "Full Directory — Barbershops, Salons, Barbers, Schools & Supply Stores | Inner G Complete",
+  description:
+    "Browse every barbershop, hair salon, barber, cosmetologist, barber & cosmetology school, and supply store in our directory — the complete A–Z index.",
+  alternates: { canonical: CANONICAL },
+  openGraph: {
+    title: "Full Directory — Every Barbershop, Salon, Barber, School & Supply Store",
+    description:
+      "The complete A–Z index of every business and professional in our directory.",
+    url: CANONICAL,
+    type: "website",
+  },
+};
+
+export default async function DirectoryIndexPage() {
+  const counts = await getDirectoryCounts();
+  const total = Object.values(counts).reduce((s, n) => s + n, 0);
+
+  return (
+    <div className="min-h-screen light bg-slate-50">
+      <Navbar />
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 pt-28 pb-16">
+        <div className="mb-10">
+          <span className="inline-flex items-center gap-1.5 text-[10px] font-black uppercase tracking-widest text-indigo-700 bg-indigo-50 border border-indigo-100 rounded-full px-3 py-1 mb-4">
+            <Library className="w-3 h-3" />
+            Complete Index
+          </span>
+          <h1 className="text-3xl sm:text-4xl font-black tracking-tight text-slate-950 leading-tight mb-3">
+            Full Directory
+          </h1>
+          <p className="text-slate-600 text-base sm:text-lg leading-relaxed max-w-2xl">
+            Browse every business and professional in our directory —{" "}
+            {total.toLocaleString()} listings across {DIRECTORY_TYPES.length} categories. Pick a
+            category to page through the complete list.
+          </p>
+        </div>
+
+        <div className="grid sm:grid-cols-2 gap-4">
+          {DIRECTORY_TYPES.map((t) => (
+            <Link
+              key={t.key}
+              href={`/directory/${t.key}`}
+              className="group flex items-center justify-between gap-3 bg-white border border-slate-200 rounded-2xl shadow-sm px-5 py-4 hover:border-indigo-300 transition-colors"
+            >
+              <div>
+                <div className="flex items-center gap-2">
+                  <h2 className="text-base font-black text-slate-900">{t.label}</h2>
+                  <span className="text-xs font-bold text-slate-400">
+                    {(counts[t.key] ?? 0).toLocaleString()}
+                  </span>
+                </div>
+                <p className="text-xs text-slate-500 mt-0.5">{t.description}</p>
+              </div>
+              <ArrowRight className="w-5 h-5 shrink-0 text-indigo-600 transition-transform group-hover:translate-x-0.5" />
+            </Link>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/media-kit/page.tsx
+++ b/app/media-kit/page.tsx
@@ -1,0 +1,288 @@
+import type { Metadata } from "next";
+import { Navbar } from "@/components/layout/navbar";
+
+export const revalidate = 3600;
+
+const CANONICAL = "https://agency.innergcomplete.com/media-kit";
+
+export const metadata: Metadata = {
+  title: "Advertising Media Kit — Sponsorships & Ad Placements | Inner G Complete",
+  description:
+    "Advertise on ShearQuery / Inner G Complete — the barber & cosmetology intelligence platform. ~223K monthly search impressions, nearly 9,000 listed entities across TX & CA, and four ad products: geographic sponsorships, on-profile ads, and search-results placements.",
+  keywords: [
+    "barber advertising",
+    "salon advertising",
+    "beauty industry sponsorship",
+    "barbershop directory advertising",
+    "cosmetology school advertising",
+    "barber supply advertising",
+  ],
+  openGraph: {
+    title: "Advertising Media Kit — Inner G Complete / ShearQuery",
+    description:
+      "Reach a concentrated barber & cosmetology audience — geographic sponsorships, on-profile ads, and search-results placements.",
+    url: CANONICAL,
+    type: "website",
+  },
+  alternates: { canonical: CANONICAL },
+};
+
+const CSS = `
+  .mk { --ink:#0a0f1e; --ink-2:#141b30; --paper:#f5f6fb; --card:#fff; --line:#e3e6f0; --accent:#4f46e5; --accent-soft:#eef0ff; --accent-ink:#3730a3; --pos:#059669; --slate:#475569; --slate-soft:#94a3b8; }
+  .mk { background: var(--paper); color: var(--ink); line-height: 1.55; }
+  .mk .wrap { max-width: 1000px; margin: 0 auto; padding: 0 24px; }
+  .mk section { padding: 64px 0; }
+  .mk h1, .mk h2, .mk h3 { margin: 0; text-wrap: balance; }
+  .mk .eyebrow { font-size: 11px; font-weight: 800; letter-spacing: 0.18em; text-transform: uppercase; color: var(--accent); }
+  .mk .num { font-variant-numeric: tabular-nums; }
+  .mk .hero { background: radial-gradient(120% 120% at 80% 0%, #1c2544 0%, var(--ink) 55%); color: #fff; padding: 120px 0 72px; }
+  .mk .hero .eyebrow { color: #a5b4fc; }
+  .mk .hero h1 { font-size: clamp(38px, 7vw, 76px); font-weight: 900; font-style: italic; letter-spacing: -0.04em; text-transform: uppercase; line-height: 0.92; margin: 18px 0 0; }
+  .mk .hero .lede { font-size: clamp(16px, 2.2vw, 20px); color: #cbd5e1; max-width: 620px; margin: 22px 0 0; }
+  .mk .badge { display: inline-flex; align-items: center; gap: 8px; margin-top: 28px; padding: 8px 15px; border: 1px solid rgba(165,180,252,0.35); border-radius: 999px; font-size: 13px; font-weight: 700; color: #c7d2fe; background: rgba(79,70,229,0.12); }
+  .mk .stats { background: var(--ink-2); color: #fff; padding: 40px 0; }
+  .mk .statgrid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 20px; }
+  .mk .stat .n { font-size: clamp(30px, 4.5vw, 46px); font-weight: 900; letter-spacing: -0.03em; line-height: 1; }
+  .mk .stat .n.pos { color: #34d399; }
+  .mk .stat .l { font-size: 11px; font-weight: 800; letter-spacing: 0.1em; text-transform: uppercase; color: #94a3b8; margin-top: 8px; }
+  .mk .kicker { font-size: clamp(24px, 3.4vw, 34px); font-weight: 900; letter-spacing: -0.03em; }
+  .mk .sub { color: var(--slate); max-width: 640px; margin: 12px 0 0; }
+  .mk .chips { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 28px; }
+  .mk .chip { background: var(--card); border: 1px solid var(--line); border-radius: 14px; padding: 16px 18px; flex: 1 1 200px; }
+  .mk .chip .big { font-size: 22px; font-weight: 900; letter-spacing: -0.02em; }
+  .mk .chip .cap { font-size: 13px; color: var(--slate); margin-top: 2px; }
+  .mk .cats { margin-top: 28px; display: grid; gap: 10px; }
+  .mk .cat { display: grid; grid-template-columns: 190px 1fr 62px; align-items: center; gap: 14px; }
+  .mk .cat .cname { font-size: 14px; font-weight: 700; }
+  .mk .cat .track { height: 12px; background: var(--accent-soft); border-radius: 999px; overflow: hidden; }
+  .mk .cat .fill { height: 100%; background: linear-gradient(90deg, #6366f1, #4f46e5); border-radius: 999px; }
+  .mk .cat .cval { font-size: 14px; font-weight: 800; text-align: right; }
+  .mk .inv { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 32px; }
+  .mk .card { background: var(--card); border: 1px solid var(--line); border-radius: 20px; padding: 26px; }
+  .mk .card.wide { grid-column: 1 / -1; }
+  .mk .card .tag { display: inline-block; font-size: 11px; font-weight: 800; letter-spacing: 0.08em; text-transform: uppercase; color: var(--accent-ink); background: var(--accent-soft); padding: 5px 10px; border-radius: 8px; }
+  .mk .card h3 { font-size: 21px; font-weight: 900; letter-spacing: -0.02em; margin-top: 14px; }
+  .mk .card p { color: var(--slate); font-size: 14.5px; margin: 10px 0 0; }
+  .mk .meta { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 16px; }
+  .mk .pill { font-size: 12px; font-weight: 700; color: var(--slate); background: #f1f5f9; border: 1px solid var(--line); border-radius: 999px; padding: 5px 11px; }
+  .mk .tiers { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; margin-top: 18px; }
+  .mk .tier { border: 1px solid var(--line); border-radius: 14px; padding: 16px; background: #fbfcfe; }
+  .mk .tier .tn { font-weight: 900; font-size: 15px; }
+  .mk .tier .td { font-size: 12.5px; color: var(--slate); margin-top: 5px; }
+  .mk .ratewrap { overflow-x: auto; margin-top: 24px; border: 1px solid var(--line); border-radius: 18px; background: var(--card); }
+  .mk table { width: 100%; border-collapse: collapse; min-width: 560px; }
+  .mk th, .mk td { text-align: left; padding: 16px 20px; border-bottom: 1px solid var(--line); font-size: 14.5px; }
+  .mk th { font-size: 11px; font-weight: 800; letter-spacing: 0.1em; text-transform: uppercase; color: var(--slate-soft); background: #fafbff; }
+  .mk td.plc { font-weight: 800; }
+  .mk .price { font-weight: 900; color: var(--accent-ink); font-size: 16px; white-space: nowrap; letter-spacing: -0.01em; }
+  .mk .price .per { color: var(--slate); font-weight: 700; font-size: 12px; margin-left: 1px; }
+  .mk tr:last-child td { border-bottom: 0; }
+  .mk .why { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; margin-top: 30px; }
+  .mk .why .w { background: var(--card); border: 1px solid var(--line); border-radius: 18px; padding: 22px; }
+  .mk .why .w .wt { font-weight: 900; font-size: 16px; }
+  .mk .why .w .wd { color: var(--slate); font-size: 14px; margin-top: 8px; }
+  .mk .cta { background: var(--ink); color: #fff; border-radius: 24px; padding: 48px 40px; text-align: center; margin: 24px 0; }
+  .mk .cta h2 { font-size: clamp(26px, 4vw, 40px); font-weight: 900; font-style: italic; text-transform: uppercase; letter-spacing: -0.03em; line-height: 0.95; }
+  .mk .cta p { color: #cbd5e1; max-width: 500px; margin: 16px auto 0; }
+  .mk .btn { display: inline-block; margin-top: 26px; background: var(--accent); color: #fff; font-weight: 800; font-size: 14px; letter-spacing: 0.03em; text-transform: uppercase; padding: 15px 30px; border-radius: 12px; text-decoration: none; }
+  .mk .contact { margin-top: 18px; font-size: 14px; color: #94a3b8; }
+  .mk .contact b { color: #fff; }
+  .mk .foot { text-align: center; color: var(--slate-soft); font-size: 12.5px; padding: 30px 0 60px; }
+  @media (max-width: 760px) {
+    .mk .statgrid { grid-template-columns: repeat(2, 1fr); gap: 24px; }
+    .mk .inv, .mk .why, .mk .tiers { grid-template-columns: 1fr; }
+    .mk .cat { grid-template-columns: 120px 1fr 52px; gap: 10px; }
+    .mk .cat .cname { font-size: 12.5px; }
+  }
+`;
+
+const MAILTO =
+  "mailto:sponsorships@innergcomplete.com?subject=ShearQuery%20Advertising%20Inquiry";
+
+export default function MediaKitPage() {
+  const rows: { placement: string; scope: string; advertiser: string; price: string }[] = [
+    { placement: "City Sponsorship", scope: "One metro hub + profiles", advertiser: "Local operators, regional brands", price: "39" },
+    { placement: "State Sponsorship", scope: "Statewide hub + all cities", advertiser: "Distributors, multi-location chains", price: "79" },
+    { placement: "National Sponsorship", scope: "Homepage + full directory", advertiser: "Manufacturers, national brands", price: "399" },
+    { placement: "On-Profile Ad", scope: "Per profile / per bundle", advertiser: "Competing shops, suppliers, schools", price: "20" },
+    { placement: "Search Results Ad", scope: "Per category + city", advertiser: "Any high-intent advertiser", price: "10" },
+  ];
+  const cats: { name: string; w: number; v: string }[] = [
+    { name: "Hair Salons", w: 100, v: "2,672" },
+    { name: "Barbershops", w: 95, v: "2,540" },
+    { name: "Barbers", w: 53, v: "1,429" },
+    { name: "Cosmetology Schools", w: 35, v: "941" },
+    { name: "Beauty Supply Stores", w: 25, v: "663" },
+    { name: "Barber Supply Stores", w: 9, v: "247" },
+    { name: "Barber Schools", w: 9, v: "244" },
+    { name: "Cosmetologists", w: 5, v: "122" },
+  ];
+
+  return (
+    <div className="mk">
+      <style dangerouslySetInnerHTML={{ __html: CSS }} />
+      <Navbar />
+
+      <header className="hero">
+        <div className="wrap">
+          <div className="eyebrow">Advertising &amp; Sponsorship Media Kit · 2026</div>
+          <h1>Reach the people<br />behind every chair.</h1>
+          <p className="lede">
+            Inner G Complete (ShearQuery) is the barber &amp; cosmetology intelligence platform — a searchable
+            directory of nearly 9,000 shops, salons, schools, licensed pros, and suppliers, with market data that
+            isn&rsquo;t on Google.
+          </p>
+          <div className="badge">◆ Intelligence not available on Google</div>
+        </div>
+      </header>
+
+      <div className="stats">
+        <div className="wrap">
+          <div className="statgrid">
+            <div className="stat"><div className="n pos num">223K</div><div className="l">Monthly search impressions</div></div>
+            <div className="stat"><div className="n num">8,862</div><div className="l">Listed entities</div></div>
+            <div className="stat"><div className="n num">19,800</div><div className="l">Interactions / 30 days</div></div>
+            <div className="stat"><div className="n num">2</div><div className="l">States live (TX · CA)</div></div>
+          </div>
+        </div>
+      </div>
+
+      <section>
+        <div className="wrap">
+          <div className="eyebrow">Who you reach</div>
+          <h2 className="kicker">A concentrated, high-intent industry audience</h2>
+          <p className="sub">
+            Not a general-interest audience — every visitor is here for one industry. Shop and salon owners deciding
+            where to spend, students choosing schools, licensed professionals, and buyers sourcing product. The
+            platform surfaces in Google roughly <b>223,000 times a month</b> for barber &amp; beauty searches.
+          </p>
+          <div className="chips">
+            <div className="chip"><div className="big">Owners</div><div className="cap">Barbershop &amp; salon operators making booth, supply &amp; hiring decisions</div></div>
+            <div className="chip"><div className="big">Students</div><div className="cap">Barber &amp; cosmetology students choosing schools and prepping for state boards</div></div>
+            <div className="chip"><div className="big">Licensed pros</div><div className="cap">Barbers &amp; cosmetologists researching chairs, brands &amp; opportunities</div></div>
+            <div className="chip"><div className="big">Buyers</div><div className="cap">Shoppers sourcing from barber &amp; beauty supply stores</div></div>
+          </div>
+          <div className="cats">
+            {cats.map((c) => (
+              <div className="cat" key={c.name}>
+                <div className="cname">{c.name}</div>
+                <div className="track"><div className="fill" style={{ width: `${c.w}%` }} /></div>
+                <div className="cval num">{c.v}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section style={{ background: "#eef1f8" }}>
+        <div className="wrap">
+          <div className="eyebrow">The inventory</div>
+          <h2 className="kicker">Four ways to advertise</h2>
+          <p className="sub">
+            From broad geographic sponsorships down to a single competitor&rsquo;s profile page — placements that match
+            how advertisers actually think about this market.
+          </p>
+          <div className="inv">
+            <div className="card wide">
+              <span className="tag">1 · Geographic Sponsorships</span>
+              <h3>Own a city, a state, or the nation</h3>
+              <p>
+                Sponsor the hub pages people land on when they search a place — your brand featured across an entire
+                geography&rsquo;s directory and market-intelligence pages.
+              </p>
+              <div className="tiers">
+                <div className="tier"><div className="tn">City</div><div className="td">One metro&rsquo;s hub &amp; profiles — e.g. Houston, Dallas, Los Angeles. Best for local operators &amp; regional brands.</div></div>
+                <div className="tier"><div className="tn">State</div><div className="td">The Texas or California statewide hub and every city beneath it. Best for regional distributors &amp; chains.</div></div>
+                <div className="tier"><div className="tn">National</div><div className="td">Homepage &amp; the full A–Z directory across all markets. Best for manufacturers &amp; national brands.</div></div>
+              </div>
+            </div>
+            <div className="card">
+              <span className="tag">2 · On-Profile Advertising</span>
+              <h3>Sponsored slot on entity pages</h3>
+              <p>
+                A clearly-labeled &ldquo;Sponsored&rdquo; placement inside individual shop, salon, and school profiles —
+                including your competitors&rsquo; pages. High intent: the visitor is already looking at a business
+                exactly like yours.
+              </p>
+              <div className="meta">
+                <span className="pill">Shop &amp; salon profiles</span>
+                <span className="pill">School profiles</span>
+                <span className="pill">&ldquo;Sponsored&rdquo; labeled</span>
+              </div>
+            </div>
+            <div className="card">
+              <span className="tag">3 · Search Results Advertising</span>
+              <h3>Top of the search engine</h3>
+              <p>
+                A featured/recommended placement in the ShearQuery search results — the moment a user is actively
+                comparing options in a category or city. Prime position at the point of decision.
+              </p>
+              <div className="meta">
+                <span className="pill">Category targeting</span>
+                <span className="pill">City targeting</span>
+                <span className="pill">Point-of-decision</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div className="wrap">
+          <div className="eyebrow">Rate card</div>
+          <h2 className="kicker">Packages &amp; placements</h2>
+          <p className="sub">
+            Starting monthly rates below, with quarterly and annual discounts available. Final pricing scales with
+            geography, category, and campaign length — reach out and we&rsquo;ll tailor a package.
+          </p>
+          <div className="ratewrap">
+            <table>
+              <thead>
+                <tr><th>Placement</th><th>Scope</th><th>Ideal advertiser</th><th>Pricing</th></tr>
+              </thead>
+              <tbody>
+                {rows.map((r) => (
+                  <tr key={r.placement}>
+                    <td className="plc">{r.placement}</td>
+                    <td>{r.scope}</td>
+                    <td>{r.advertiser}</td>
+                    <td><span className="price">From ${r.price}<span className="per">/mo</span></span></td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      <section style={{ background: "#eef1f8" }}>
+        <div className="wrap">
+          <div className="eyebrow">Why here</div>
+          <h2 className="kicker">What makes this audience worth paying for</h2>
+          <div className="why">
+            <div className="w"><div className="wt">Single-industry intent</div><div className="wd">No wasted impressions on a general audience — everyone here is in barbering &amp; cosmetology, deciding or buying right now.</div></div>
+            <div className="w"><div className="wt">Data that isn&rsquo;t on Google</div><div className="wd">Real state-board pass rates, market ecosystems, and rankings pull visitors and keep them — context your ad sits inside.</div></div>
+            <div className="w"><div className="wt">Placement, not a banner farm</div><div className="wd">Limited, clearly-labeled slots — your brand isn&rsquo;t buried among dozens of ads competing for the same glance.</div></div>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <div className="wrap">
+          <div className="cta">
+            <h2>Let&rsquo;s put your<br />brand in front of them.</h2>
+            <p>Tell us the geography and category you want to own, and we&rsquo;ll match you to the right placement and package.</p>
+            <a className="btn" href={MAILTO}>Start a conversation</a>
+            <div className="contact"><b>sponsorships@innergcomplete.com</b> &nbsp;·&nbsp; agency.innergcomplete.com</div>
+          </div>
+        </div>
+      </section>
+
+      <div className="foot">
+        Figures reflect the live platform as of July 2026 · entity counts and 30-day interaction volume from internal
+        analytics · search impressions from Google Search Console (trailing 28-day average) · pass-rate data from TX
+        TDLR &amp; CA BBC.
+      </div>
+    </div>
+  );
+}

--- a/app/schools/[slug]/page.tsx
+++ b/app/schools/[slug]/page.tsx
@@ -26,6 +26,7 @@ import Image from "next/image";
 import { EntityPhotoGallery } from "@/components/shared/entity-photo-gallery";
 import { NearbyEntitiesSection } from "@/components/shared/nearby-entities-section";
 import { fetchNearbyEntities } from "@/lib/nearby-entities";
+import { deriveExamState, examPrepInfo } from "@/lib/exam-prep";
 import { SCHOOL_PUBLIC_COLUMNS } from "@/lib/public-columns";
 import { SearchVisibilityCard } from "@/components/shared/search-visibility-card";
 import { ReviewsSection } from "@/components/shared/reviews-section";
@@ -151,8 +152,10 @@ export async function generateMetadata(props: { params: Promise<{ slug: string }
 // Every FAQ entry is conditional on real data being present — no entry is
 // ever emitted with a guessed or placeholder answer.
 function buildSchoolJsonLd(school: any, websiteHref: string | null) {
+  const examState = deriveExamState(school.formatted_address);
+  const stateName = examState === "CA" ? "California" : "Texas";
   const address = school.formatted_address
-    ? { "@type": "PostalAddress", streetAddress: school.formatted_address, addressRegion: "TX", addressCountry: "US" }
+    ? { "@type": "PostalAddress", streetAddress: school.formatted_address, addressRegion: examState, addressCountry: "US" }
     : undefined;
 
   const org: Record<string, any> = {
@@ -160,7 +163,7 @@ function buildSchoolJsonLd(school: any, websiteHref: string | null) {
     "@type": "EducationalOrganization",
     name: school.school_name,
     description: `${school.school_category}${school._matchType === "cosmetology" ? " / beauty school / hair school" : ""}${
-      school.city ? ` in ${school.city}, Texas` : ""
+      school.city ? ` in ${school.city}, ${stateName}` : ""
     }`,
   };
   if (address) org.address = address;
@@ -561,9 +564,11 @@ export default async function SchoolProfilePage(props: { params: Promise<{ slug:
                 matched to the school type: cosmetology schools get the
                 cosmetology prep, barber schools the barber prep. */}
             {(() => {
-              const isCosmet = school._matchType === "cosmetology";
-              const prepHref = isCosmet ? "/texas-cosmetology-exam-intelligence-prep" : "/texas-barber-exam-intelligence-prep";
-              const prepLabel = isCosmet ? "Texas Cosmetology Exam Intelligence Prep" : "Texas Barber Exam Intelligence Prep";
+              const examState = deriveExamState(school.formatted_address);
+              const { href: prepHref, label: prepLabel } = examPrepInfo(
+                examState,
+                school._matchType === "cosmetology" ? "cosmetology" : "barber"
+              );
               return (
                 <div className="bg-white border border-slate-200 rounded-2xl shadow-sm px-6 py-5">
                   <p className="text-xs font-bold text-slate-400 uppercase tracking-widest mb-3 text-center">

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -8,6 +8,7 @@ import { fetchAllRows } from '@/lib/supabase-fetch-all'
 import { getQualifyingCities, BESPOKE_CITY_ROUTES } from '@/lib/city-readiness'
 import { getQualifyingCitiesCA, CA_BESPOKE_CITY_ROUTES } from '@/lib/california-city-readiness'
 import { getCityZipCodes } from '@/lib/city-hub-data'
+import { PAGE_SIZE as DIRECTORY_PAGE_SIZE } from '@/lib/directory-config'
 
 export const dynamic = 'force-dynamic'
 
@@ -305,9 +306,44 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.5,
     }));
 
+    // Crawlable browse directory (/directory → /directory/<type> → /<type>/<n>).
+    // This is the internal-link backbone that hands Google a real path to every
+    // profile page — one paginated URL per PAGE_SIZE block of each family, so
+    // the deep pages (page 2, 3, …) are submitted, not just page 1.
+    const directoryFamilies: { key: string; rows: any[] }[] = [
+      { key: 'barbershops', rows: allShops },
+      { key: 'salons', rows: allSalons },
+      { key: 'barbers', rows: allBarbers },
+      { key: 'cosmetologists', rows: allCosmetologists },
+      { key: 'barber-schools', rows: barberSchools },
+      { key: 'cosmetology-schools', rows: cosmetologySchools },
+      { key: 'barber-supply-stores', rows: barberSupplyStores },
+      { key: 'beauty-supply-stores', rows: beautySupplyStores },
+      { key: 'events', rows: allEvents },
+    ];
+    const directorySitemap = [
+      {
+        url: `${baseUrl}/directory`,
+        lastModified: new Date(),
+        changeFrequency: 'weekly' as const,
+        priority: 0.7,
+      },
+      ...directoryFamilies.flatMap(({ key, rows }) => {
+        const count = rows.filter((r: any) => r.slug).length;
+        const totalPages = Math.max(1, Math.ceil(count / DIRECTORY_PAGE_SIZE));
+        return Array.from({ length: totalPages }, (_, i) => ({
+          url: i === 0 ? `${baseUrl}/directory/${key}` : `${baseUrl}/directory/${key}/${i + 1}`,
+          lastModified: new Date(),
+          changeFrequency: 'weekly' as const,
+          priority: i === 0 ? 0.65 : 0.5,
+        }));
+      }),
+    ];
+
     return [
       ...staticSitemap,
       ...dynamicSitemap,
+      ...directorySitemap,
       ...cityHubSitemap,
       ...cityZipSitemap,
       ...cityHubSitemapCA,

--- a/app/texas/houston/HoustonDirectory.tsx
+++ b/app/texas/houston/HoustonDirectory.tsx
@@ -3,6 +3,7 @@ import { Star, ArrowRight, Award, MapPin, Scissors, Building2, UserCheck, Gradua
 import type { HoustonData } from "./data";
 import { Navbar } from "@/components/layout/navbar";
 import { AdSponsorshipBanner } from "@/components/ads/AdSponsorshipBanner";
+import { directoryHrefForSection } from "@/lib/directory-config";
 
 // These are all real, previously-orphaned Houston-area landing pages (no
 // internal links pointed at them from anywhere in the app before this) —
@@ -131,7 +132,7 @@ export function HoustonDirectory({
                   <span className="text-sm font-bold text-slate-400">({section.count.toLocaleString()})</span>
                 </div>
                 <Link
-                  href={`/tools/barbershop-search?tab=${encodeURIComponent(section.searchTab)}&q=${encodeURIComponent("Houston" + (zipQuerySuffix || ""))}`}
+                  href={directoryHrefForSection(section.key, "houston")}
                   className="inline-flex items-center gap-1 text-xs font-bold text-indigo-600 hover:text-indigo-800 uppercase tracking-wider"
                 >
                   View All

--- a/components/california-hub/CaliforniaHubDirectory.tsx
+++ b/components/california-hub/CaliforniaHubDirectory.tsx
@@ -1,7 +1,18 @@
 import Link from "next/link";
-import { Star, ArrowRight, Award, MapPin, Scissors, Building2, UserCheck, GraduationCap, ShoppingBag, Armchair, DollarSign } from "lucide-react";
+import { Star, ArrowRight, Award, MapPin, Scissors, Building2, UserCheck, GraduationCap, ShoppingBag, Armchair, DollarSign, Compass } from "lucide-react";
 import type { CaliforniaHubData } from "@/lib/california-hub-data";
 import { Navbar } from "@/components/layout/navbar";
+import { directoryHrefForSection } from "@/lib/directory-config";
+
+// Genuinely statewide California resources (not tied to one city). These are
+// California-specific by design — the exam-prep pages point at the CA Board of
+// Barbering & Cosmetology's own data, NOT the Texas exam/regulator.
+const CALIFORNIA_STATEWIDE_LINKS: { href: string; label: string }[] = [
+  { href: "/california-school-leaderboard", label: "California School Pass-Rate Leaderboard" },
+  { href: "/california-cosmetology-exam-intelligence-prep", label: "California Cosmetology Exam Prep" },
+  { href: "/california-barber-exam-intelligence-prep", label: "California Barber Exam Prep" },
+  { href: "/directory", label: "Full Directory (A–Z)" },
+];
 const SECTION_ICONS: Record<string, any> = {
   shops: Scissors,
   salons: Building2,
@@ -84,21 +95,6 @@ export function CaliforniaHubDirectory({
           </div>
         )}
 
-        {/* California Resources */}
-        <Link
-          href="/california-school-leaderboard"
-          className="flex items-center justify-between gap-3 bg-white border border-slate-200 rounded-2xl shadow-sm px-6 py-5 mb-8 hover:border-indigo-300 transition-colors group"
-        >
-          <div>
-            <h2 className="text-lg font-black text-slate-900">California School Pass-Rate Leaderboard</h2>
-            <p className="text-xs text-slate-500 mt-0.5">
-              Real 2026 California state board first-time written pass rates by school — cosmetology, barber,
-              esthetics &amp; manicuring. Not on Google.
-            </p>
-          </div>
-          <ArrowRight className="w-5 h-5 shrink-0 text-indigo-600 transition-transform group-hover:translate-x-0.5" />
-        </Link>
-
         {/* Browse California Cities */}
         <div className="bg-white border border-slate-200 rounded-2xl shadow-sm px-6 py-5 mb-8">
           <div className="flex items-center gap-2 mb-1">
@@ -155,7 +151,7 @@ export function CaliforniaHubDirectory({
                   <span className="text-sm font-bold text-slate-400">({section.count.toLocaleString()})</span>
                 </div>
                 <Link
-                  href={`/tools/barbershop-search?tab=${encodeURIComponent(section.searchTab)}`}
+                  href={directoryHrefForSection(section.key)}
                   className="inline-flex items-center gap-1 text-xs font-bold text-indigo-600 hover:text-indigo-800 uppercase tracking-wider"
                 >
                   View All
@@ -203,6 +199,28 @@ export function CaliforniaHubDirectory({
               )}
             </div>
           ))}
+        </div>
+
+        {/* Statewide Resources */}
+        <div className="bg-white border border-slate-200 rounded-2xl shadow-sm px-6 py-5 mt-8">
+          <div className="flex items-center gap-2 mb-1">
+            <Compass className="w-5 h-5 text-slate-700" />
+            <h2 className="text-lg font-black text-slate-900">Statewide Resources</h2>
+          </div>
+          <p className="text-xs text-slate-500 mb-4">
+            Tools and guides that apply across California, not just one city.
+          </p>
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+            {CALIFORNIA_STATEWIDE_LINKS.map((link) => (
+              <Link
+                key={link.href}
+                href={link.href}
+                className="rounded-xl border border-slate-200 bg-slate-50 hover:bg-indigo-50 hover:border-indigo-300 transition-colors p-4 block"
+              >
+                <p className="font-bold text-slate-900 text-sm">{link.label}</p>
+              </Link>
+            ))}
+          </div>
         </div>
 
         <div className="text-center mt-10">

--- a/components/city-hub/CityHubDirectory.tsx
+++ b/components/city-hub/CityHubDirectory.tsx
@@ -3,6 +3,7 @@ import { Star, ArrowRight, Award, MapPin, Scissors, Building2, UserCheck, Gradua
 import type { CityHubData } from "@/lib/city-hub-data";
 import { Navbar } from "@/components/layout/navbar";
 import { AdSponsorshipBanner } from "@/components/ads/AdSponsorshipBanner";
+import { directoryHrefForSection } from "@/lib/directory-config";
 
 // Real, city-specific landing pages that predate this hub hierarchy — keyed
 // by citySlug so each city's page only shows its own real content, never an
@@ -140,7 +141,7 @@ export function CityHubDirectory({
                   <span className="text-sm font-bold text-slate-400">({section.count.toLocaleString()})</span>
                 </div>
                 <Link
-                  href={`/tools/barbershop-search?tab=${encodeURIComponent(section.searchTab)}&q=${encodeURIComponent(cityLabel + (zipQuerySuffix || ""))}`}
+                  href={directoryHrefForSection(section.key, citySlug)}
                   className="inline-flex items-center gap-1 text-xs font-bold text-indigo-600 hover:text-indigo-800 uppercase tracking-wider"
                 >
                   View All

--- a/components/exam-prep/CaliforniaExamPrep.tsx
+++ b/components/exam-prep/CaliforniaExamPrep.tsx
@@ -1,0 +1,292 @@
+import { createClient } from "@supabase/supabase-js";
+import Link from "next/link";
+import { Navbar } from "@/components/layout/navbar";
+import { TrendingUp, CheckCircle2, GraduationCap, ArrowRight, MapPin, BookOpen } from "lucide-react";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+const MIN_SAMPLE = 5;
+const PERIOD = "Q1 2026";
+const AUTHORITY = "California Board of Barbering & Cosmetology";
+
+type Variant = "barber" | "cosmetology";
+
+interface StatRow {
+  source_school_name: string;
+  source_city: string | null;
+  pass_count: number | null;
+  test_takers: number | null;
+  pass_rate: number | null;
+  school_id: string | null;
+  school_type: string | null;
+}
+
+async function fetchCaStats(variant: Variant) {
+  const supabase = createClient(supabaseUrl, supabaseKey);
+  let rows: StatRow[] = [];
+  let from = 0;
+  while (true) {
+    const { data, error } = await supabase
+      .from("school_exam_stats")
+      .select("source_school_name, source_city, pass_count, test_takers, pass_rate, school_id, school_type")
+      .eq("state", "CA")
+      .eq("program_path", "school")
+      .eq("license_type", variant)
+      .range(from, from + 999);
+    if (error || !data) break;
+    rows = rows.concat(data as StatRow[]);
+    if (data.length < 1000) break;
+    from += 1000;
+  }
+
+  const takers = rows.reduce((s, r) => s + (r.test_takers ?? 0), 0);
+  const pass = rows.reduce((s, r) => s + (r.pass_count ?? 0), 0);
+  const statewideRate = takers > 0 ? pass / takers : null;
+
+  const ranked = rows
+    .filter((r) => (r.test_takers ?? 0) >= MIN_SAMPLE && r.pass_rate != null)
+    .sort((a, b) => (b.pass_rate ?? 0) - (a.pass_rate ?? 0) || (b.test_takers ?? 0) - (a.test_takers ?? 0));
+
+  // Slugs for any ranked school already linked to an entity → link to profile.
+  const linkedType = variant === "barber" ? "barber" : "cosmetology";
+  const ids = [...new Set(ranked.filter((r) => r.school_id && r.school_type === linkedType).map((r) => r.school_id!))];
+  const slugById = new Map<string, string>();
+  if (ids.length) {
+    const table = variant === "barber" ? "agent_barber_school_leads" : "agent_cosmetology_school_leads";
+    const { data } = await supabase.from(table).select("id, slug").in("id", ids);
+    (data || []).forEach((s: any) => slugById.set(s.id, s.slug));
+  }
+
+  return { schoolCount: rows.length, takers, statewideRate, top: ranked.slice(0, 5), slugById };
+}
+
+function pct(v: number | null) {
+  return v != null ? `${Math.round(v * 100)}%` : "—";
+}
+function titleCase(s: string) {
+  return (s || "").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export async function CaliforniaExamPrep({ variant }: { variant: Variant }) {
+  const { schoolCount, takers, statewideRate, top, slugById } = await fetchCaStats(variant);
+  const licenseLabel = variant === "barber" ? "Barber" : "Cosmetology";
+  const examWord = variant === "barber" ? "barber" : "cosmetology";
+
+  const faqs = [
+    {
+      q: `What is the first-time pass rate for the California ${examWord} written exam?`,
+      a: statewideRate != null
+        ? `Across the ${schoolCount} California ${examWord} schools we track, the first-time written pass rate is ${pct(statewideRate)}, based on ${takers.toLocaleString()} first-time test-takers reported by the ${AUTHORITY} in ${PERIOD}.`
+        : `The ${AUTHORITY} reports first-time written pass rates by school each quarter; see the California ${licenseLabel} leaderboard for the latest.`,
+    },
+    {
+      q: `Who administers the California ${examWord} licensing exam?`,
+      a: `The ${AUTHORITY} (BBC) sets and reports the California ${examWord} state board exam — a different regulator and a different exam than Texas, so Texas benchmarks don't transfer.`,
+    },
+    {
+      q: `Where can I see how my California ${examWord} school ranks?`,
+      a: `Our California ${licenseLabel} School Pass-Rate Leaderboard ranks schools by their real first-time written pass rate — data that isn't available on Google.`,
+    },
+  ];
+
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "Dataset",
+        name: `California ${licenseLabel} School First-Time Written Pass Rates (${PERIOD})`,
+        description: `First-time written state board pass rates for California ${examWord} schools, from the ${AUTHORITY}.`,
+        creator: { "@type": "Organization", name: AUTHORITY },
+      },
+      {
+        "@type": "FAQPage",
+        mainEntity: faqs.map((f) => ({
+          "@type": "Question",
+          name: f.q,
+          acceptedAnswer: { "@type": "Answer", text: f.a },
+        })),
+      },
+    ],
+  };
+
+  return (
+    <div className="min-h-screen light bg-slate-50">
+      <Navbar />
+
+      {/* Hero */}
+      <section className="relative overflow-hidden bg-slate-950 pt-28 pb-16 lg:pt-32 lg:pb-24 border-b border-slate-800">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 text-center">
+          <span className="inline-flex items-center gap-1.5 text-[10px] font-black uppercase tracking-widest text-indigo-300 bg-indigo-500/10 border border-indigo-400/20 rounded-full px-3 py-1 mb-5">
+            <MapPin className="w-3 h-3" />
+            Real CA BBC Data — {PERIOD}
+          </span>
+          <h1 className="text-4xl sm:text-6xl font-black leading-[0.95] tracking-tighter uppercase italic text-white mb-5">
+            California {licenseLabel}<br />Exam Intelligence Prep
+          </h1>
+          <p className="text-slate-300 text-base sm:text-lg leading-relaxed max-w-2xl mx-auto mb-8">
+            Real 2026 first-time written pass rates from the {AUTHORITY}, ranked by school — so California{" "}
+            {examWord} students know exactly where they stand before exam day. Not available on Google.
+          </p>
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+            <Link
+              href="/california-school-leaderboard"
+              data-ig-click="exam_prep_cta"
+              className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 hover:bg-indigo-500 text-white font-extrabold text-sm uppercase tracking-wider px-6 py-3.5 transition-colors shadow-lg shadow-indigo-600/30"
+            >
+              <TrendingUp className="w-4 h-4" />
+              See the California {licenseLabel} Leaderboard
+            </Link>
+            <Link
+              href={variant === "barber" ? "/directory/barber-schools" : "/directory/cosmetology-schools"}
+              className="inline-flex items-center gap-2 rounded-xl border border-slate-700 text-slate-200 hover:bg-slate-900 font-bold text-sm uppercase tracking-wider px-6 py-3.5 transition-colors"
+            >
+              Browse Schools
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* Stat band */}
+      <section className="bg-white border-b border-slate-200">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 py-10 grid grid-cols-3 gap-4 text-center">
+          <div>
+            <div className="text-3xl sm:text-4xl font-black text-red-600">{pct(statewideRate)}</div>
+            <div className="text-[10px] sm:text-xs font-black uppercase tracking-widest text-slate-400 mt-1">
+              First-Time Written Pass Rate
+            </div>
+          </div>
+          <div>
+            <div className="text-3xl sm:text-4xl font-black text-slate-900">{schoolCount.toLocaleString()}</div>
+            <div className="text-[10px] sm:text-xs font-black uppercase tracking-widest text-slate-400 mt-1">
+              CA {licenseLabel} Schools Tracked
+            </div>
+          </div>
+          <div>
+            <div className="text-3xl sm:text-4xl font-black text-slate-900">{takers.toLocaleString()}</div>
+            <div className="text-[10px] sm:text-xs font-black uppercase tracking-widest text-slate-400 mt-1">
+              First-Time Test-Takers
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 py-14 space-y-14">
+        {/* The gap */}
+        <section>
+          <h2 className="text-2xl sm:text-3xl font-black uppercase italic tracking-tighter text-slate-950 mb-4">
+            The first-time written exam is where California {examWord} students lose time
+          </h2>
+          <p className="text-slate-600 leading-relaxed">
+            {statewideRate != null ? (
+              <>
+                Only <strong>{pct(statewideRate)}</strong> of California {examWord} candidates pass the {AUTHORITY}{" "}
+                written exam on their first attempt ({takers.toLocaleString()} first-time test-takers, {PERIOD}). Every
+                retake is more time and money before licensure — and the gap varies enormously by school. We surface the
+                real per-school numbers so students and schools can act on them instead of guessing.
+              </>
+            ) : (
+              <>
+                The {AUTHORITY} reports first-time written pass rates by school. We normalize them into a ranked,
+                per-school view so California {examWord} students and schools can see exactly where they stand.
+              </>
+            )}
+          </p>
+        </section>
+
+        {/* Top schools preview */}
+        {top.length > 0 && (
+          <section>
+            <h2 className="text-2xl sm:text-3xl font-black uppercase italic tracking-tighter text-slate-950 mb-1">
+              Top California {licenseLabel} Schools by First-Time Written Pass Rate
+            </h2>
+            <p className="text-xs text-slate-400 font-medium mb-5">
+              Schools with at least {MIN_SAMPLE} first-time written test-takers in {PERIOD}.
+            </p>
+            <div className="bg-white border border-slate-200 rounded-2xl shadow-sm divide-y divide-slate-100 overflow-hidden">
+              {top.map((s, i) => {
+                const slug = s.school_id ? slugById.get(s.school_id) : null;
+                const name = titleCase(s.source_school_name);
+                const city = titleCase(s.source_city || "");
+                return (
+                  <div key={`${s.source_school_name}-${s.source_city}`} className="flex items-center gap-3 px-5 py-3">
+                    <span className="text-xs font-black text-slate-300 w-6 tabular-nums">{i + 1}</span>
+                    <div className="min-w-0 flex-1">
+                      {slug ? (
+                        <Link href={`/schools/${slug}`} className="font-bold text-slate-900 text-sm hover:text-indigo-600">{name}</Link>
+                      ) : (
+                        <span className="font-bold text-slate-900 text-sm">{name}</span>
+                      )}
+                      {city && <span className="text-slate-400 font-medium text-xs"> — {city}</span>}
+                    </div>
+                    <span className="font-black text-green-600 text-sm tabular-nums">{pct(s.pass_rate)}</span>
+                  </div>
+                );
+              })}
+            </div>
+            <Link
+              href="/california-school-leaderboard"
+              className="inline-flex items-center gap-1 mt-4 text-sm font-bold text-indigo-600 hover:text-indigo-800"
+            >
+              See the full California {licenseLabel} leaderboard <ArrowRight className="w-4 h-4" />
+            </Link>
+          </section>
+        )}
+
+        {/* What the CA exam is */}
+        <section className="bg-white border border-slate-200 rounded-2xl shadow-sm p-6 sm:p-8">
+          <h2 className="text-xl font-black text-slate-950 flex items-center gap-2 mb-3">
+            <BookOpen className="w-5 h-5 text-indigo-600" />
+            California is a different exam than Texas
+          </h2>
+          <p className="text-slate-600 leading-relaxed text-sm">
+            The {AUTHORITY} (BBC) administers and reports California&apos;s {examWord} licensing exam — a different
+            regulator, format, and passing standard than the Texas TDLR exam. That&apos;s why we built California its own
+            pass-rate intelligence instead of reusing Texas benchmarks. The numbers here are the BBC&apos;s own
+            first-time written results for {PERIOD}.
+          </p>
+        </section>
+
+        {/* FAQ */}
+        <section>
+          <h2 className="text-2xl font-black uppercase italic tracking-tighter text-slate-950 mb-5">FAQ</h2>
+          <div className="space-y-4">
+            {faqs.map((f) => (
+              <div key={f.q} className="bg-white border border-slate-200 rounded-2xl shadow-sm p-5">
+                <p className="font-black text-slate-900 mb-1.5">{f.q}</p>
+                <p className="text-sm text-slate-600 leading-relaxed">{f.a}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Bottom CTA */}
+        <section className="text-center bg-slate-950 rounded-2xl px-6 py-12">
+          <GraduationCap className="w-8 h-8 text-indigo-400 mx-auto mb-4" />
+          <h2 className="text-2xl sm:text-3xl font-black uppercase italic tracking-tighter text-white mb-3">
+            Know your school&apos;s real pass rate
+          </h2>
+          <p className="text-slate-300 text-sm max-w-xl mx-auto mb-6">
+            See where every California {examWord} school ranks on first-time written pass rate — then find the right
+            program in our directory.
+          </p>
+          <Link
+            href="/california-school-leaderboard"
+            data-ig-click="exam_prep_cta"
+            className="inline-flex items-center gap-2 rounded-xl bg-indigo-600 hover:bg-indigo-500 text-white font-extrabold text-sm uppercase tracking-wider px-6 py-3.5 transition-colors"
+          >
+            <TrendingUp className="w-4 h-4" />
+            Open the California {licenseLabel} Leaderboard
+          </Link>
+        </section>
+
+        <div className="flex items-center gap-2 justify-center text-xs text-slate-400 font-medium">
+          <CheckCircle2 className="w-3.5 h-3.5 text-emerald-500" />
+          Pass-rate data from the {AUTHORITY}, {PERIOD}
+        </div>
+      </div>
+
+      <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+    </div>
+  );
+}

--- a/components/layout/footer.tsx
+++ b/components/layout/footer.tsx
@@ -7,6 +7,7 @@ const footerLinks = {
     { label: "Texas Barber Exam Intelligence Prep", href: "/texas-barber-exam-intelligence-prep" },
     { label: "Texas Cosmetology Exam Intelligence Prep", href: "/texas-cosmetology-exam-intelligence-prep" },
     { label: "Barbershop Search Engine", href: "/tools/barbershop-search" },
+    { label: "Full Directory (A–Z)", href: "/directory" },
   ],
   "Industry Tools": [
     { label: "Barbershop Apprentice Jobs Houston", href: "/barbershop-apprentice-jobs-houston" },
@@ -38,6 +39,7 @@ const footerLinks = {
     { label: "Accreditation Advisory Committee Toolkit", href: "/program-advisory-committee-kit" },
   ],
   Company: [
+    { label: "Advertise / Media Kit", href: "/media-kit" },
     { label: "Research & Insights", href: "/insights" },
     { label: "Technical Glossary", href: "/glossary" },
     { label: "About Us", href: "/about" },

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -13,6 +13,7 @@ const navLinks = [
   { label: "Market Insights", href: "/insights" },
   { label: "AI Lab", href: "/ai-solutions" },
   { label: "Membership", href: "/membership" },
+  { label: "Advertise", href: "/media-kit" },
 ]
 
 const stateHubLinks = [

--- a/components/shared/exam-prep-cta.tsx
+++ b/components/shared/exam-prep-cta.tsx
@@ -1,29 +1,24 @@
 import Link from "next/link";
 import { GraduationCap, ArrowRight } from "lucide-react";
+import { examPrepInfo, type ExamState, type ExamVariant } from "@/lib/exam-prep";
 
 // Reusable funnel CTA that routes exam-track visitors to the exam-prep
 // conversion page. Used across the cosmetology/barber student entry pages
 // (practice deck, school directories, licensing/exam guides) so they all
-// hand off to the same prep destination. Carries a distinct
+// hand off to the same prep destination. `state` routes to the correct
+// regulator's page (TX vs CA); defaults to TX. Carries a distinct
 // data-ig-click="exam_prep_cta" so these clicks are cleanly attributable in
 // pixel analytics (separate from the generic outbound_lead label).
 export function ExamPrepCTA({
   variant = "cosmetology",
+  state = "TX",
   className = "",
 }: {
-  variant?: "cosmetology" | "barber";
+  variant?: ExamVariant;
+  state?: ExamState;
   className?: string;
 }) {
-  const isCosmet = variant === "cosmetology";
-  const href = isCosmet
-    ? "/texas-cosmetology-exam-intelligence-prep"
-    : "/texas-barber-exam-intelligence-prep";
-  const label = isCosmet
-    ? "Texas Cosmetology Exam Intelligence Prep"
-    : "Texas Barber Exam Intelligence Prep";
-  const sub = isCosmet
-    ? "Real 2026 pass-rate benchmarks, a study guide, and a written practice test to help you pass the Texas cosmetology state board the first time."
-    : "Real 2026 pass-rate benchmarks, a study guide, and a written practice test to help you pass the Texas barber exam the first time.";
+  const { href, label, sub } = examPrepInfo(state, variant);
 
   return (
     <Link

--- a/components/texas-hub/TexasHubDirectory.tsx
+++ b/components/texas-hub/TexasHubDirectory.tsx
@@ -3,6 +3,7 @@ import { Star, ArrowRight, Award, MapPin, Scissors, Building2, UserCheck, Gradua
 import type { TexasHubData } from "@/lib/texas-hub-data";
 import { Navbar } from "@/components/layout/navbar";
 import { AdSponsorshipBanner } from "@/components/ads/AdSponsorshipBanner";
+import { directoryHrefForSection } from "@/lib/directory-config";
 // Genuinely statewide resources — unlike the Houston-area service pages
 // (which live on /houston's own "Explore Houston Services" section instead,
 // since they're metro-specific, not statewide), these aren't tied to one city.
@@ -14,6 +15,7 @@ const TEXAS_STATEWIDE_LINKS: { href: string; label: string }[] = [
   { href: "/how-to-get-a-barber-license-in-texas", label: "How to Get a Barber License in Texas" },
   { href: "/texas-barber-practical-exam-kit-list", label: "Texas Barber Practical Exam Kit List" },
   { href: "/texas-cosmetology-practical-exam-kit-list", label: "Texas Cosmetology Practical Exam Kit List" },
+  { href: "/directory", label: "Full Directory (A–Z)" },
 ];
 
 const SECTION_ICONS: Record<string, any> = {
@@ -156,7 +158,7 @@ export function TexasHubDirectory({
                   <span className="text-sm font-bold text-slate-400">({section.count.toLocaleString()})</span>
                 </div>
                 <Link
-                  href={`/tools/barbershop-search?tab=${encodeURIComponent(section.searchTab)}`}
+                  href={directoryHrefForSection(section.key)}
                   className="inline-flex items-center gap-1 text-xs font-bold text-indigo-600 hover:text-indigo-800 uppercase tracking-wider"
                 >
                   View All

--- a/lib/directory-config.ts
+++ b/lib/directory-config.ts
@@ -1,0 +1,169 @@
+/**
+ * Config for the crawlable A–Z directory at /directory.
+ *
+ * Each entity family gets a paginated browse path (/directory/<key>, then
+ * /directory/<key>/2, /3, …) that renders a plain HTML list of <a> links down
+ * to every profile page. This is the internal-link backbone that gives Google
+ * a real crawl tree to the long tail of entities — previously most profiles
+ * were only reachable via the sitemap (orphan pages), because the hub "See All"
+ * links point at the client-side search app, which renders zero crawlable
+ * links. See lib/directory-data.ts for the fetch layer.
+ *
+ * NOTE: two pairs of families share a profile route on purpose — barber &
+ * cosmetology schools both live under /schools/[slug], and barber-supply &
+ * beauty-supply stores both under /stores/[slug] — but they stay distinct
+ * browse types here because they're distinct directories to a user (and to us).
+ */
+export interface DirectoryType {
+  key: string; // URL segment under /directory
+  label: string; // plural, e.g. "Barbershops"
+  labelSingular: string;
+  table: string;
+  entityPrefix: string; // profile route prefix, e.g. "/shop"
+  nameCol: string;
+  cityCol: string; // column used to DISPLAY a row's city
+  cityFallbackCol?: string; // used when cityCol is null (barbers/cosmetologists)
+  // Column used to FILTER by city on scoped pages (/directory/<type>/<city>).
+  // Defaults to cityCol; shops & salons override to formatted_address because
+  // their `city` column is proven unreliable outside Houston — this mirrors
+  // exactly how lib/city-hub-data.ts matches each family to a city.
+  cityFilterCol?: string;
+  description: string;
+}
+
+export const PAGE_SIZE = 100;
+
+export const DIRECTORY_TYPES: DirectoryType[] = [
+  {
+    key: "barbershops",
+    label: "Barbershops",
+    labelSingular: "Barbershop",
+    table: "agent_barbershop_leads",
+    entityPrefix: "/shop",
+    nameCol: "shop_name",
+    cityCol: "city",
+    cityFilterCol: "formatted_address",
+    description: "Every barbershop in our directory, browsable A–Z by city.",
+  },
+  {
+    key: "salons",
+    label: "Hair Salons",
+    labelSingular: "Hair Salon",
+    table: "agent_salon_leads",
+    entityPrefix: "/salons",
+    nameCol: "shop_name",
+    cityCol: "city",
+    cityFilterCol: "formatted_address",
+    description: "Every hair salon in our directory, browsable A–Z by city.",
+  },
+  {
+    key: "barbers",
+    label: "Barbers",
+    labelSingular: "Barber",
+    table: "agent_barber_leads",
+    entityPrefix: "/barbers",
+    nameCol: "name",
+    cityCol: "metro_area",
+    cityFallbackCol: "address",
+    description: "Every licensed barber profile in our directory.",
+  },
+  {
+    key: "cosmetologists",
+    label: "Cosmetologists",
+    labelSingular: "Cosmetologist",
+    table: "agent_cosmetologist_leads",
+    entityPrefix: "/cosmetologists",
+    nameCol: "name",
+    cityCol: "metro_area",
+    cityFallbackCol: "address",
+    description: "Every licensed cosmetologist profile in our directory.",
+  },
+  {
+    key: "barber-schools",
+    label: "Barber Schools",
+    labelSingular: "Barber School",
+    table: "agent_barber_school_leads",
+    entityPrefix: "/schools",
+    nameCol: "school_name",
+    cityCol: "city",
+    description: "Every barber school in our directory, with state board pass-rate coverage.",
+  },
+  {
+    key: "cosmetology-schools",
+    label: "Cosmetology Schools",
+    labelSingular: "Cosmetology School",
+    table: "agent_cosmetology_school_leads",
+    entityPrefix: "/schools",
+    nameCol: "school_name",
+    cityCol: "city",
+    description: "Every cosmetology school in our directory, with state board pass-rate coverage.",
+  },
+  {
+    key: "barber-supply-stores",
+    label: "Barber Supply Stores",
+    labelSingular: "Barber Supply Store",
+    table: "agent_barber_supply_store_leads",
+    entityPrefix: "/stores",
+    nameCol: "name",
+    cityCol: "city",
+    description: "Every barber supply store in our directory.",
+  },
+  {
+    key: "beauty-supply-stores",
+    label: "Beauty Supply Stores",
+    labelSingular: "Beauty Supply Store",
+    table: "agent_beauty_supply_store_leads",
+    entityPrefix: "/stores",
+    nameCol: "name",
+    cityCol: "city",
+    description: "Every beauty supply store in our directory.",
+  },
+  {
+    key: "events",
+    label: "Events",
+    labelSingular: "Event",
+    table: "events",
+    entityPrefix: "/events",
+    nameCol: "title",
+    cityCol: "city",
+    description: "Industry events, shows, and meetups in our directory.",
+  },
+];
+
+export function getDirectoryType(key: string): DirectoryType | undefined {
+  return DIRECTORY_TYPES.find((t) => t.key === key);
+}
+
+/**
+ * Maps a hub-section key (from texas-hub-data / california-hub-data /
+ * city-hub-data — e.g. "shops", "cosmetSchools") to its crawlable browse path,
+ * so hub "View All" links point at the directory instead of the client-side
+ * search app (which renders zero crawlable links). The combined "stores"
+ * section has no single list — barber-supply and beauty-supply are separate
+ * families — so it goes to the directory index where both are one click away.
+ */
+const SECTION_TO_DIRECTORY_KEY: Record<string, string> = {
+  shops: "barbershops",
+  salons: "salons",
+  barbers: "barbers",
+  cosmetologists: "cosmetologists",
+  barberSchools: "barber-schools",
+  cosmetSchools: "cosmetology-schools",
+  events: "events",
+  stores: "", // combined family → index
+};
+
+export function directoryHrefForSection(sectionKey: string, citySlug?: string): string {
+  const key = SECTION_TO_DIRECTORY_KEY[sectionKey];
+  // The combined "stores" section (barber-supply + beauty-supply) has no single
+  // list, so it always goes to the index — a city can't scope it cleanly.
+  if (!key) return "/directory";
+  return citySlug ? `/directory/${key}/${citySlug}` : `/directory/${key}`;
+}
+
+/** Distinct columns to SELECT for a browse list (slug + name + city fields). */
+export function selectColumnsFor(t: DirectoryType): string {
+  const cols = new Set(["slug", "updated_at", t.nameCol, t.cityCol]);
+  if (t.cityFallbackCol) cols.add(t.cityFallbackCol);
+  return [...cols].join(", ");
+}

--- a/lib/directory-data.ts
+++ b/lib/directory-data.ts
@@ -1,0 +1,115 @@
+import { createClient } from "@supabase/supabase-js";
+import {
+  DIRECTORY_TYPES,
+  DirectoryType,
+  PAGE_SIZE,
+  selectColumnsFor,
+} from "./directory-config";
+import { citySlugToName } from "./city-readiness";
+import { citySlugToNameCA } from "./california-city-readiness";
+
+/**
+ * Resolve a directory city slug to its proper-case name, or null if it isn't a
+ * known hub city. Strict allow-list (TX cities, then CA cities) — never fuzzy —
+ * so a typo'd /directory/<type>/<junk> 404s instead of scanning the whole table
+ * for an empty result. Covers bespoke Houston (it's in TX_CITIES).
+ */
+export function resolveDirectoryCity(slug: string): string | null {
+  return citySlugToName(slug) || citySlugToNameCA(slug);
+}
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseKey =
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+function client() {
+  return createClient(supabaseUrl, supabaseKey);
+}
+
+export interface DirectoryEntity {
+  slug: string;
+  name: string;
+  city: string | null;
+}
+
+export interface DirectoryPage {
+  entities: DirectoryEntity[];
+  total: number;
+  totalPages: number;
+  page: number;
+}
+
+/**
+ * One page of a browse list. Ordered by name then slug so pagination is stable
+ * across requests (slug is the URL — guaranteed present and unique). Rows with
+ * no slug are excluded: they have no live profile page to link to.
+ */
+export async function getDirectoryPage(
+  type: DirectoryType,
+  page: number,
+  cityName?: string | null
+): Promise<DirectoryPage> {
+  const supabase = client();
+  const filterCol = type.cityFilterCol || type.cityCol;
+  const cityFilter = cityName ? `%${cityName}%` : null;
+
+  // Count first: a range() whose offset exceeds the row count makes PostgREST
+  // return an error (not an empty page), so we must know totalPages before
+  // issuing the range query and bail early for out-of-range pages — that's
+  // what lets the caller render a clean 404 instead of a 500.
+  let countQuery = supabase
+    .from(type.table)
+    .select("slug", { count: "exact", head: true })
+    .not("slug", "is", null);
+  if (cityFilter) countQuery = countQuery.ilike(filterCol, cityFilter);
+  const { count } = await countQuery;
+
+  const total = count ?? 0;
+  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  if (page > totalPages) {
+    return { entities: [], total, totalPages, page };
+  }
+
+  const from = (page - 1) * PAGE_SIZE;
+  const to = from + PAGE_SIZE - 1;
+
+  let dataQuery = supabase
+    .from(type.table)
+    .select(selectColumnsFor(type))
+    .not("slug", "is", null);
+  if (cityFilter) dataQuery = dataQuery.ilike(filterCol, cityFilter);
+  const { data, error } = await dataQuery
+    .order(type.nameCol, { ascending: true, nullsFirst: false })
+    .order("slug", { ascending: true })
+    .range(from, to);
+
+  if (error) throw new Error(`${type.table}: ${error.message}`);
+
+  const entities: DirectoryEntity[] = (data || []).map((row: any) => ({
+    slug: row.slug,
+    name: row[type.nameCol] || "Unnamed",
+    city: row[type.cityCol] || (type.cityFallbackCol ? row[type.cityFallbackCol] : null) || null,
+  }));
+
+  return {
+    entities,
+    total,
+    totalPages,
+    page,
+  };
+}
+
+/** Head-only exact counts for each family — for the /directory index cards. */
+export async function getDirectoryCounts(): Promise<Record<string, number>> {
+  const supabase = client();
+  const results = await Promise.all(
+    DIRECTORY_TYPES.map(async (t) => {
+      const { count } = await supabase
+        .from(t.table)
+        .select("slug", { count: "exact", head: true })
+        .not("slug", "is", null);
+      return [t.key, count ?? 0] as const;
+    })
+  );
+  return Object.fromEntries(results);
+}

--- a/lib/exam-prep.ts
+++ b/lib/exam-prep.ts
@@ -1,0 +1,50 @@
+/**
+ * Single source of truth for routing a school/student to the right exam-prep
+ * page. The school tables have no `state` column, so state is derived from the
+ * formatted_address. Used by components/shared/exam-prep-cta.tsx and the inline
+ * CTA on app/schools/[slug] so a California school never links to Texas prep.
+ */
+export type ExamState = "TX" | "CA";
+export type ExamVariant = "cosmetology" | "barber";
+
+// Match ", CA 90210" / ", CA" / ", California" — a comma then CA/California as a
+// word, so a Texas address ("…, TX 77002") never false-matches. Default TX
+// (the overwhelming majority of the directory) when the state is indeterminate.
+export function deriveExamState(formattedAddress?: string | null): ExamState {
+  if (formattedAddress && /,\s*(CA\b|California\b)/i.test(formattedAddress)) return "CA";
+  return "TX";
+}
+
+export interface PrepInfo {
+  href: string;
+  label: string;
+  sub: string;
+}
+
+export function examPrepInfo(state: ExamState, variant: ExamVariant): PrepInfo {
+  const isCosmet = variant === "cosmetology";
+  if (state === "CA") {
+    return isCosmet
+      ? {
+          href: "/california-cosmetology-exam-intelligence-prep",
+          label: "California Cosmetology Exam Intelligence Prep",
+          sub: "Real 2026 first-time written pass-rate benchmarks from the California Board of Barbering & Cosmetology, plus a study guide to help you pass the California cosmetology state board.",
+        }
+      : {
+          href: "/california-barber-exam-intelligence-prep",
+          label: "California Barber Exam Intelligence Prep",
+          sub: "Real 2026 first-time written pass-rate benchmarks from the California Board of Barbering & Cosmetology, plus a study guide to help you pass the California barber exam.",
+        };
+  }
+  return isCosmet
+    ? {
+        href: "/texas-cosmetology-exam-intelligence-prep",
+        label: "Texas Cosmetology Exam Intelligence Prep",
+        sub: "Real 2026 pass-rate benchmarks, a study guide, and a written practice test to help you pass the Texas cosmetology state board the first time.",
+      }
+    : {
+        href: "/texas-barber-exam-intelligence-prep",
+        label: "Texas Barber Exam Intelligence Prep",
+        sub: "Real 2026 pass-rate benchmarks, a study guide, and a written practice test to help you pass the Texas barber exam the first time.",
+      };
+}


### PR DESCRIPTION
…g media kit

Directory (SEO crawl backbone):
- Add /directory index + paginated /directory/<type> lists for all 9 entity families, giving Google a real internal-link tree to every profile page (previously most were sitemap-only orphans).
- Add city-scoped lists (/directory/<type>/<city>) matching each hub's own city-matching column (formatted_address for shops/salons, metro_area for barbers, etc.), with self-canonical pagination and clean 404s.
- Wire every hub's "View All" (Texas, California, city hubs, Houston) to the directory, city-scoped where applicable; add directory links to the Statewide Resources sections and the footer; emit directory URLs in sitemap.

California exam prep:
- Add /california-cosmetology- and /california-barber-exam-intelligence-prep, data-driven from real CA BBC first-time written pass rates (school_exam_stats).
- Make the exam-prep CTA state-aware (deriveExamState from formatted_address) so ~184 CA schools stop showing Texas prep; fix the school JSON-LD region.

Advertising media kit:
- Add /media-kit page (reach stats, ad inventory, rate card with live pricing).
- Add "Advertise" to the top nav and "Advertise / Media Kit" to the footer.