### PR TITLE
feat(claim,profiles): link community claims to entities + entity-page…

### DIFF
--- a/app/api/community/register/route.ts
+++ b/app/api/community/register/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { createAdminClient } from "@/lib/supabase/admin";
+import { claimTypeConfig } from "@/lib/entity-claim";
 
 // Deliberately much simpler than /api/barber/register — community members
 // get a search-visible directory profile, not a business dashboard, so
@@ -7,7 +8,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 export async function POST(req: Request) {
   try {
     const body = await req.json();
-    const { firstName, lastName, email, phone, password } = body;
+    const { firstName, lastName, email, phone, password, claimEntityType, claimEntityId } = body;
 
     if (!firstName || !lastName || !email || !phone || !password) {
       return NextResponse.json(
@@ -55,9 +56,82 @@ export async function POST(req: Request) {
       throw memberError;
     }
 
+    // If they arrived from a "Claim your profile" CTA, link the entity now.
+    // isEntityClaimed() reads community_member_entity_links, so writing this
+    // row is what actually turns on the green "Claimed" badge. Without it the
+    // claim CTA was a dead end — sign up, get nothing, badge never appears.
+    let claimLinked = false;
+    let claimRedirect: string | null = null;
+    if (claimEntityType && claimEntityId) {
+      // Validate against the canonical list rather than trusting the client —
+      // these values come straight off a query string.
+      const config = claimTypeConfig(String(claimEntityType));
+      if (!config) {
+        console.warn(`[CommunityRegister] Unknown claim entity type: ${claimEntityType}`);
+      } else {
+        // Confirm the entity actually exists before linking a member to it.
+        const { data: entity } = await (adminSupabase as any)
+          .from(config.table)
+          .select("id, slug")
+          .eq("id", claimEntityId)
+          .maybeSingle();
+
+        if (!entity) {
+          console.warn(`[CommunityRegister] Claim target not found: ${claimEntityType}/${claimEntityId}`);
+        } else {
+          // Look up the member row we just created to get its own id.
+          const { data: member } = await (adminSupabase as any)
+            .from("community_members")
+            .select("id")
+            .eq("user_id", authUser.id)
+            .maybeSingle();
+
+          if (member) {
+            const { error: linkError } = await (adminSupabase as any)
+              .from("community_member_entity_links")
+              .insert({
+                community_member_id: member.id,
+                entity_type: config.key,
+                entity_id: claimEntityId,
+              });
+
+            if (linkError) {
+              // A failed link must not fail the signup — they still have a
+              // valid membership, and an admin can link them via
+              // /admin/community-entity-links.
+              console.error("[CommunityRegister] Entity link failed:", linkError);
+            } else {
+              claimLinked = true;
+              // shop/salon also carry a claimed_at column that the rest of the
+              // app reads; keep it in sync (see CLAIMED_AT_TYPES).
+              if (config.key === "shop" || config.key === "salon") {
+                await (adminSupabase as any)
+                  .from(config.table)
+                  .update({ claimed_at: new Date().toISOString() })
+                  .eq("id", claimEntityId);
+              }
+              if (entity.slug) {
+                const routes: Record<string, string> = {
+                  shop: "/shop", salon: "/salons", barber: "/barbers",
+                  cosmetologist: "/cosmetologists", barber_school: "/schools",
+                  cosmetology_school: "/schools", barber_supply_store: "/stores",
+                  beauty_supply_store: "/stores", event: "/events",
+                };
+                const base = routes[config.key];
+                if (base) claimRedirect = `${base}/${entity.slug}?claimed=1`;
+              }
+            }
+          }
+        }
+      }
+    }
+
     return NextResponse.json({
       success: true,
-      redirect: "/tools/barbershop-search?welcome=1",
+      claimLinked,
+      // Send a claimer back to the profile they just claimed so they see the
+      // badge immediately, rather than dumping them in generic search.
+      redirect: claimRedirect || "/tools/barbershop-search?welcome=1",
     });
   } catch (error: any) {
     console.error("[CommunityRegister] Error:", error);

--- a/app/barbers/[slug]/page.tsx
+++ b/app/barbers/[slug]/page.tsx
@@ -4,7 +4,6 @@ import type { Metadata } from "next";
 import { BackToSearchLink } from "@/components/shared/back-to-search-link";
 import { DynamicBackButton } from "@/components/shared/dynamic-back-button";
 import { Navbar } from "@/components/layout/navbar";
-import { CreatePassportButton } from "@/components/shared/create-passport-button";
 import { EntityPhotoGallery } from "@/components/shared/entity-photo-gallery";
 import { NearbyEntitiesSection } from "@/components/shared/nearby-entities-section";
 import { SearchVisibilityCard } from "@/components/shared/search-visibility-card";
@@ -20,7 +19,6 @@ import {
   CheckCircle2,
   GraduationCap,
   Scissors,
-  ExternalLink,
   Instagram,
   Youtube,
   Globe,
@@ -29,6 +27,8 @@ import {
   Clock,
   Navigation,
   Landmark,
+  CalendarCheck,
+  Phone,
 } from "lucide-react";
 
 export const revalidate = 3600;
@@ -360,6 +360,61 @@ export default async function BarberProfilePage(props: { params: Promise<{ slug:
                 </div>
               )}
 
+              {/* Primary CTA row — the actions a visitor came here to take,
+                  above the fold instead of buried in the sidebar. Booking is
+                  the money action so it gets the filled button; the rest are
+                  equal-weight secondaries. Each is conditional: profile_url and
+                  phone are 100% populated on this table, website_url is on 2 of
+                  1,429 rows, so the Website button almost never renders. */}
+              <div className="flex flex-wrap items-stretch gap-2 mt-5 pt-5 border-t border-slate-100">
+                {barber.profile_url && (
+                  <a
+                    href={barber.profile_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-ig-click="outbound_lead"
+                    className="flex-1 min-w-[150px] inline-flex items-center justify-center gap-2 px-5 py-3 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white font-extrabold text-sm uppercase tracking-wider transition-colors shadow-md shadow-indigo-600/20"
+                  >
+                    <CalendarCheck className="w-4 h-4" />
+                    Book Now
+                  </a>
+                )}
+                {barber.phone && (
+                  <a
+                    href={`tel:${String(barber.phone).replace(/[^\d+]/g, "")}`}
+                    data-ig-click="outbound_lead"
+                    className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-2 px-4 py-3 rounded-xl border border-slate-200 bg-white hover:border-indigo-200 hover:bg-indigo-50 text-slate-700 hover:text-indigo-700 font-bold text-sm transition-colors"
+                  >
+                    <Phone className="w-4 h-4" />
+                    Call
+                  </a>
+                )}
+                {barber.website_url && (
+                  <a
+                    href={barber.website_url.startsWith("http") ? barber.website_url : `https://${barber.website_url}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-ig-click="outbound_lead"
+                    className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-2 px-4 py-3 rounded-xl border border-slate-200 bg-white hover:border-indigo-200 hover:bg-indigo-50 text-slate-700 hover:text-indigo-700 font-bold text-sm transition-colors"
+                  >
+                    <Globe className="w-4 h-4" />
+                    Website
+                  </a>
+                )}
+                {directionsHref && (
+                  <a
+                    href={directionsHref}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-ig-click="outbound_lead"
+                    className="flex-1 min-w-[140px] inline-flex items-center justify-center gap-2 px-4 py-3 rounded-xl border border-slate-200 bg-white hover:border-indigo-200 hover:bg-indigo-50 text-slate-700 hover:text-indigo-700 font-bold text-sm transition-colors"
+                  >
+                    <Navigation className="w-4 h-4" />
+                    Directions
+                  </a>
+                )}
+              </div>
+
               {socialLinks.length > 0 && (
                 <div className="flex items-center gap-2 mt-4 pt-4 border-t border-slate-100">
                   {socialLinks.map(({ label, href, Icon }) => (
@@ -419,6 +474,42 @@ export default async function BarberProfilePage(props: { params: Promise<{ slug:
               )}
             </div>
 
+            {/* Business Hours — directly after Services, where someone who
+                just picked a service asks "are they open?". Was in the sidebar
+                below Nearby Shops, effectively last on mobile. */}
+            {hours.length > 0 && hours.some((h) => h.ranges.length > 0) && (
+              <div className="bg-white border border-slate-200 rounded-2xl shadow-sm px-6 py-5">
+                <h2 className="text-lg font-black text-slate-900 mb-4 flex items-center gap-2">
+                  <Clock className="w-4 h-4 text-slate-400" />
+                  Business Hours
+                </h2>
+                <ul className="space-y-2">
+                  {hours.map((h, i) => (
+                    <li
+                      key={h.day}
+                      className={`flex items-start justify-between gap-3 text-sm ${
+                        i === TODAY_INDEX
+                          ? "text-slate-900 font-black"
+                          : "text-slate-500 font-medium"
+                      }`}
+                    >
+                      <span className="flex items-center gap-2">
+                        {h.day}
+                        {i === TODAY_INDEX && (
+                          <span className="text-[10px] font-black uppercase tracking-wider text-indigo-600 bg-indigo-50 border border-indigo-100 rounded px-1.5 py-0.5">
+                            Today
+                          </span>
+                        )}
+                      </span>
+                      <span className="text-right">
+                        {h.ranges.length > 0 ? h.ranges.join(", ") : "Closed"}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
             {/* Credentials */}
             {(barber.school_name || barber.licensure_status || barber.completed_school_hours) && (
               <div className="bg-white border border-slate-200 rounded-2xl shadow-sm px-6 py-5">
@@ -447,75 +538,19 @@ export default async function BarberProfilePage(props: { params: Promise<{ slug:
           <div className="space-y-4">
             <SearchVisibilityCard searchPerformance={searchPerformance} isClaimed={isClaimed} entityLabel="barber" />
 
-            {barber.profile_url && (
-              <div className="bg-white border border-slate-200 rounded-2xl shadow-sm p-5">
-                <a
-                  href={barber.profile_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  data-ig-click="outbound_lead"
-                  className="w-full inline-flex items-center justify-center gap-2 px-5 py-3 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white font-extrabold text-sm uppercase tracking-wider transition-colors shadow-md shadow-indigo-600/20"
-                >
-                  Book on Booksy
-                  <ExternalLink className="w-4 h-4" />
-                </a>
-              </div>
-            )}
-
-            <div className="bg-white border border-slate-200 rounded-2xl shadow-sm p-5">
-              <p className="text-xs font-bold text-slate-400 uppercase tracking-widest mb-3 text-center">
-                Is this you?
-              </p>
-              <CreatePassportButton
-                label="Create Your Career Passport"
-                subtext="Get discovered by shops looking to hire"
-                className="w-full inline-flex flex-col items-center justify-center gap-1 px-5 py-3 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white transition-colors shadow-md shadow-indigo-600/20"
-              />
-            </div>
-
+            {/* Book / Call / Website / Directions all moved into the header
+                block above. The passport CTA is removed from this page per
+                product direction — it belongs on recruiting surfaces, not on a
+                consumer-facing profile where it competed with booking. */}
             {directionsHref && (
               <div className="bg-white border border-slate-200 rounded-2xl shadow-sm p-5">
                 <h3 className="text-xs font-black text-slate-900 uppercase tracking-wider mb-3">Location</h3>
-                <p className="text-sm text-slate-600 font-medium mb-3">{barber.address || barber.metro_area}</p>
-                <a
-                  href={directionsHref}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  data-ig-click="outbound_lead"
-                  className="inline-flex items-center gap-1.5 text-sm font-bold text-indigo-600 hover:underline"
-                >
-                  <Navigation className="w-4 h-4" />
-                  Get Directions
-                </a>
+                <p className="text-sm text-slate-600 font-medium">{barber.address || barber.metro_area}</p>
               </div>
             )}
 
             <NearbyEntitiesSection title="Nearby Shops" icon={Scissors} entities={nearbyShops} />
             <NearbyEntitiesSection title="Nearby Barber Schools" icon={GraduationCap} entities={nearbySchools} />
-
-            {hours.length > 0 && hours.some((h) => h.ranges.length > 0) && (
-              <div className="bg-white border border-slate-200 rounded-2xl shadow-sm p-5">
-                <h3 className="text-xs font-black text-slate-900 uppercase tracking-wider mb-3 flex items-center gap-1.5">
-                  <Clock className="w-3.5 h-3.5" />
-                  Business Hours
-                </h3>
-                <ul className="space-y-1.5">
-                  {hours.map((h, i) => (
-                    <li
-                      key={h.day}
-                      className={`flex items-start justify-between gap-3 text-xs font-medium ${
-                        i === TODAY_INDEX ? "text-slate-900 font-bold" : "text-slate-500"
-                      }`}
-                    >
-                      <span>{h.day}</span>
-                      <span className="text-right">
-                        {h.ranges.length > 0 ? h.ranges.join(", ") : "Closed"}
-                      </span>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            )}
           </div>
         </div>
 

--- a/app/cosmetologists/[slug]/page.tsx
+++ b/app/cosmetologists/[slug]/page.tsx
@@ -4,7 +4,6 @@ import type { Metadata } from "next";
 import { BackToSearchLink } from "@/components/shared/back-to-search-link";
 import { DynamicBackButton } from "@/components/shared/dynamic-back-button";
 import { Navbar } from "@/components/layout/navbar";
-import { CreatePassportButton } from "@/components/shared/create-passport-button";
 import { EntityPhotoGallery } from "@/components/shared/entity-photo-gallery";
 import { NearbyEntitiesSection } from "@/components/shared/nearby-entities-section";
 import { fetchNearbyEntities } from "@/lib/nearby-entities";
@@ -16,7 +15,6 @@ import {
   MapPin,
   Star,
   Sparkles,
-  ExternalLink,
   Instagram,
   Youtube,
   Globe,
@@ -26,6 +24,9 @@ import {
   Landmark,
   GraduationCap,
   CheckCircle2,
+  CalendarCheck,
+  Phone,
+  Clock,
 } from "lucide-react";
 import { ClaimShopButton } from "@/components/shared/claim-shop-button";
 import { isEntityClaimed } from "@/lib/entity-claim";
@@ -39,6 +40,10 @@ const supabase = createClient(supabaseUrl, supabaseKey);
 const PUBLIC_COLUMNS = COSMETOLOGIST_PUBLIC_COLUMNS.join(", ");
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+// 0 = Monday, matching the day order Booksy returns. Same definition as
+// app/barbers/[slug]/page.tsx.
+const TODAY_INDEX = (new Date().getDay() + 6) % 7;
 
 async function getCosmetologist(param: string) {
   const { data: bySlug, error: slugErr } = await supabase
@@ -167,6 +172,12 @@ export default async function CosmetologistProfilePage(props: { params: Promise<
   const services: { name: string; price: number; duration?: string }[] = Array.isArray(person.booksy_services)
     ? person.booksy_services
     : [];
+  // booksy_hours is currently populated on 0 of 122 cosmetologist rows — the
+  // StyleSeat scrape doesn't capture it the way the Booksy barber scrape does.
+  // Wired anyway so the section appears the moment that changes, and renders
+  // nothing until then rather than an empty card.
+  const hours: { day: string; ranges: string[] }[] = Array.isArray(person.booksy_hours) ? person.booksy_hours : [];
+
   const specialties: string[] = (person.desired_specialties || "")
     .split(",")
     .map((s: string) => s.trim())
@@ -309,6 +320,60 @@ export default async function CosmetologistProfilePage(props: { params: Promise<
                 </div>
               )}
 
+              {/* Primary CTA row — mirrors app/barbers/[slug]. Booking is the
+                  money action so it gets the filled button. Each is conditional:
+                  profile_url and phone are 100% populated on this table,
+                  website_url is populated on 0 of 122 rows, so the Website
+                  button renders for nobody today but is wired for when it is. */}
+              <div className="flex flex-wrap items-stretch gap-2 mt-5 pt-5 border-t border-slate-100">
+                {person.profile_url && (
+                  <a
+                    href={person.profile_url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-ig-click="outbound_lead"
+                    className="flex-1 min-w-[150px] inline-flex items-center justify-center gap-2 px-5 py-3 rounded-xl bg-fuchsia-600 hover:bg-fuchsia-700 text-white font-extrabold text-sm uppercase tracking-wider transition-colors shadow-md shadow-fuchsia-600/20"
+                  >
+                    <CalendarCheck className="w-4 h-4" />
+                    Book Now
+                  </a>
+                )}
+                {person.phone && (
+                  <a
+                    href={`tel:${String(person.phone).replace(/[^\d+]/g, "")}`}
+                    data-ig-click="outbound_lead"
+                    className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-2 px-4 py-3 rounded-xl border border-slate-200 bg-white hover:border-fuchsia-200 hover:bg-fuchsia-50 text-slate-700 hover:text-fuchsia-700 font-bold text-sm transition-colors"
+                  >
+                    <Phone className="w-4 h-4" />
+                    Call
+                  </a>
+                )}
+                {person.website_url && (
+                  <a
+                    href={person.website_url.startsWith("http") ? person.website_url : `https://${person.website_url}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-ig-click="outbound_lead"
+                    className="flex-1 min-w-[110px] inline-flex items-center justify-center gap-2 px-4 py-3 rounded-xl border border-slate-200 bg-white hover:border-fuchsia-200 hover:bg-fuchsia-50 text-slate-700 hover:text-fuchsia-700 font-bold text-sm transition-colors"
+                  >
+                    <Globe className="w-4 h-4" />
+                    Website
+                  </a>
+                )}
+                {directionsHref && (
+                  <a
+                    href={directionsHref}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-ig-click="outbound_lead"
+                    className="flex-1 min-w-[140px] inline-flex items-center justify-center gap-2 px-4 py-3 rounded-xl border border-slate-200 bg-white hover:border-fuchsia-200 hover:bg-fuchsia-50 text-slate-700 hover:text-fuchsia-700 font-bold text-sm transition-colors"
+                  >
+                    <Navigation className="w-4 h-4" />
+                    Directions
+                  </a>
+                )}
+              </div>
+
               {socialLinks.length > 0 && (
                 <div className="flex items-center gap-2 mt-4 pt-4 border-t border-slate-100">
                   {socialLinks.map(({ label, href, Icon }) => (
@@ -370,52 +435,52 @@ export default async function CosmetologistProfilePage(props: { params: Promise<
                 </p>
               )}
             </div>
+
+            {/* Business Hours — directly after Services, matching
+                app/barbers/[slug]. Renders only when real hours exist. */}
+            {hours.length > 0 && hours.some((h) => h.ranges.length > 0) && (
+              <div className="bg-white border border-slate-200 rounded-2xl shadow-sm px-6 py-5">
+                <h2 className="text-lg font-black text-slate-900 mb-4 flex items-center gap-2">
+                  <Clock className="w-4 h-4 text-slate-400" />
+                  Business Hours
+                </h2>
+                <ul className="space-y-2">
+                  {hours.map((h, i) => (
+                    <li
+                      key={h.day}
+                      className={`flex items-start justify-between gap-3 text-sm ${
+                        i === TODAY_INDEX ? "text-slate-900 font-black" : "text-slate-500 font-medium"
+                      }`}
+                    >
+                      <span className="flex items-center gap-2">
+                        {h.day}
+                        {i === TODAY_INDEX && (
+                          <span className="text-[10px] font-black uppercase tracking-wider text-fuchsia-600 bg-fuchsia-50 border border-fuchsia-100 rounded px-1.5 py-0.5">
+                            Today
+                          </span>
+                        )}
+                      </span>
+                      <span className="text-right">
+                        {h.ranges.length > 0 ? h.ranges.join(", ") : "Closed"}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
           </div>
 
           {/* Sidebar */}
           <div className="space-y-4">
             <SearchVisibilityCard searchPerformance={searchPerformance} isClaimed={isClaimed} entityLabel="cosmetologist" />
 
-            {person.profile_url && (
-              <div className="bg-white border border-slate-200 rounded-2xl shadow-sm p-5">
-                <a
-                  href={person.profile_url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  data-ig-click="outbound_lead"
-                  className="w-full inline-flex items-center justify-center gap-2 px-5 py-3 rounded-xl bg-fuchsia-600 hover:bg-fuchsia-700 text-white font-extrabold text-sm uppercase tracking-wider transition-colors shadow-md shadow-fuchsia-600/20"
-                >
-                  Book on StyleSeat
-                  <ExternalLink className="w-4 h-4" />
-                </a>
-              </div>
-            )}
-
-            <div className="bg-white border border-slate-200 rounded-2xl shadow-sm p-5">
-              <p className="text-xs font-bold text-slate-400 uppercase tracking-widest mb-3 text-center">
-                Is this you?
-              </p>
-              <CreatePassportButton
-                label="Create Your Career Passport"
-                subtext="Get discovered by shops and salons looking to hire"
-                className="w-full inline-flex flex-col items-center justify-center gap-1 px-5 py-3 rounded-xl bg-fuchsia-600 hover:bg-fuchsia-700 text-white transition-colors shadow-md shadow-fuchsia-600/20"
-              />
-            </div>
-
+            {/* Book / Call / Website / Directions all moved into the header
+                block above. Passport CTA removed per product direction — it
+                belongs on recruiting surfaces, not a consumer-facing profile. */}
             {directionsHref && (
               <div className="bg-white border border-slate-200 rounded-2xl shadow-sm p-5">
                 <h3 className="text-xs font-black text-slate-900 uppercase tracking-wider mb-3">Location</h3>
-                <p className="text-sm text-slate-600 font-medium mb-3">{person.address || person.metro_area}</p>
-                <a
-                  href={directionsHref}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  data-ig-click="outbound_lead"
-                  className="inline-flex items-center gap-1.5 text-sm font-bold text-fuchsia-600 hover:underline"
-                >
-                  <Navigation className="w-4 h-4" />
-                  Get Directions
-                </a>
+                <p className="text-sm text-slate-600 font-medium">{person.address || person.metro_area}</p>
               </div>
             )}
 

--- a/app/membership/page.tsx
+++ b/app/membership/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Suspense } from "react";
 import { Sparkles, BadgeCheck, Users, CheckCircle2 } from "lucide-react";
 import { Navbar } from "@/components/layout/navbar";
 import { CommunityMembershipForm } from "@/components/forms/CommunityMembershipForm";
@@ -71,7 +72,12 @@ export default function MembershipPage() {
             <div className="lg:col-span-2 bg-white border border-slate-200 rounded-2xl shadow-sm p-6 sm:p-8">
               <h2 className="text-lg font-black text-slate-900 mb-1">Create Your Free Membership</h2>
               <p className="text-sm text-slate-500 mb-6">Takes about a minute.</p>
-              <CommunityMembershipForm />
+              {/* The form reads claim_type/claim_id from the query string
+                  (handed over by ClaimShopButton), so useSearchParams needs a
+                  Suspense boundary or this page can't be statically rendered. */}
+              <Suspense fallback={<div className="h-64 animate-pulse rounded-xl bg-slate-100" />}>
+                <CommunityMembershipForm />
+              </Suspense>
             </div>
           </div>
         </div>

--- a/components/forms/CommunityMembershipForm.tsx
+++ b/components/forms/CommunityMembershipForm.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import { useState } from "react"
-import { ArrowRight, Loader2 } from "lucide-react"
+import { useSearchParams } from "next/navigation"
+import { ArrowRight, Loader2, ShieldCheck } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { createBrowserClient } from "@/lib/supabase/browser"
 import { toast } from "sonner"
@@ -12,6 +13,14 @@ import { toast } from "sonner"
 // no school/role selection, since the only benefit right now is search
 // visibility, not a business dashboard.
 export function CommunityMembershipForm() {
+  // Claim context handed over by ClaimShopButton. When present, signup also
+  // links this member to the entity so the "Claimed" badge turns on.
+  const searchParams = useSearchParams()
+  const claimEntityType = searchParams.get("claim_type")
+  const claimEntityId = searchParams.get("claim_id")
+  const claimEntityName = searchParams.get("claim_name")
+  const isClaiming = Boolean(claimEntityType && claimEntityId)
+
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [formData, setFormData] = useState({
     firstName: "",
@@ -36,7 +45,7 @@ export function CommunityMembershipForm() {
       const response = await fetch("/api/community/register", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(formData),
+        body: JSON.stringify({ ...formData, claimEntityType, claimEntityId }),
       })
 
       const data = await response.json()
@@ -46,7 +55,17 @@ export function CommunityMembershipForm() {
       }
 
       if ((window as any).innerG?.track) {
-        (window as any).innerG.track('community_membership_signup', {})
+        (window as any).innerG.track('community_membership_signup', {
+          claim_entity_type: claimEntityType || undefined,
+          claim_entity_id: claimEntityId || undefined,
+          claim_linked: !!data.claimLinked,
+        })
+      }
+
+      // Surface a silent link failure — the membership is real either way, but
+      // the user came here specifically to get the badge.
+      if (isClaiming && !data.claimLinked) {
+        toast.warning("Membership created, but we couldn't link that listing automatically. Our team will review it.")
       }
 
       const supabase = createBrowserClient()
@@ -71,6 +90,16 @@ export function CommunityMembershipForm() {
 
   return (
     <form className="space-y-4" onSubmit={handleSubmit}>
+      {isClaiming && (
+        <div className="flex items-start gap-2.5 rounded-xl border border-emerald-100 bg-emerald-50 px-4 py-3">
+          <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" />
+          <p className="text-xs font-medium leading-relaxed text-emerald-800">
+            You&apos;re claiming{" "}
+            <span className="font-black">{claimEntityName || "this listing"}</span>. Finish signing up and the
+            verified badge goes live on it right away.
+          </p>
+        </div>
+      )}
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div className="space-y-1.5">
           <label className="text-[10px] font-black uppercase tracking-widest text-slate-400 ml-1">First Name</label>

--- a/components/shared/claim-shop-button.tsx
+++ b/components/shared/claim-shop-button.tsx
@@ -25,9 +25,20 @@ export function ClaimShopButton({
   const id = entityId ?? shop?.id;
   const name = entityName ?? shop?.shop_name;
 
+  // Carry the entity through to signup. Previously this linked to a bare
+  // /membership, so the claim intent was lost the moment the user navigated —
+  // they'd register, become a member, and never get the badge, because nothing
+  // in the signup path ever wrote a community_member_entity_links row. Only an
+  // admin could create that link by hand.
+  const claimHref = id
+    ? `/membership?claim_type=${encodeURIComponent(entityType)}&claim_id=${encodeURIComponent(id)}${
+        name ? `&claim_name=${encodeURIComponent(name)}` : ""
+      }`
+    : "/membership";
+
   return (
     <Link
-      href="/membership"
+      href={claimHref}
       onClick={() => {
         if (typeof window !== "undefined" && (window as any).innerG?.track) {
           (window as any).innerG.track('claim_shop_initiated', { entity_id: id, entity_name: name, entity_type: entityType });


### PR DESCRIPTION
… CTAs & hours

- Community register (/api/community/register) now accepts claimEntityType / claimEntityId, validates against the canonical claim config, writes community_member_entity_links (what actually turns on the "Claimed" badge), syncs claimed_at for shop/salon, and redirects the claimer back to the claimed profile — the claim CTA is no longer a dead end.
- Barber & cosmetologist profile pages: added an above-the-fold CTA row (Book / Call / Website / Directions, conditional on populated fields) and a Business Hours block placed right after Services.
- Supporting tweaks to the membership page, community membership form, and the claim-shop button.


Claude-Session: https://claude.ai/code/session_013B3hgc6Pn9cKLXf882795M