### PR TITLE
feat(ads): target the entity bottom banner by entity page type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ public/milady_split/Milady Barber Book 6th Edition.pdf
 .env*.local
 scripts/styleseat-agent/auth.json
 scripts/xrp-whale-watch/
+
+# Local-only Search Console reporting scripts + their CSV output
+scripts/gsc_*.js
+scratchpad_reports/

--- a/app/admin/ad-campaigns/CampaignForm.tsx
+++ b/app/admin/ad-campaigns/CampaignForm.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { AD_PLACEMENTS, PLACEMENT_LABELS, SEARCH_AD_TABS } from "@/lib/ad-campaigns";
+import { AD_PLACEMENTS, PLACEMENT_LABELS, SEARCH_AD_TABS, BANNER_PAGE_TYPES } from "@/lib/ad-campaigns";
 import { EntityTypeahead } from "./EntityTypeahead";
 import { CitiesMultiSelect } from "./CitiesMultiSelect";
 
@@ -52,6 +52,7 @@ export interface CampaignInitial {
   ad_eyebrow: string | null;
   ad_headline: string | null;
   ad_cta_label: string | null;
+  banner_page_types: string[];
   status: string;
 }
 
@@ -76,6 +77,7 @@ export function CampaignForm({
 
   const initialTabs = new Set(initial?.filter_tabs || []);
   const initialStates = new Set(initial?.target_states || []);
+  const initialPageTypes = new Set(initial?.banner_page_types || []);
 
   return (
     <form action={submitAction} className="bg-white border border-slate-200 rounded-2xl shadow-sm p-6 mb-8 space-y-5">
@@ -236,9 +238,24 @@ export function CampaignForm({
         </>
       )}
 
-      {/* 5) Entity bottom banner — destination entity + compact ad copy. */}
+      {/* 5) Entity bottom banner — page-type targeting, destination entity, copy. */}
       {isEntityBanner && (
         <>
+          <div className="border-t border-slate-100 pt-5">
+            <p className="text-sm font-black text-slate-800 mb-1">Show on these entity page types</p>
+            <p className="text-[11px] text-slate-400 mb-3">Which kinds of entity pages this banner appears on. Select one or more; none = all types.</p>
+            <div className="flex flex-wrap gap-2">
+              {BANNER_PAGE_TYPES.map((pt) => (
+                <label
+                  key={pt.key}
+                  className="cursor-pointer select-none rounded-full border border-slate-300 px-3.5 py-1.5 text-sm font-bold text-slate-600 bg-white transition-colors has-[:checked]:bg-indigo-600 has-[:checked]:border-indigo-600 has-[:checked]:text-white hover:border-indigo-400"
+                >
+                  <input type="checkbox" name="banner_page_types" value={pt.key} defaultChecked={initialPageTypes.has(pt.key)} className="sr-only" />
+                  {pt.label}
+                </label>
+              ))}
+            </div>
+          </div>
           <EntityTypeahead
             heading="Link destination — the entity this banner sends visitors to"
             initialType={initial?.entity_type}

--- a/app/admin/ad-campaigns/page.tsx
+++ b/app/admin/ad-campaigns/page.tsx
@@ -43,6 +43,7 @@ async function createCampaign(formData: FormData) {
   const ad_eyebrow = String(formData.get("ad_eyebrow") || "").trim() || null;
   const ad_headline = String(formData.get("ad_headline") || "").trim() || null;
   const ad_cta_label = String(formData.get("ad_cta_label") || "").trim() || null;
+  const banner_page_types = formData.getAll("banner_page_types").map((t) => String(t));
   const isBanner = BANNER_PLACEMENTS.has(placement);
   const err = (m: string) => redirect(`/admin/ad-campaigns?error=${encodeURIComponent(m)}`);
 
@@ -96,6 +97,7 @@ async function createCampaign(formData: FormData) {
     ad_eyebrow,
     ad_headline,
     ad_cta_label,
+    banner_page_types,
     banner_image_url,
     click_url,
     status: "active",
@@ -150,6 +152,7 @@ async function updateCampaign(formData: FormData) {
   const ad_eyebrow = String(formData.get("ad_eyebrow") || "").trim() || null;
   const ad_headline = String(formData.get("ad_headline") || "").trim() || null;
   const ad_cta_label = String(formData.get("ad_cta_label") || "").trim() || null;
+  const banner_page_types = formData.getAll("banner_page_types").map((t) => String(t));
   const isBanner = BANNER_PLACEMENTS.has(placement);
 
   if (!email || !name || !placement) err("Email, campaign name, and placement are required.");
@@ -201,6 +204,7 @@ async function updateCampaign(formData: FormData) {
     ad_eyebrow,
     ad_headline,
     ad_cta_label,
+    banner_page_types,
     click_url,
     status,
     updated_at: new Date().toISOString(),
@@ -218,7 +222,7 @@ export default async function AdminAdCampaignsPage(props: { searchParams: Promis
   const admin = createAdminClient();
   const { data: campaigns } = await (admin as any)
     .from("ad_campaigns")
-    .select("id, user_id, name, placement, entity_type, creative, scope, filter_tabs, target_states, target_cities, ad_eyebrow, ad_headline, ad_cta_label, click_url, banner_image_url, status, created_at")
+    .select("id, user_id, name, placement, entity_type, creative, scope, filter_tabs, target_states, target_cities, ad_eyebrow, ad_headline, ad_cta_label, banner_page_types, click_url, banner_image_url, status, created_at")
     .order("created_at", { ascending: false });
 
   const userIds = [...new Set((campaigns || []).map((c: any) => c.user_id))];
@@ -256,6 +260,7 @@ export default async function AdminAdCampaignsPage(props: { searchParams: Promis
         ad_eyebrow: c.ad_eyebrow ?? null,
         ad_headline: c.ad_headline ?? null,
         ad_cta_label: c.ad_cta_label ?? null,
+        banner_page_types: c.banner_page_types || [],
         click_url: c.click_url,
         banner_image_url: c.banner_image_url,
         status: c.status,

--- a/lib/ad-campaigns.ts
+++ b/lib/ad-campaigns.ts
@@ -50,6 +50,18 @@ export function entityHref(entityType: string | null, slug: string | null): stri
   return t && slug ? `${t.route}/${slug}` : null;
 }
 
+// Entity PAGE types the entity_bottom_banner can be shown on (route key → label).
+// Empty selection = every type. These keys match the route segment parsed from
+// the pathname in getEntityBottomBannerAd (schools/stores each cover two tables).
+export const BANNER_PAGE_TYPES: { key: string; label: string }[] = [
+  { key: "shop", label: "Barbershops" },
+  { key: "salons", label: "Salons" },
+  { key: "barbers", label: "Barbers" },
+  { key: "cosmetologists", label: "Cosmetologists" },
+  { key: "schools", label: "Schools" },
+  { key: "stores", label: "Supply Stores" },
+];
+
 // Search filter tabs an ad can be targeted to (the entity-result tabs; the
 // non-entity tabs like AI Mode / Articles / Videos aren't ad-eligible).
 export const SEARCH_AD_TABS = [
@@ -77,6 +89,7 @@ export interface AdCampaign {
   ad_eyebrow?: string | null;
   ad_headline?: string | null;
   ad_cta_label?: string | null;
+  banner_page_types?: string[];
   status: string;
   start_date: string | null;
   end_date: string | null;

--- a/lib/profile-ad.ts
+++ b/lib/profile-ad.ts
@@ -147,14 +147,20 @@ export async function getEntityBottomBannerAd(pathname: string): Promise<EntityB
     const admin = createAdminClient();
     const { data: camps } = await (admin as any)
       .from("ad_campaigns")
-      .select("entity_type, creative, target_states, target_cities, ad_eyebrow, ad_headline, ad_cta_label, created_at")
+      .select("entity_type, creative, target_states, target_cities, banner_page_types, ad_eyebrow, ad_headline, ad_cta_label, created_at")
       .eq("placement", "entity_bottom_banner")
       .eq("status", "active")
       .order("created_at", { ascending: false });
     if (!camps || !camps.length) return null;
 
     const ctx = await viewedEntityGeo(admin, route, slug);
-    const match = (camps as any[]).find((c) => c.entity_type && c.creative && geoMatches(c, ctx));
+    const match = (camps as any[]).find(
+      (c) =>
+        c.entity_type &&
+        c.creative &&
+        (!c.banner_page_types?.length || c.banner_page_types.includes(route)) &&
+        geoMatches(c, ctx)
+    );
     if (!match) return null;
 
     const href = entityHref(match.entity_type, match.creative);

--- a/supabase/migrations/20260726220000_add_banner_page_types.sql
+++ b/supabase/migrations/20260726220000_add_banner_page_types.sql
@@ -1,0 +1,6 @@
+-- Which entity PAGE types the entity_bottom_banner shows on (route keys:
+-- shop | salons | barbers | cosmetologists | schools | stores). Empty = every
+-- entity page type. Distinct from `entity_type`, which is the banner's DESTINATION
+-- entity — this controls where it appears, not what it links to.
+ALTER TABLE public.ad_campaigns
+  ADD COLUMN IF NOT EXISTS banner_page_types text[] NOT NULL DEFAULT '{}';


### PR DESCRIPTION
Add banner_page_types[] to ad_campaigns (migration) so an entity_bottom_banner campaign can restrict which entity page types it shows on (shop / salons / barbers / cosmetologists / schools / stores). Empty = all types. Distinct from entity_type (the banner's destination). getEntityBottomBannerAd filters by the current route; the campaign form adds a page-type multiselect and persists it.

Also: gitignore the local-only GSC reporting scripts (scripts/gsc_*.js) and their CSV output (scratchpad_reports/).