### PR TITLE
feat(insights): rework "Opening a Shop in Texas" for cost+profit inte…

### DIFF
--- a/app/insights/opening-your-own-shop-in-texas/page.tsx
+++ b/app/insights/opening-your-own-shop-in-texas/page.tsx
@@ -7,6 +7,7 @@ import { AuthorBio } from "@/components/insights/author-bio"
 import { RelatedArticles } from "@/components/insights/related-articles"
 import { BreadcrumbSchema } from "@/components/insights/breadcrumb-schema"
 import { Navbar } from "@/components/layout/navbar"
+import { getHoustonBoothRentStats } from "@/lib/houston-booth-rent"
 import {
   ArrowLeft,
   ArrowRight,
@@ -22,6 +23,9 @@ import {
   DollarSign,
   Truck,
   MapPin,
+  TrendingUp,
+  ListOrdered,
+  Receipt,
 } from "lucide-react"
 import Link from "next/link"
 import Image from "next/image"
@@ -74,39 +78,64 @@ const references = [
 ]
 
 export const metadata = {
-  title: "Opening Your Own Shop in Texas (2026): TDLR Establishment License Requirements | Inner G Complete",
+  title: "How to Open a Barbershop in Texas (2026): Costs, Licenses & Profit | Inner G Complete",
   description:
-    "What TDLR actually requires to open a barbershop or salon in Texas — establishment license application, premises and equipment rules, required postings, and how inspections work. Sourced directly from TDLR.",
+    "What it really costs to open a barbershop in Texas — a full startup cost breakdown (~$28k–$110k), licensing fees, and real profit math grounded in current Houston booth-rent data. Plus the TDLR establishment license and inspection rules, sourced directly from TDLR.",
   keywords: [
-    "TDLR requirements for opening a salon",
-    "tdlr barber shop requirements",
-    "how to open a barbershop in Texas",
-    "Texas barbershop establishment license",
-    "TDLR salon inspection requirements",
-    "opening a home salon Texas",
-    "Texas cosmetology establishment license",
-    "booth rent shop Houston",
+    "how much does it cost to open a barbershop in Texas",
     "cost to open a barbershop in Texas",
+    "barbershop startup cost Texas",
+    "how to open a barbershop in Texas",
+    "barbershop profit margin Texas",
+    "how much do barbershop owners make in Texas",
+    "Texas barbershop establishment license",
+    "tdlr barber shop requirements",
+    "booth rent shop Houston",
     "mobile barbershop license Texas",
   ],
   openGraph: {
-    title: "Opening Your Own Shop in Texas (2026)",
+    title: "How to Open a Barbershop in Texas (2026): Costs, Licenses & Profit",
     description:
-      "Establishment license application, premises and equipment rules, required postings, and inspections — the canonical TDLR shop-opening guide.",
+      "Full startup cost breakdown, licensing fees, and profit math grounded in real Houston booth-rent data — plus the TDLR establishment license rules.",
     url: "https://agency.innergcomplete.com/insights/opening-your-own-shop-in-texas",
     type: "article",
-    images: [{ url: "/opening_shop_texas_cover.png", width: 1200, height: 630, alt: "Opening Your Own Shop in Texas" }],
+    images: [{ url: "/opening_shop_texas_cover.png", width: 1200, height: 630, alt: "How to Open a Barbershop in Texas" }],
   },
   twitter: {
     card: "summary_large_image",
-    title: "Opening Your Own Shop in Texas (2026)",
-    description: "Establishment license, premises rules, required postings, and inspections — the TDLR shop-opening guide.",
+    title: "How to Open a Barbershop in Texas (2026): Costs, Licenses & Profit",
+    description: "Startup cost breakdown, licensing fees, and profit math grounded in real Houston booth-rent data.",
     images: ["/opening_shop_texas_cover.png"],
   },
   alternates: { canonical: "https://agency.innergcomplete.com/insights/opening-your-own-shop-in-texas" },
 }
 
-export default function OpeningYourOwnShopGuide() {
+// Refresh the tracked Houston booth-rent figures once a day (ISR) so the
+// profit section self-updates without hitting Supabase on every request.
+export const revalidate = 86400
+
+export default async function OpeningYourOwnShopGuide() {
+  const rent = await getHoustonBoothRentStats()
+
+  // Derived money helpers, all grounded in the live tracked figures above.
+  const money = (n: number) => `$${n.toLocaleString()}`
+  // Annual booth-rent income, rounded to the nearest $100 for clean display.
+  const annual = (weekly: number, chairs: number) => money(Math.round((weekly * 52 * chairs) / 100) * 100)
+  const low4 = annual(rent.lowBandRent, 4)
+  const avg4 = annual(rent.avgWeeklyRent, 4)
+  const high4 = annual(rent.highBandRent, 4)
+
+  // Weekly-rent range label for a group of ZIPs, e.g. "$150–170/wk".
+  const zipRange = (zips: { weekly: number }[]) => {
+    if (!zips.length) return `$${rent.avgWeeklyRent}/wk`
+    const lo = Math.min(...zips.map((z) => z.weekly))
+    const hi = Math.max(...zips.map((z) => z.weekly))
+    return lo === hi ? `$${lo}/wk` : `$${lo}–${hi}/wk`
+  }
+  // Only show the cheapest/priciest ZIP cards when the live query returned
+  // enough per-ZIP data to split neighborhoods honestly.
+  const hasZipBreakdown = rent.cheapestZips.length > 0 && rent.priciestZips.length > 0
+
   return (
     <main className="min-h-screen bg-background light text-foreground flex flex-col pt-20">
       <script
@@ -119,12 +148,36 @@ export default function OpeningYourOwnShopGuide() {
               "@type": "WebPage",
               "@id": "https://agency.innergcomplete.com/insights/opening-your-own-shop-in-texas",
             },
-            headline: "Opening Your Own Shop in Texas: TDLR Establishment License Requirements",
+            headline: "How to Open a Barbershop in Texas: Costs, Licenses & Profit",
             description:
-              "What TDLR requires to open a barbershop or salon in Texas — establishment license, premises and equipment rules, required postings, and inspections.",
+              "What it costs to open a barbershop in Texas — full startup cost breakdown, licensing fees, and profit math grounded in real Houston booth-rent data, plus TDLR establishment license, premises, and inspection rules.",
             author: { "@type": "Person", name: "Lamont Evans", url: "https://agency.innergcomplete.com/about" },
             publisher: { "@type": "Organization", name: "Inner G Complete Agency" },
             datePublished: "2026-07-08T08:00:00Z",
+            dateModified: "2026-07-26T08:00:00Z",
+          }),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "HowTo",
+            name: "How to Open a Barbershop in Texas",
+            description:
+              "The step-by-step path to opening a licensed barbershop in Texas, from your individual license through the TDLR establishment license and first inspection.",
+            estimatedCost: { "@type": "MonetaryAmount", currency: "USD", minValue: 28000, maxValue: 110000 },
+            step: [
+              { "@type": "HowToStep", name: "Get your individual license", text: "Earn your individual TDLR barber or cosmetology license — the establishment license is separate and does not replace it." },
+              { "@type": "HowToStep", name: "Choose your model and location", text: `Decide whether you'll rent booths or hire employees, then pick a location — in Houston, tracked booth rent ranges from $${rent.lowBandRent} to $${rent.highBandRent} per week depending on the ZIP.` },
+              { "@type": "HowToStep", name: "Register your business", text: "Form your business entity — a Texas LLC filing costs $300 — and choose your structure (sole proprietor, LLC, corporation)." },
+              { "@type": "HowToStep", name: "Secure compliant premises", text: "Lease or build out a space that meets TDLR premises rules. A home-based shop must have its own entrance, separate from the residence." },
+              { "@type": "HowToStep", name: "Apply for the TDLR establishment license", text: "Submit the TDLR establishment license application ($78 fee) online, with details on ownership and business structure." },
+              { "@type": "HowToStep", name: "Equip every station", text: "Provide each practitioner a work station, styling chair, covered waste receptacle, and sanitation equipment. Nail services require an autoclave, dry-heat, or UV sanitizer." },
+              { "@type": "HowToStep", name: "Post required signage", text: "Display the establishment license, consumer complaint sign, human trafficking awareness sign, inspection-report notice, sanitation rules, and each practitioner's license." },
+              { "@type": "HowToStep", name: "Pass inspection and open", text: "TDLR inspections are unannounced and risk-based — stay compliant on ordinary days, not just when you expect a visit." },
+            ],
           }),
         }}
       />
