### PR TITLE
feat(ads): split bottom-banner page-type picker into all 8 entity types

### DIFF
--- a/lib/ad-campaigns.ts
+++ b/lib/ad-campaigns.ts
@@ -50,16 +50,20 @@ export function entityHref(entityType: string | null, slug: string | null): stri
   return t && slug ? `${t.route}/${slug}` : null;
 }
 
-// Entity PAGE types the entity_bottom_banner can be shown on (route key → label).
-// Empty selection = every type. These keys match the route segment parsed from
-// the pathname in getEntityBottomBannerAd (schools/stores each cover two tables).
+// Entity PAGE types the entity_bottom_banner can be shown on. Empty selection =
+// every type. Keys are the specific entity types (barber schools vs cosmetology
+// schools, barber supply vs beauty supply are distinguished) — even though they
+// share a URL route (/schools, /stores). getEntityBottomBannerAd resolves the
+// viewed page's specific type by which table the slug lives in, then matches it.
 export const BANNER_PAGE_TYPES: { key: string; label: string }[] = [
   { key: "shop", label: "Barbershops" },
-  { key: "salons", label: "Salons" },
-  { key: "barbers", label: "Barbers" },
-  { key: "cosmetologists", label: "Cosmetologists" },
-  { key: "schools", label: "Schools" },
-  { key: "stores", label: "Supply Stores" },
+  { key: "salon", label: "Salons" },
+  { key: "barber", label: "Barbers" },
+  { key: "cosmetologist", label: "Cosmetologists" },
+  { key: "barber_school", label: "Barber Schools" },
+  { key: "cosmetology_school", label: "Cosmetology Schools" },
+  { key: "barber_supply_store", label: "Barber Supply Stores" },
+  { key: "beauty_supply_store", label: "Beauty Supply Stores" },
 ];
 
 // Search filter tabs an ad can be targeted to (the entity-result tabs; the

--- a/lib/profile-ad.ts
+++ b/lib/profile-ad.ts
@@ -112,25 +112,33 @@ export interface EntityBottomBannerAd {
   creative: string; // for ad tracking
 }
 
-// Which table(s) back each entity route, for looking up the VIEWED entity's
-// location (to geo-match a campaign). Schools/stores share a route across two
-// tables. Events are intentionally excluded — the banner runs on business
-// profiles, matching ScrollCTA's own page filter.
-const BANNER_ROUTE_TABLES: Record<string, string[]> = {
-  shop: ["agent_barbershop_leads"],
-  salons: ["agent_salon_leads"],
-  schools: ["agent_barber_school_leads", "agent_cosmetology_school_leads"],
-  stores: ["agent_barber_supply_store_leads", "agent_beauty_supply_store_leads"],
-  barbers: ["agent_barber_leads"],
-  cosmetologists: ["agent_cosmetologist_leads"],
+// Each entity route → the candidate table(s) with their SPECIFIC entity-type key.
+// /schools and /stores each map to two types (barber vs cosmetology school,
+// barber vs beauty supply), distinguished by which table the slug is in — that's
+// what lets a banner target, say, only Cosmetology Schools. Events are excluded —
+// the banner runs on business profiles, matching ScrollCTA's own page filter.
+const BANNER_ROUTE_RESOLVE: Record<string, { table: string; type: string }[]> = {
+  shop: [{ table: "agent_barbershop_leads", type: "shop" }],
+  salons: [{ table: "agent_salon_leads", type: "salon" }],
+  barbers: [{ table: "agent_barber_leads", type: "barber" }],
+  cosmetologists: [{ table: "agent_cosmetologist_leads", type: "cosmetologist" }],
+  schools: [
+    { table: "agent_barber_school_leads", type: "barber_school" },
+    { table: "agent_cosmetology_school_leads", type: "cosmetology_school" },
+  ],
+  stores: [
+    { table: "agent_barber_supply_store_leads", type: "barber_supply_store" },
+    { table: "agent_beauty_supply_store_leads", type: "beauty_supply_store" },
+  ],
 };
 
-async function viewedEntityGeo(admin: any, route: string, slug: string): Promise<AdViewerContext> {
-  for (const table of BANNER_ROUTE_TABLES[route] || []) {
+// Resolve the viewed entity's specific type + location from route + slug.
+async function resolveViewedEntity(admin: any, route: string, slug: string): Promise<{ type: string; ctx: AdViewerContext } | null> {
+  for (const { table, type } of BANNER_ROUTE_RESOLVE[route] || []) {
     const { data } = await admin.from(table).select("*").eq("slug", slug).maybeSingle();
-    if (data) return { city: data.city || data.metro_area || null, address: data.formatted_address || data.address || null };
+    if (data) return { type, ctx: { city: data.city || data.metro_area || null, address: data.formatted_address || data.address || null } };
   }
-  return {};
+  return null;
 }
 
 // Serves the dismissible bottom-banner ad for an entity page. Resolves the
@@ -153,13 +161,14 @@ export async function getEntityBottomBannerAd(pathname: string): Promise<EntityB
       .order("created_at", { ascending: false });
     if (!camps || !camps.length) return null;
 
-    const ctx = await viewedEntityGeo(admin, route, slug);
+    const viewed = await resolveViewedEntity(admin, route, slug);
+    if (!viewed) return null;
     const match = (camps as any[]).find(
       (c) =>
         c.entity_type &&
         c.creative &&
-        (!c.banner_page_types?.length || c.banner_page_types.includes(route)) &&
-        geoMatches(c, ctx)
+        (!c.banner_page_types?.length || c.banner_page_types.includes(viewed.type)) &&
+        geoMatches(c, viewed.ctx)
     );
     if (!match) return null;
 


### PR DESCRIPTION
The page-type targeting lumped both school types under "Schools" and both store types under "Supply Stores". Split BANNER_PAGE_TYPES into the specific types (Barber Schools / Cosmetology Schools, Barber Supply / Beauty Supply Stores). Since /schools and /stores routes don't reveal the subtype, serving now resolves the viewed entity's specific type by which table its slug lives in, and matches banner_page_types against that. No data migration — feature not yet in use.