@@ -158,30 +211,30 @@ export default function OpeningYourOwnShopGuide() {
             <ExecutiveSummary
               data={{
                 problem:
-                  "A newly-licensed barber or cosmetologist asking 'what do I need to open my own shop' is a distinct persona from a student asking 'how do I get licensed' — and one that's never been addressed here.",
+                  "Most 'how to open a barbershop in Texas' guides answer the paperwork but dodge the two questions that actually decide it: what does it really cost to open, and what will it make once it's open?",
                 requirement:
-                  "A separate TDLR establishment license (not just your individual license), premises that meet sanitation/safety rules, required equipment per practitioner, and specific postings visible to the public.",
-                roi: "Establishment license required in addition to every practitioner's individual license",
+                  "Roughly $28k–$110k to open depending on buildout and chair count, a separate TDLR establishment license ($78) on top of your individual license, compliant premises, per-practitioner equipment, and required public postings.",
+                roi: `Booth-rent income grounded in real Houston data: at the tracked $${rent.avgWeeklyRent}/wk average, a filled 4-chair shop collects ~${avg4}/year before overhead`,
                 solution:
-                  "A canonical, TDLR-sourced guide to the establishment license, premises rules, equipment requirements, required postings, and how unannounced inspections actually work.",
+                  "A full startup cost breakdown, profit math grounded in our tracked Houston booth-rent data, a step-by-step opening roadmap, and the TDLR establishment, premises, and inspection rules — sourced directly from TDLR.",
               }}
             />
 
             <h1 className="text-4xl font-black tracking-tighter text-foreground sm:text-6xl md:text-7xl uppercase italic leading-[0.95] mb-8">
-              Opening Your <br />Own Shop <br />in Texas
+              How to Open a <br />Barbershop <br />in Texas
             </h1>
 
             <p className="text-xl text-muted-foreground leading-relaxed font-medium text-balance mb-6">
-              What TDLR actually requires to open a barbershop or salon in Texas — the establishment license,
-              premises and equipment rules, required postings, and how inspections work — sourced directly from
-              TDLR.
+              What it really costs to open a barbershop in Texas, what it can make, and every TDLR requirement in
+              between — a full startup cost breakdown, profit math grounded in real Houston booth-rent data, and
+              the establishment license, premises, and inspection rules sourced directly from TDLR.
             </p>
 
             <StatisticalSignal
               signals={[
-                { label: "Licenses Required", value: "2", icon: "shield" },
-                { label: "Inspection Notice", value: "None", icon: "activity" },
-                { label: "Sole Proprietor Structures", value: "Disclosed", icon: "data" },
+                { label: "Startup Cost", value: "$28k–$110k", icon: "data" },
+                { label: "Avg Booth Rent", value: `$${rent.avgWeeklyRent}/wk`, icon: "shield" },
+                { label: "TDLR License Fee", value: "$78", icon: "activity" },
               ]}
             />
 
@@ -272,7 +325,9 @@ export default function OpeningYourOwnShopGuide() {
                 The TDLR establishment license fee itself is small — $78, whether you&apos;re licensing a
                 full-service shop, a specialty establishment, or a mobile unit.
                 <Cite id={5} />
-                The real cost of opening a shop is almost entirely buildout and equipment, not paperwork.
+                The real cost of opening a shop is almost entirely buildout and equipment, not paperwork. A lean
+                shop moving into an existing salon space can open for as little as ~$28k; a mid-range 4–5 chair
+                build-out typically lands in the $80k–$150k range, and an upscale ground-up build runs $200k or more.
               </p>
               <div className="grid sm:grid-cols-3 gap-4 not-prose">
                 <div className="rounded-2xl border border-border bg-white p-5">
@@ -288,16 +343,139 @@ export default function OpeningYourOwnShopGuide() {
                   <p className="text-2xl font-black text-foreground tracking-tighter">$200k+</p>
                 </div>
               </div>
+
+              {/* Line-item startup cost table */}
+              <div className="not-prose rounded-2xl border border-border overflow-hidden">
+                <div className="flex items-center gap-2 bg-primary/5 border-b border-border px-5 py-3">
+                  <Receipt className="h-4 w-4 text-primary" />
+                  <p className="text-xs font-black text-primary uppercase tracking-widest">
+                    Startup Cost Breakdown — Typical 3–5 Chair Texas Shop
+                  </p>
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-border text-left">
+                        <th className="px-5 py-2.5 font-black text-foreground uppercase text-[10px] tracking-widest">Line Item</th>
+                        <th className="px-5 py-2.5 font-black text-foreground uppercase text-[10px] tracking-widest text-right">Low</th>
+                        <th className="px-5 py-2.5 font-black text-foreground uppercase text-[10px] tracking-widest text-right">High</th>
+                      </tr>
+                    </thead>
+                    <tbody className="text-muted-foreground font-medium">
+                      {[
+                        ["Buildout & renovation (plumbing, electrical, flooring)", "$10,000", "$45,000"],
+                        ["Barber chairs (3–5, hydraulic)", "$2,700", "$8,500"],
+                        ["Stations, mirrors & storage", "$3,000", "$12,000"],
+                        ["Clippers, trimmers & shears (per chair)", "$500", "$1,400"],
+                        ["Initial product & retail inventory", "$1,500", "$6,000"],
+                        ["POS & booking software (setup)", "$300", "$1,500"],
+                        ["Signage & branding", "$1,500", "$6,000"],
+                        ["TDLR establishment license", "$78", "$78"],
+                        ["Business license & local permits", "$100", "$500"],
+                        ["Texas LLC filing", "$300", "$300"],
+                        ["Insurance (first year)", "$1,500", "$5,000"],
+                        ["Launch marketing", "$1,000", "$4,000"],
+                        ["Working capital (≈3 months)", "$5,000", "$15,000"],
+                      ].map(([item, low, high]) => (
+                        <tr key={item} className="border-b border-border/60">
+                          <td className="px-5 py-2.5">{item}</td>
+                          <td className="px-5 py-2.5 text-right tabular-nums">{low}</td>
+                          <td className="px-5 py-2.5 text-right tabular-nums">{high}</td>
+                        </tr>
+                      ))}
+                      <tr className="bg-primary/5 font-black text-foreground">
+                        <td className="px-5 py-3 uppercase text-xs tracking-widest">Estimated Total</td>
+                        <td className="px-5 py-3 text-right tabular-nums">~$28,000</td>
+                        <td className="px-5 py-3 text-right tabular-nums">~$110,000</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+
               <p>
-                Build-out (renovation, plumbing, electrical, flooring) is typically the single largest line item —
-                30-40% of total cost. Equipment runs another 20-25%: a quality hydraulic barber chair costs roughly
-                $900-$1,700, and hand tools (clippers, trimmers, shears) for each chair run another $500-$1,400.
-                The remaining 15-20% is working capital to cover rent and payroll before the shop is generating
-                steady revenue.
+                Buildout is almost always the single largest line item — 30–40% of the total — followed by
+                equipment at 20–25%. The $78 establishment fee and $300 LLC filing are the only truly fixed,
+                Texas-specific numbers here; everything else swings with your lease, your city, and how much of the
+                buildout you do yourself versus hire out.
               </p>
               <p>
-                These figures come from general industry cost guides, not TDLR — they&apos;ll vary significantly by
-                city, lease terms, and how much of the buildout you do yourself versus hire out.
+                The line-item ranges above come from general industry cost guides, not TDLR. The booth-rent and
+                profit figures in the next two sections, however, come from our own continuously-tracked Houston
+                shop data.
+              </p>
+            </div>
+          </section>
+
+          {/* Profitability — grounded in tracked Houston booth-rent data */}
+          <section>
+            <div className="flex items-center gap-3 mb-6">
+              <TrendingUp className="h-5 w-5 text-primary" />
+              <h2 className="text-2xl font-black uppercase tracking-tight text-foreground">
+                What Does a Texas Barbershop Actually Make?
+              </h2>
+            </div>
+            <div className="prose prose-lg max-w-none text-muted-foreground font-medium leading-relaxed space-y-4">
+              <p>
+                A Texas shop makes money one of two ways, and they have completely different profit profiles: you
+                either <strong>rent out chairs</strong> (you&apos;re the landlord and collect booth rent) or you{" "}
+                <strong>staff barbers</strong> (you&apos;re the operator and keep a margin on every cut). The
+                booth-rent model is where we have real, first-party data.
+              </p>
+              <p>
+                Across {rent.sampleSize} currently-tracked Houston shops, weekly booth rent averages{" "}
+                <strong>${rent.avgWeeklyRent}/chair</strong>, ranging from <strong>${rent.lowBandRent}</strong> in the
+                cheapest ZIPs to <strong>${rent.highBandRent}</strong> in the priciest. That turns directly into
+                annual booth-rent income once your chairs are filled:
+              </p>
+
+              {/* Booth-rent income table, computed live from the tracked average */}
+              <div className="not-prose rounded-2xl border border-border overflow-hidden">
+                <div className="flex items-center gap-2 bg-primary/5 border-b border-border px-5 py-3">
+                  <DollarSign className="h-4 w-4 text-primary" />
+                  <p className="text-xs font-black text-primary uppercase tracking-widest">
+                    Annual Booth-Rent Income by Chair Count (Houston tracked data)
+                  </p>
+                </div>
+                <div className="overflow-x-auto">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-border text-left">
+                        <th className="px-5 py-2.5 font-black text-foreground uppercase text-[10px] tracking-widest">Chairs Filled</th>
+                        <th className="px-5 py-2.5 font-black text-foreground uppercase text-[10px] tracking-widest text-right">Cheapest ZIPs<br />(${rent.lowBandRent}/wk)</th>
+                        <th className="px-5 py-2.5 font-black text-foreground uppercase text-[10px] tracking-widest text-right">Tracked Avg<br />(${rent.avgWeeklyRent}/wk)</th>
+                        <th className="px-5 py-2.5 font-black text-foreground uppercase text-[10px] tracking-widest text-right">Priciest ZIPs<br />(${rent.highBandRent}/wk)</th>
+                      </tr>
+                    </thead>
+                    <tbody className="text-muted-foreground font-medium">
+                      {[3, 4, 5, 6].map((chairs) => (
+                        <tr key={chairs} className="border-b border-border/60">
+                          <td className="px-5 py-2.5 font-bold text-foreground">{chairs} chairs</td>
+                          <td className="px-5 py-2.5 text-right tabular-nums">{annual(rent.lowBandRent, chairs)}</td>
+                          <td className="px-5 py-2.5 text-right tabular-nums font-bold text-foreground">{annual(rent.avgWeeklyRent, chairs)}</td>
+                          <td className="px-5 py-2.5 text-right tabular-nums">{annual(rent.highBandRent, chairs)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+
+              <p>
+                That&apos;s <em>gross</em> booth-rent income, before your own overhead — your lease, utilities,
+                insurance, and supplies. The headline takeaway from our data: <strong>location swings owner income
+                roughly {rent.swingMultiple}×</strong>. The same 4-chair shop collects roughly {low4}/year in a
+                ${rent.lowBandRent}/wk ZIP versus {high4} in a ${rent.highBandRent}/wk ZIP — same buildout, same
+                license, a far bigger rent roll. Choosing the neighborhood is a bigger financial decision than
+                choosing the fixtures.
+              </p>
+              <p>
+                If you staff barbers instead of renting chairs, the model flips: you carry payroll but keep a cut of
+                every service. General industry guides put full-service Texas shop revenue at roughly
+                $95k–$285k/year with 10–20% net margins and owner take-home around $50k–$150k — but those are
+                industry-guide estimates, not our tracked data, and they hinge heavily on volume, pricing, and how
+                many chairs you keep full. We flag the difference so you know which numbers are ours and which
+                aren&apos;t.
               </p>
             </div>
           </section>
@@ -315,21 +493,24 @@ export default function OpeningYourOwnShopGuide() {
               <p>
                 Buildout cost isn&apos;t the only number that varies by location — so does ongoing booth rent, if
                 you&apos;re renting out chairs rather than staffing employees. Real, currently-listed weekly booth
-                rent across 25 tracked Houston shops averages <strong>$197/week</strong>, ranging from as low as{" "}
-                <strong>$125/week</strong> to as high as <strong>$300/week</strong> depending on the neighborhood.
+                rent across {rent.sampleSize} tracked Houston shops averages <strong>${rent.avgWeeklyRent}/week</strong>,
+                ranging from as low as <strong>${rent.lowBandRent}/week</strong> to as high as{" "}
+                <strong>${rent.highBandRent}/week</strong> depending on the neighborhood.
               </p>
-              <div className="grid sm:grid-cols-2 gap-4 not-prose">
-                <div className="rounded-2xl border border-border bg-white p-5">
-                  <p className="text-xs font-black text-primary uppercase tracking-widest mb-2">Cheapest Tracked ZIPs</p>
-                  <p className="text-2xl font-black text-foreground tracking-tighter">$125–150/wk</p>
-                  <p className="text-xs text-muted-foreground mt-1">77071, 77077, 77025, 77338, 77067</p>
+              {hasZipBreakdown && (
+                <div className="grid sm:grid-cols-2 gap-4 not-prose">
+                  <div className="rounded-2xl border border-border bg-white p-5">
+                    <p className="text-xs font-black text-primary uppercase tracking-widest mb-2">Cheapest Tracked ZIPs</p>
+                    <p className="text-2xl font-black text-foreground tracking-tighter">{zipRange(rent.cheapestZips)}</p>
+                    <p className="text-xs text-muted-foreground mt-1">{rent.cheapestZips.map((z) => z.zip).join(", ")}</p>
+                  </div>
+                  <div className="rounded-2xl border border-border bg-white p-5">
+                    <p className="text-xs font-black text-primary uppercase tracking-widest mb-2">Highest Tracked ZIPs</p>
+                    <p className="text-2xl font-black text-foreground tracking-tighter">{zipRange(rent.priciestZips)}</p>
+                    <p className="text-xs text-muted-foreground mt-1">{rent.priciestZips.map((z) => z.zip).join(", ")}</p>
+                  </div>
                 </div>
-                <div className="rounded-2xl border border-border bg-white p-5">
-                  <p className="text-xs font-black text-primary uppercase tracking-widest mb-2">Highest Tracked ZIPs</p>
-                  <p className="text-2xl font-black text-foreground tracking-tighter">$260–300/wk</p>
-                  <p className="text-xs text-muted-foreground mt-1">77449, 77002, 77079</p>
-                </div>
-              </div>
+              )}
               <p>
                 See the full, continuously-updated{" "}
                 <Link href="/barber-booth-rent-houston" className="text-primary font-bold hover:underline">
@@ -483,6 +664,55 @@ export default function OpeningYourOwnShopGuide() {
             </div>
           </section>
 
+          {/* Steps to Open — numbered roadmap, mirrors the HowTo schema */}
+          <section>
+            <div className="flex items-center gap-3 mb-6">
+              <ListOrdered className="h-5 w-5 text-primary" />
+              <h2 className="text-2xl font-black uppercase tracking-tight text-foreground">
+                Steps to Open Your Barbershop
+              </h2>
+            </div>
+            <div className="prose prose-lg max-w-none text-muted-foreground font-medium leading-relaxed">
+              <p className="mb-6">
+                Put together, the path from licensed barber to open shop is eight steps. Cost and compliance run in
+                parallel — start budgeting the moment you pick a model.
+              </p>
+            </div>
+            <ol className="not-prose space-y-4 list-none pl-0">
+              {[
+                {
+                  t: "Get your individual license",
+                  d: (
+                    <>
+                      The establishment license is separate and doesn&apos;t replace it. Still working on yours? See our{" "}
+                      <Link href="/insights/texas-barber-cosmetology-license-requirements" className="text-primary font-bold hover:underline">
+                        Texas License Requirements guide
+                      </Link>
+                      .
+                    </>
+                  ),
+                },
+                { t: "Choose your model and location", d: `Rent booths or hire employees, then pick a location — in Houston, tracked booth rent runs $${rent.lowBandRent}–$${rent.highBandRent}/week depending on the ZIP, which swings your economics more than any fixture choice.` },
+                { t: "Register your business", d: "Form your entity and pick a structure — a Texas LLC filing is $300. TDLR's application asks how the business is owned and structured." },
+                { t: "Secure compliant premises", d: "Lease or build out a space that meets TDLR premises rules. A home-based shop must have its own entrance, separate and distinct from the residence." },
+                { t: "Apply for the TDLR establishment license", d: "Submit the application online with the $78 fee. Mobile units need a separate Mobile Establishment license with GPS/itinerary tracking." },
+                { t: "Equip every station", d: "Each practitioner needs a work station, styling chair, covered waste receptacle, and sanitation equipment. Nail services require an autoclave, dry-heat, or UV sanitizer." },
+                { t: "Post required signage", d: "Establishment license, consumer complaint sign, human trafficking awareness sign, inspection-report notice, sanitation rules, and every practitioner's license at their station." },
+                { t: "Pass inspection and open", d: "TDLR inspections are unannounced and risk-based. Stay compliant on ordinary days, then fill your chairs." },
+              ].map((step, i) => (
+                <li key={step.t} className="flex items-start gap-4 rounded-2xl border border-border bg-white p-5">
+                  <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary text-primary-foreground font-black text-sm">
+                    {i + 1}
+                  </span>
+                  <div>
+                    <p className="font-black text-foreground text-sm uppercase tracking-tight mb-1">{step.t}</p>
+                    <p className="text-sm text-muted-foreground font-medium leading-relaxed">{step.d}</p>
+                  </div>
+                </li>
+              ))}
+            </ol>
+          </section>
+
           {/* Owning the Shop: routes into real shop-owner tooling, not just more reading */}
           <section className="rounded-3xl border border-primary/20 bg-primary/5 p-8">
             <h2 className="text-2xl font-black uppercase tracking-tight text-foreground mb-3">
@@ -565,6 +795,16 @@ export default function OpeningYourOwnShopGuide() {
                 question: "How much does it cost to open a barbershop in Texas?",
                 answer:
                   "The TDLR establishment license itself is just $78. The real cost is buildout and equipment: a basic 3-chair shop typically runs $50k-$80k, a mid-range 4-5 chair shop $80k-$150k, and an upscale build-out $200k or more, according to general industry cost guides.",
+              },
+              {
+                question: "How much do barbershop owners make in Texas?",
+                answer:
+                  `It depends on the model. If you rent out chairs, our tracked Houston data shows booth rent averaging $${rent.avgWeeklyRent}/week per chair — so a filled 4-chair shop collects about ${avg4}/year in booth rent before overhead, and location swings that ${rent.swingMultiple}x (roughly ${low4}/year in the cheapest ZIPs versus ${high4} in the priciest). If you staff barbers instead, industry guides estimate owner take-home around $50,000-$150,000/year on 10-20% margins.`,
+              },
+              {
+                question: "Is booth rent or hiring employees more profitable for a Texas barbershop?",
+                answer:
+                  `Booth rent gives you predictable income with no payroll — at Houston's tracked $${rent.avgWeeklyRent}/week average, filled chairs generate a steady rent roll (${annual(rent.avgWeeklyRent, 3)}/year for 3 chairs, ${annual(rent.avgWeeklyRent, 6)} for 6) before your overhead. Employees carry payroll risk but let you keep a margin on every service and retail sale, which scales higher if you can keep chairs busy. Most new owners start with booth rent for the lower risk.`,
               },
               {
                 question: "Can I open a mobile barbershop or salon in Texas?",

--- a/lib/houston-booth-rent.ts
+++ b/lib/houston-booth-rent.ts
@@ -1,0 +1,110 @@
+import { createClient } from "@supabase/supabase-js";
+import { fetchAllRows } from "@/lib/supabase-fetch-all";
+import { extractZip } from "@/lib/geo-enrichment";
+import { parseWeeklyRent, median } from "@/lib/shop-ecosystem";
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+const HOUSTON_FILTER = "%houston%";
+
+export interface ZipRent {
+  zip: string;
+  weekly: number; // per-ZIP median weekly booth rent, rounded
+}
+
+export interface HoustonBoothRentStats {
+  avgWeeklyRent: number; // rounded mean of every parseable weekly booth rent
+  lowBandRent: number; // lowest per-ZIP median (falls back to overall min)
+  highBandRent: number; // highest per-ZIP median (falls back to overall max)
+  sampleSize: number; // shops + salons reporting a parseable booth rent
+  swingMultiple: string; // highBand / lowBand, 1 decimal — e.g. "2.4"
+  cheapestZips: ZipRent[]; // up to 5 lowest-median ZIPs (empty if too few qualify)
+  priciestZips: ZipRent[]; // up to 3 highest-median ZIPs (empty if too few qualify)
+}
+
+// Last known-good tracked figures. Used only if the live query is unreachable
+// or returns too few data points to trust, so the article always renders.
+export const HOUSTON_BOOTH_RENT_FALLBACK: HoustonBoothRentStats = {
+  avgWeeklyRent: 197,
+  lowBandRent: 125,
+  highBandRent: 300,
+  sampleSize: 25,
+  swingMultiple: "2.4",
+  cheapestZips: [
+    { zip: "77071", weekly: 125 },
+    { zip: "77077", weekly: 135 },
+    { zip: "77025", weekly: 140 },
+    { zip: "77338", weekly: 145 },
+    { zip: "77067", weekly: 150 },
+  ],
+  priciestZips: [
+    { zip: "77449", weekly: 260 },
+    { zip: "77002", weekly: 280 },
+    { zip: "77079", weekly: 300 },
+  ],
+};
+
+// Pulls only the shop + salon rent_rate columns for Houston and derives the
+// booth-rent stats the "Opening Your Own Shop in Texas" profit section cites.
+// Mirrors the parseWeeklyRent / median / extractZip pipeline already used by
+// app/texas/houston/data.ts so numbers stay consistent across the site.
+export async function getHoustonBoothRentStats(): Promise<HoustonBoothRentStats> {
+  try {
+    const supabase = createClient(supabaseUrl, supabaseKey);
+    const [shops, salons] = await Promise.all([
+      fetchAllRows(supabase, "agent_barbershop_leads", "city, rent_rate", (q) => q.ilike("city", HOUSTON_FILTER)),
+      fetchAllRows(supabase, "agent_salon_leads", "city, formatted_address, rent_rate", (q) => q.ilike("city", HOUSTON_FILTER)),
+    ]);
+
+    const allRents: number[] = [];
+    const rentsByZip = new Map<string, number[]>();
+    const add = (zipSource: string | null, rentRate: string | null) => {
+      const rent = parseWeeklyRent(rentRate);
+      if (rent == null) return;
+      allRents.push(rent);
+      const z = extractZip(zipSource);
+      if (z) {
+        if (!rentsByZip.has(z)) rentsByZip.set(z, []);
+        rentsByZip.get(z)!.push(rent);
+      }
+    };
+    for (const s of shops as any[]) add(s.city, s.rent_rate);
+    for (const s of salons as any[]) add(s.formatted_address || s.city, s.rent_rate);
+
+    // Too thin to publish as "tracked data" — fall back to last known-good.
+    if (allRents.length < 5) return HOUSTON_BOOTH_RENT_FALLBACK;
+
+    const avgWeeklyRent = Math.round(allRents.reduce((a, b) => a + b, 0) / allRents.length);
+
+    // Per-ZIP medians (only ZIPs with >=2 points) give stable neighborhood
+    // bands; fall back to overall min/max if too few ZIPs qualify.
+    const zipPairs: ZipRent[] = Array.from(rentsByZip.entries())
+      .filter(([, arr]) => arr.length >= 2)
+      .map(([zip, arr]) => ({ zip, weekly: Math.round(median(arr) as number) }))
+      .filter((p) => Number.isFinite(p.weekly))
+      .sort((a, b) => a.weekly - b.weekly);
+
+    const zipMedians = zipPairs.map((p) => p.weekly);
+    const lowBandRent = zipMedians.length >= 2 ? zipMedians[0] : Math.round(Math.min(...allRents));
+    const highBandRent = zipMedians.length >= 2 ? zipMedians[zipMedians.length - 1] : Math.round(Math.max(...allRents));
+
+    const swingMultiple = lowBandRent > 0 ? (highBandRent / lowBandRent).toFixed(1) : HOUSTON_BOOTH_RENT_FALLBACK.swingMultiple;
+
+    // Break out cheapest/priciest neighborhood ZIPs only when enough ZIPs
+    // qualify to split without overlap; otherwise leave empty and the article
+    // shows the band numbers without a specific ZIP list.
+    let cheapestZips: ZipRent[] = [];
+    let priciestZips: ZipRent[] = [];
+    if (zipPairs.length >= 4) {
+      const nCheap = Math.min(5, Math.floor(zipPairs.length / 2));
+      const nPrice = Math.min(3, zipPairs.length - nCheap);
+      cheapestZips = zipPairs.slice(0, nCheap);
+      priciestZips = zipPairs.slice(zipPairs.length - nPrice).reverse();
+    }
+
+    return { avgWeeklyRent, lowBandRent, highBandRent, sampleSize: allRents.length, swingMultiple, cheapestZips, priciestZips };
+  } catch {
+    return HOUSTON_BOOTH_RENT_FALLBACK;
+  }
+}


### PR DESCRIPTION
…nt, bind Houston data live

Ranks #14 with 1,155 impressions but 0 clicks — it was a TDLR-compliance page competing on a keyword whose intent is cost + profit (the #1 result is a cost/profit page). Reframed accordingly:

- Re-led title/H1/meta on "How to Open a Barbershop in Texas: Costs, Licenses & Profit"; money-forward stat signals and executive summary.
- Added a 13-line-item startup cost table (~$28k-$110k) and a new "What Does a Texas Barbershop Actually Make?" profit section.
- Grounded the profit math in our tracked Houston booth-rent data instead of generic industry figures (our defensible differentiator).
- Added a numbered "Steps to Open" roadmap + HowTo schema; page now emits TechArticle + FAQPage + HowTo. Two new profit FAQs; dateModified added.

New lib/houston-booth-rent.ts pulls only shop/salon rent_rate for Houston and derives avg/low/high bands, per-ZIP cheapest/priciest breakdown, sample size, and swing multiple — reusing the existing parseWeeklyRent/median/ extractZip pipeline so numbers match the Houston hub page. Safe fallback on any error. Page is async with daily ISR (revalidate=86400); every booth-rent figure, the income table, and the neighborhood ZIP cards bind to live data.


Claude-Session: https://claude.ai/code/session_013B3hgc6Pn9cKLXf882795M