### PR TITLE
feat(ads): rotate multiple campaigns through one ad position

### DIFF
--- a/app/admin/ad-campaigns/CampaignForm.tsx
+++ b/app/admin/ad-campaigns/CampaignForm.tsx
@@ -24,14 +24,17 @@ const ENTITY_PLACEMENTS = new Set([
 const BANNER_PLACEMENTS = new Set(["state_hub_banner", "city_hub_banner"]);
 
 // Per-placement helper copy so the admin knows what the ad does + what to fill.
+// Every placement holds one ad at a time but any number of campaigns: eligible
+// campaigns rotate through the slot (see lib/ad-rotation.ts), so none of these
+// are exclusive reservations.
 const PLACEMENT_HELP: Record<string, string> = {
   shop_profile: "Shows in the sponsored slot on shop profile pages, advertising the entity below (links to its profile).",
   salon_profile: "Shows in the sponsored slot on salon profile pages, advertising the entity below (links to its profile).",
   barber_supply_profile: "Shows in the sponsored slot on barber supply store pages, advertising the entity below (links to its profile).",
   beauty_supply_profile: "Shows in the sponsored slot on beauty supply store pages, advertising the entity below (links to its profile).",
-  search_results: "Shows at the top of the search results on the selected filter tabs, advertising the entity below.",
-  state_hub_banner: "Reserves the sponsorship banner on the state hub. Set the state it covers.",
-  city_hub_banner: "Reserves the sponsorship banner on a city hub. Set the city it covers.",
+  search_results: "Shows at the top of the search results on the selected filter tabs, advertising the entity below. One sponsored card shows per search — campaigns sharing a tab take turns.",
+  state_hub_banner: "Takes a turn in the sponsorship banner on the state hub. Set the state it covers.",
+  city_hub_banner: "Takes a turn in the sponsorship banner on a city hub. Set the city it covers.",
   entity_bottom_banner: "Shows as the dismissible bottom banner on entity pages in the targeted cities/states, linking to the entity below. Write short copy that fits a compact CTA.",
 };
 

--- a/app/admin/ad-campaigns/page.tsx
+++ b/app/admin/ad-campaigns/page.tsx
@@ -225,6 +225,17 @@ export default async function AdminAdCampaignsPage(props: { searchParams: Promis
     .select("id, user_id, name, placement, entity_type, creative, scope, filter_tabs, target_states, target_cities, ad_eyebrow, ad_headline, ad_cta_label, banner_page_types, click_url, banner_image_url, status, created_at")
     .order("created_at", { ascending: false });
 
+  // Active campaigns per placement. A position serves one ad per render and
+  // rotates through the rest (lib/ad-rotation.ts), so the useful thing to see
+  // while selling another slot is how crowded that slot already is. It's an
+  // upper bound on the real rotation pool — geo targeting and filter tabs can
+  // narrow which of them are eligible on any given page.
+  const activeByPlacement = new Map<string, number>();
+  for (const c of ((campaigns || []) as any[])) {
+    if (c.status !== "active") continue;
+    activeByPlacement.set(c.placement, (activeByPlacement.get(c.placement) || 0) + 1);
+  }
+
   const userIds = [...new Set((campaigns || []).map((c: any) => c.user_id))];
   const emailById = new Map<string, string>();
   if (userIds.length) {
@@ -282,6 +293,11 @@ export default async function AdminAdCampaignsPage(props: { searchParams: Promis
           that entity&apos;s profile page. For a <b>Search Results Ad</b>, pick the filter tabs it appears on (top of
           those results). The advertiser sees the matching impressions &amp; clicks under Account → Ad Performance.
         </p>
+        <p className="text-slate-500 text-sm mb-8 max-w-2xl">
+          A placement can be sold to <b>as many advertisers as you like</b>. One ad shows in the position at a time, and
+          the eligible campaigns take turns — split evenly across every 10 impressions on that position — so a visitor
+          who reloads can see a different advertiser. Pausing a campaign takes it out of the rotation immediately.
+        </p>
 
         {ok && (
           <div className="flex items-center gap-2 bg-emerald-50 border border-emerald-200 text-emerald-800 rounded-xl px-4 py-3 mb-6 text-sm font-bold">
@@ -333,7 +349,17 @@ export default async function AdminAdCampaignsPage(props: { searchParams: Promis
                       {c.name}
                       <span className={`ml-2 inline-flex items-center text-[10px] font-black uppercase tracking-wider rounded-full px-2 py-0.5 ${c.status === "active" ? "bg-emerald-50 text-emerald-700 border border-emerald-200" : "bg-amber-50 text-amber-700 border border-amber-200"}`}>{c.status}</span>
                     </td>
-                    <td className="px-4 py-3 text-slate-500">{PLACEMENT_LABELS[c.placement] || c.placement}</td>
+                    <td className="px-4 py-3 text-slate-500">
+                      {PLACEMENT_LABELS[c.placement] || c.placement}
+                      {c.status === "active" && (activeByPlacement.get(c.placement) || 0) > 1 && (
+                        <span
+                          className="block mt-1 text-[10px] font-black uppercase tracking-wider text-indigo-600"
+                          title="One ad shows at a time; eligible campaigns take turns, evenly over every 10 impressions."
+                        >
+                          Rotating · {activeByPlacement.get(c.placement)} campaigns
+                        </span>
+                      )}
+                    </td>
                     <td className="px-4 py-3 text-slate-400 text-xs">
                       {c.entity_type ? <span className="font-bold text-slate-600">{c.entity_type}</span> : "—"}
                       {c.creative && <span className="block font-mono text-[10px] text-slate-400 truncate max-w-[160px]">{c.creative}</span>}

--- a/app/tools/barbershop-search/actions.ts
+++ b/app/tools/barbershop-search/actions.ts
@@ -4,6 +4,7 @@ import { createClient } from "@supabase/supabase-js";
 import { GoogleGenAI } from "@google/genai";
 import { parseWeeklyRent } from "@/lib/shop-ecosystem";
 import { AD_ENTITY_TYPES } from "@/lib/ad-campaigns";
+import { rotateEligible } from "@/lib/ad-rotation";
 
 // rent_rate is free text ("$175/week", "40% for 5 months then $300/wk",
 // etc.) with no queryable numeric column, so a rent filter has to fetch a
@@ -830,6 +831,7 @@ export interface SponsoredSearchEntity {
   verified: boolean; // claimed (owner-verified) listing
   creative: string;
   entityType: string;
+  campaignId: string;
 }
 
 function firstImage(row: any): string | null {
@@ -880,27 +882,34 @@ async function buildSponsoredEntity(admin: any, match: any): Promise<SponsoredSe
     verified: !!row.claimed_at,
     creative: match.creative,
     entityType: match.entity_type,
+    campaignId: match.id,
   };
 }
 
-// All active search_results ads that target this tab — multiple sponsored
-// entities can show at once. Empty filter_tabs = every tab; "All" is a literal
-// tab, not a wildcard, so a campaign targeting All does not leak onto
-// Salons/Barbershops/etc. Deduped by entity so the same listing from two
-// campaigns only appears once. Newest campaigns first.
+// How many sponsored cards the top of a results tab shows at once. The slot used
+// to render EVERY matching campaign, which stops scaling the moment more than a
+// couple of advertisers share a tab (ten shops would stack ten sponsored cards
+// above the organic results). One ad shows; the rest rotate through the slot.
+const SEARCH_ADS_PER_TAB = 1;
+
+// The sponsored ad(s) at the top of a results tab. Empty filter_tabs = every
+// tab; "All" is a literal tab, not a wildcard, so a campaign targeting All does
+// not leak onto Salons/Barbershops/etc. Deduped by entity so the same listing
+// from two campaigns only appears once. Which of the eligible campaigns gets the
+// slot rotates per search — see lib/ad-rotation.ts.
 export async function getSponsoredSearchEntities(filterTab: string): Promise<SponsoredSearchEntity[]> {
   try {
     const admin = createClient(supabaseUrl, process.env.SUPABASE_SERVICE_ROLE_KEY || supabaseKey);
     const { data: camps } = await admin
       .from("ad_campaigns")
-      .select("entity_type, creative, filter_tabs, created_at")
+      .select("id, entity_type, creative, filter_tabs, created_at")
       .eq("placement", "search_results")
       .eq("status", "active")
       .order("created_at", { ascending: false });
     if (!camps || !camps.length) return [];
 
     const seen = new Set<string>();
-    const matches = (camps as any[]).filter((c) => {
+    const eligible = (camps as any[]).filter((c) => {
       if (!c.entity_type || !c.creative) return false;
       if (c.filter_tabs?.length && !c.filter_tabs.includes(filterTab)) return false;
       const key = `${c.entity_type}:${c.creative}`;
@@ -908,9 +917,16 @@ export async function getSponsoredSearchEntities(filterTab: string): Promise<Spo
       seen.add(key);
       return true;
     });
+    if (!eligible.length) return [];
 
-    const built = await Promise.all(matches.map((m) => buildSponsoredEntity(admin, m)));
-    return built.filter((e): e is SponsoredSearchEntity => e !== null);
+    // Each tab has its own eligible set, so each tab rotates on its own cursor.
+    const rotated = await rotateEligible(admin as any, "search_results", eligible);
+    // Take a couple of extra candidates so a campaign whose entity row has gone
+    // missing doesn't leave the slot empty for this search.
+    const built = await Promise.all(
+      rotated.slice(0, SEARCH_ADS_PER_TAB + 2).map((m) => buildSponsoredEntity(admin, m))
+    );
+    return built.filter((e): e is SponsoredSearchEntity => e !== null).slice(0, SEARCH_ADS_PER_TAB);
   } catch {
     return [];
   }

--- a/app/tools/barbershop-search/page.tsx
+++ b/app/tools/barbershop-search/page.tsx
@@ -922,7 +922,7 @@ function SearchContent() {
                 />
               )}
               {page === 1 && results.length > 0 && sponsoredEntities.map((sponsoredEntity) => (
-                <AdTracker key={`${sponsoredEntity.creative}-${filterTab}`} placement="search_results" adType="search_results" creative={sponsoredEntity.creative} scope={filterTab}>
+                <AdTracker key={`${sponsoredEntity.creative}-${filterTab}`} placement="search_results" adType="search_results" creative={sponsoredEntity.creative} scope={filterTab} campaignId={sponsoredEntity.campaignId}>
                   <Link
                     href={sponsoredEntity.href}
                     className="bg-amber-50/60 p-4 sm:p-5 rounded-xl border-2 border-amber-300 shadow-sm hover:shadow-md transition-all flex flex-row gap-4 sm:gap-5 relative block"

--- a/components/ads/AdSponsorshipBanner.tsx
+++ b/components/ads/AdSponsorshipBanner.tsx
@@ -16,6 +16,7 @@ interface AdSponsorshipBannerProps {
   external?: boolean; // open href in a new tab
   creativeKey?: string; // the campaign's creative, so tracked events match it
   scope?: string; // tracked scope (state/city) — must match the campaign's scope
+  campaignId?: string; // the serving campaign, for per-advertiser attribution
 }
 
 export function AdSponsorshipBanner({
@@ -27,6 +28,7 @@ export function AdSponsorshipBanner({
   external = false,
   creativeKey,
   scope,
+  campaignId,
 }: AdSponsorshipBannerProps) {
   const isState = type === "state";
   const trackedScope = scope ?? (isState ? "Texas" : cityLabel);
@@ -62,6 +64,7 @@ export function AdSponsorshipBanner({
       adType="geographic"
       creative={creativeKey || placementLabel}
       scope={trackedScope}
+      campaignId={campaignId}
     >
     <div
       className={`relative overflow-hidden rounded-2xl border border-slate-800 bg-slate-950 text-white shadow-xl transition-all duration-300 hover:shadow-2xl hover:border-amber-500/50 group ${className}`}

--- a/components/ads/AdTracker.tsx
+++ b/components/ads/AdTracker.tsx
@@ -24,11 +24,19 @@ export interface AdTrackerProps {
   creative?: string;
   /** Geographic scope of the placement, e.g. "Dallas, TX" / "Texas". */
   scope?: string;
+  /**
+   * The ad_campaigns row this serve came from. Since a position now rotates
+   * several campaigns (lib/ad-rotation.ts), placement + creative + scope no
+   * longer identifies one advertiser — the campaign id does, and it's what the
+   * advertiser-facing reports attribute on. Absent on the demo ads, which
+   * belong to no campaign.
+   */
+  campaignId?: string;
   className?: string;
   children: React.ReactNode;
 }
 
-export function AdTracker({ placement, adType, creative, scope, className, children }: AdTrackerProps) {
+export function AdTracker({ placement, adType, creative, scope, campaignId, className, children }: AdTrackerProps) {
   const ref = useRef<HTMLDivElement>(null);
   const impressionFired = useRef(false);
 
@@ -37,6 +45,7 @@ export function AdTracker({ placement, adType, creative, scope, className, child
     ad_type: adType,
     creative,
     scope,
+    campaign_id: campaignId,
     ad_page: typeof window !== "undefined" ? window.location.pathname : undefined,
   });
 

--- a/components/ads/RotatingHubBanner.tsx
+++ b/components/ads/RotatingHubBanner.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { AdSponsorshipBanner } from "@/components/ads/AdSponsorshipBanner";
+import { fetchRotatingBannerAd } from "@/components/ads/ad-rotation-actions";
+import type { BannerAd } from "@/lib/profile-ad";
+
+// The state/city hub sponsorship banner for pages that are CACHED (every hub
+// runs `revalidate = 3600`). Same shape as RotatingProfileAd: the server's peek
+// paints immediately, then this claims the load's real rotation turn.
+//
+// The banner sits near the top of a hub page, so it's a likely LCP element —
+// which is why the peek renders a real banner server-side instead of leaving the
+// slot empty until the client resolves. Two extra precautions for the same
+// reason: the replacement image is preloaded before the swap, so a rotation
+// never flashes an empty frame, and an identical pick doesn't re-render at all.
+
+export function RotatingHubBanner({
+  placement,
+  type,
+  scope,
+  cityLabel,
+  className,
+  initial,
+  suppressDemo,
+}: {
+  placement: string;
+  type: "state" | "city";
+  scope: string;
+  cityLabel?: string;
+  className?: string;
+  /** The server's peek at the pool — rendered immediately. */
+  initial: BannerAd | null;
+  /** When true and no campaign is serving, render nothing instead of the demo
+   *  banner (the demo art is Texas-branded — see SponsorshipBanner). */
+  suppressDemo: boolean;
+}) {
+  const [ad, setAd] = useState<BannerAd | null>(initial);
+  // Claiming a turn is a WRITE, so exactly once per page load: a re-invoked
+  // effect (StrictMode does this in development) would step the cursor twice,
+  // and on an even-sized pool steps of two mean half the advertisers never show.
+  const claimedFor = useRef<string | null>(null);
+
+  useEffect(() => {
+    const slot = `${placement}|${scope}`;
+    if (claimedFor.current === slot) return;
+    claimedFor.current = slot;
+
+    let ignore = false;
+    fetchRotatingBannerAd(placement, scope)
+      .then((next) => {
+        if (ignore) return;
+        if (next?.campaignId === ad?.campaignId) return; // same turn — leave the paint alone
+        if (!next) {
+          setAd(null); // pool emptied since this HTML was cached
+          return;
+        }
+        // Decode the new creative before swapping so the slot never goes blank
+        // mid-rotation. Campaign banners render with `unoptimized`, so this is
+        // the very URL <Image> will request.
+        const img = new window.Image();
+        img.onload = img.onerror = () => {
+          if (!ignore) setAd(next);
+        };
+        img.src = next.imageUrl;
+      })
+      .catch(() => {
+        /* keep whatever the server already rendered */
+      });
+    return () => {
+      ignore = true;
+    };
+    // Deliberately keyed on the slot, not on `ad` — this claims one rotation
+    // turn per page load, and re-running it on every swap would spin the cursor.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [placement, scope]);
+
+  if (!ad && suppressDemo) return null;
+
+  return (
+    <AdSponsorshipBanner
+      // Remount on swap so AdTracker re-arms against the campaign now showing.
+      key={ad?.campaignId ?? "demo"}
+      type={type}
+      cityLabel={cityLabel}
+      className={className}
+      scope={scope}
+      imageUrl={ad?.imageUrl}
+      href={ad?.href}
+      external={ad?.external}
+      creativeKey={ad?.creative ?? undefined}
+      campaignId={ad?.campaignId}
+    />
+  );
+}

--- a/components/ads/RotatingProfileAd.tsx
+++ b/components/ads/RotatingProfileAd.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { SponsoredEntityAd, type FeaturedEntity } from "@/components/ads/SponsoredEntityAd";
+import { fetchRotatingProfileAd } from "@/components/ads/ad-rotation-actions";
+import type { ProfileAd } from "@/lib/profile-ad";
+
+// The on-profile sponsored slot for pages that are CACHED (salon and store
+// profiles run `revalidate = 3600`). The server fills `initial` with a peek at
+// the pool — a real ad, in the initial HTML, so there's no empty gap and no
+// layout shift — and this component then claims the load's actual rotation turn
+// through a server action, swapping only when a different campaign comes back.
+//
+// With one campaign on the slot the peek already IS the turn, so nothing ever
+// swaps. It only swaps once a position genuinely holds several advertisers,
+// which is the whole point.
+//
+// Shop profiles deliberately don't use this: `/shop/[slug]` is force-dynamic, so
+// its ad rotates server-side on every request already and needs no client swap.
+
+export interface ProfileAdDemo {
+  featured: FeaturedEntity;
+  entityLabel: string;
+  entityHref: string;
+  /** The demo's own placement label, so a swap can't leave the campaign ad
+   *  wearing the demo's name (or vice versa). */
+  placementLabel: string;
+}
+
+export function RotatingProfileAd({
+  placement,
+  placementLabel,
+  city,
+  address,
+  initial,
+  demo,
+  currentSlug,
+}: {
+  placement: string;
+  /** Label used while a real campaign is serving. */
+  placementLabel: string;
+  city?: string | null;
+  address?: string | null;
+  /** The server's peek at the pool — rendered immediately. */
+  initial: ProfileAd | null;
+  /** Shown when no campaign is serving. Null for slots with no demo (stores). */
+  demo: ProfileAdDemo | null;
+  currentSlug?: string;
+}) {
+  const [ad, setAd] = useState<ProfileAd | null>(initial);
+  // Claiming a rotation turn is a WRITE, so it has to happen exactly once per
+  // page load — React re-invoking this effect (StrictMode in development does
+  // exactly that) would step the cursor twice, and on an even-sized pool steps
+  // of two mean half the advertisers never get shown at all. Keyed on the slot
+  // so a client-side navigation to another page still claims its own turn.
+  const claimedFor = useRef<string | null>(null);
+
+  useEffect(() => {
+    const slot = `${placement}|${city ?? ""}|${address ?? ""}|${currentSlug ?? ""}`;
+    if (claimedFor.current === slot) return;
+    claimedFor.current = slot;
+
+    let ignore = false;
+    // currentSlug goes along so the client claims against the SAME pool the
+    // server peeked at — this page's own entity excluded. Leave it out and the
+    // two would disagree on the pool, which means a different rotation key (a
+    // second cursor for the same slot) and a campaign that renders as nothing.
+    fetchRotatingProfileAd(placement, { city, address, slug: currentSlug })
+      .then((next) => {
+        // A null here means the pool emptied (all campaigns paused or expired)
+        // since this HTML was cached, so fall back to the demo rather than keep
+        // serving an ad that's no longer sold.
+        if (!ignore) setAd(next);
+      })
+      .catch(() => {
+        /* keep whatever the server already rendered */
+      });
+    return () => {
+      ignore = true;
+    };
+  }, [placement, city, address, currentSlug]);
+
+  const shown = ad
+    ? {
+        featured: ad.featured,
+        entityLabel: ad.entityLabel,
+        entityHref: ad.entityHref,
+        placementLabel,
+        campaignId: ad.campaignId as string | undefined,
+      }
+    : demo
+    ? { ...demo, campaignId: undefined }
+    : null;
+  if (!shown) return null;
+
+  return (
+    <SponsoredEntityAd
+      // Remount on swap so AdTracker re-arms: its impression timer closes over
+      // the props it mounted with, so without a fresh mount the impression would
+      // be reported against the ad that was replaced.
+      key={shown.campaignId ?? "demo"}
+      featured={shown.featured}
+      entityLabel={shown.entityLabel}
+      placementLabel={shown.placementLabel}
+      placementKey={placement}
+      entityHref={shown.entityHref}
+      currentSlug={currentSlug}
+      campaignId={shown.campaignId}
+    />
+  );
+}

--- a/components/ads/SalonSponsoredAd.tsx
+++ b/components/ads/SalonSponsoredAd.tsx
@@ -1,10 +1,17 @@
-import { SponsoredEntityAd, type FeaturedEntity } from "@/components/ads/SponsoredEntityAd";
+import { type FeaturedEntity } from "@/components/ads/SponsoredEntityAd";
+import { RotatingProfileAd } from "@/components/ads/RotatingProfileAd";
 import { getProfileCampaignAd } from "@/lib/profile-ad";
 
 // Sponsored placement on every salon page ("About this salon" section). Serves
 // a real ad_campaign (placement "salon_profile") when one is active — same
 // look, real advertiser entity — and falls back to the demo (Expert Hair
-// Salon) when there's no campaign. Mirrors ShopSponsoredAd exactly.
+// Salon) when there's no campaign.
+//
+// Unlike ShopSponsoredAd, the pick is finished on the client: salon pages are
+// `revalidate = 3600`, so a server-side rotation would be frozen into the cached
+// HTML for an hour. This renders a peek (no cursor claim) for the instant paint
+// and RotatingProfileAd claims the load's real turn — so a reload can show a
+// different advertiser even though the page itself is cached.
 //
 // Demo snapshot of the live row (agent_salon_leads, slug
 // expert-hair-salon-houston-78294ecf). taglineChips are editorial (that row
@@ -21,26 +28,20 @@ const FEATURED: FeaturedEntity = {
 };
 
 export async function SalonSponsoredAd({ currentSlug, city, address }: { currentSlug?: string; city?: string | null; address?: string | null }) {
-  const campaign = await getProfileCampaignAd("salon_profile", { city, address });
-  if (campaign) {
-    return (
-      <SponsoredEntityAd
-        featured={campaign.featured}
-        entityLabel={campaign.entityLabel}
-        placementLabel="Salon Page Ad"
-        placementKey="salon_profile"
-        entityHref={campaign.entityHref}
-        currentSlug={currentSlug}
-      />
-    );
-  }
+  const peek = await getProfileCampaignAd("salon_profile", { city, address, slug: currentSlug }, { rotate: false });
   return (
-    <SponsoredEntityAd
-      featured={FEATURED}
-      entityLabel="Featured Salon"
-      placementLabel="Salon Page Ad (Expert Hair Salon Feature)"
-      placementKey="salon_profile"
-      entityHref={`/salons/${FEATURED.slug}`}
+    <RotatingProfileAd
+      placement="salon_profile"
+      placementLabel="Salon Page Ad"
+      city={city}
+      address={address}
+      initial={peek}
+      demo={{
+        featured: FEATURED,
+        entityLabel: "Featured Salon",
+        entityHref: `/salons/${FEATURED.slug}`,
+        placementLabel: "Salon Page Ad (Expert Hair Salon Feature)",
+      }}
       currentSlug={currentSlug}
     />
   );

--- a/components/ads/ShopSponsoredAd.tsx
+++ b/components/ads/ShopSponsoredAd.tsx
@@ -22,7 +22,7 @@ const FEATURED: FeaturedEntity = {
 };
 
 export async function ShopSponsoredAd({ currentSlug, city, address }: { currentSlug?: string; city?: string | null; address?: string | null }) {
-  const campaign = await getProfileCampaignAd("shop_profile", { city, address });
+  const campaign = await getProfileCampaignAd("shop_profile", { city, address, slug: currentSlug });
   if (campaign) {
     return (
       <SponsoredEntityAd
@@ -32,6 +32,7 @@ export async function ShopSponsoredAd({ currentSlug, city, address }: { currentS
         placementKey="shop_profile"
         entityHref={campaign.entityHref}
         currentSlug={currentSlug}
+        campaignId={campaign.campaignId}
       />
     );
   }

--- a/components/ads/SponsoredEntityAd.tsx
+++ b/components/ads/SponsoredEntityAd.tsx
@@ -38,13 +38,16 @@ interface SponsoredEntityAdProps {
   /** Current page's entity slug — when it matches the featured slug the ad
    *  hides itself (never advertise an entity on its own page). */
   currentSlug?: string;
+  /** Serving campaign, when this is a real (rotating) campaign ad rather than
+   *  the demo — attributes the impression/click to that advertiser. */
+  campaignId?: string;
 }
 
-export function SponsoredEntityAd({ featured, entityLabel, placementLabel, placementKey, entityHref, currentSlug }: SponsoredEntityAdProps) {
+export function SponsoredEntityAd({ featured, entityLabel, placementLabel, placementKey, entityHref, currentSlug, campaignId }: SponsoredEntityAdProps) {
   if (currentSlug && currentSlug === featured.slug) return null;
 
   return (
-    <AdTracker placement={placementKey} adType="on_profile" creative={featured.slug} scope={featured.city} className="mb-8">
+    <AdTracker placement={placementKey} adType="on_profile" creative={featured.slug} scope={featured.city} campaignId={campaignId} className="mb-8">
       {/* "Sponsored" disclosure sits above the card, not inside it, so the
           creative below reads as a genuine ad while staying clearly labeled. */}
       <div className="flex items-center justify-between mb-2 px-1">

--- a/components/ads/SponsorshipBanner.tsx
+++ b/components/ads/SponsorshipBanner.tsx
@@ -1,9 +1,14 @@
-import { AdSponsorshipBanner } from "@/components/ads/AdSponsorshipBanner";
+import { RotatingHubBanner } from "@/components/ads/RotatingHubBanner";
 import { getBannerCampaignAd } from "@/lib/profile-ad";
 
 // Server wrapper for the hub sponsorship banner. Looks up a live campaign
 // banner for this state/city; if found, renders the uploaded creative linking
 // to the campaign's destination, otherwise falls back to the demo banner.
+//
+// Every hub page is `revalidate = 3600`, so which campaign gets the slot can't
+// be decided here — the answer would be frozen into the cached HTML for an hour.
+// This does a peek (no rotation claim) so the banner is in the initial HTML, and
+// RotatingHubBanner claims the load's real turn on the client.
 export async function SponsorshipBanner({
   type,
   cityLabel,
@@ -17,25 +22,25 @@ export async function SponsorshipBanner({
 }) {
   const placement = type === "state" ? "state_hub_banner" : "city_hub_banner";
   const effectiveScope = (scope || (type === "state" ? "Texas" : cityLabel) || "").trim();
-  const campaign = await getBannerCampaignAd(placement, effectiveScope);
+  const peek = await getBannerCampaignAd(placement, effectiveScope, { rotate: false });
 
   // The demo banner graphic is Texas-branded, so it only stands in for the
   // Texas state hub. Any other state hub renders a banner only when a real
-  // campaign fills it (no misleading Texas placeholder on e.g. California).
-  if (!campaign && type === "state" && effectiveScope.toLowerCase() !== "texas") {
-    return null;
-  }
+  // campaign fills it (no misleading Texas placeholder on e.g. California) —
+  // RotatingHubBanner renders nothing in that case. It's still mounted rather
+  // than short-circuited here, so a banner sold after this page was cached
+  // appears on the next load instead of waiting out the revalidate window.
+  const suppressDemo = type === "state" && effectiveScope.toLowerCase() !== "texas";
 
   return (
-    <AdSponsorshipBanner
+    <RotatingHubBanner
+      placement={placement}
       type={type}
+      scope={effectiveScope}
       cityLabel={cityLabel}
       className={className}
-      scope={effectiveScope}
-      imageUrl={campaign?.imageUrl}
-      href={campaign?.href}
-      external={campaign?.external}
-      creativeKey={campaign?.creative ?? undefined}
+      initial={peek}
+      suppressDemo={suppressDemo}
     />
   );
 }

--- a/components/ads/StoreSponsoredAd.tsx
+++ b/components/ads/StoreSponsoredAd.tsx
@@ -1,10 +1,18 @@
-import { SponsoredEntityAd } from "@/components/ads/SponsoredEntityAd";
+import { RotatingProfileAd } from "@/components/ads/RotatingProfileAd";
 import { getProfileCampaignAd } from "@/lib/profile-ad";
 
 // Sponsored slot on supply-store profile pages. Serves an active campaign
 // (placement "barber_supply_profile" / "beauty_supply_profile") — same look as
 // the shop/salon on-profile ads. Unlike those, there's no demo fallback, so it
 // only renders when a campaign is actually sold for this store type.
+//
+// Store pages are `revalidate = 3600`, so the pick is finished on the client
+// (see RotatingProfileAd): the server renders a peek without claiming a rotation
+// turn, and the client claims the real turn on each load. That also means a
+// campaign sold after this page was cached still shows up right away, instead of
+// waiting out the hour — which matters here more than elsewhere, since an empty
+// slot is this placement's fallback.
+
 export async function StoreSponsoredAd({
   storeType,
   currentSlug,
@@ -17,16 +25,16 @@ export async function StoreSponsoredAd({
   address?: string | null;
 }) {
   const placement = storeType === "barber_supply" ? "barber_supply_profile" : "beauty_supply_profile";
-  const campaign = await getProfileCampaignAd(placement, { city, address });
-  if (!campaign) return null;
+  const peek = await getProfileCampaignAd(placement, { city, address, slug: currentSlug }, { rotate: false });
 
   return (
-    <SponsoredEntityAd
-      featured={campaign.featured}
-      entityLabel={campaign.entityLabel}
+    <RotatingProfileAd
+      placement={placement}
       placementLabel={placement === "barber_supply_profile" ? "Barber Supply Page Ad" : "Beauty Supply Page Ad"}
-      placementKey={placement}
-      entityHref={campaign.entityHref}
+      city={city}
+      address={address}
+      initial={peek}
+      demo={null}
       currentSlug={currentSlug}
     />
   );

--- a/components/ads/ad-rotation-actions.ts
+++ b/components/ads/ad-rotation-actions.ts
@@ -1,0 +1,25 @@
+"use server";
+
+// Server-action bridge that lets an ad slot inside a CACHED page still rotate on
+// every page load.
+//
+// Salon profiles, store profiles and the state/city hubs are all
+// `revalidate = 3600`, so whatever ad the server picked is frozen into the HTML
+// for an hour — a visitor reloading would keep seeing the same advertiser no
+// matter what the rotation cursor says. Server actions are never cached, so the
+// client rotators (RotatingProfileAd / RotatingHubBanner) call these on mount to
+// claim this load's real turn.
+//
+// The serving logic itself stays in lib/profile-ad: it uses the service-role
+// admin client and can't be imported into a client component. Same pattern as
+// components/shared/scroll-cta-ad.ts.
+
+import { getProfileCampaignAd, getBannerCampaignAd, type AdViewerContext } from "@/lib/profile-ad";
+
+export async function fetchRotatingProfileAd(placement: string, ctx: AdViewerContext) {
+  return getProfileCampaignAd(placement, ctx);
+}
+
+export async function fetchRotatingBannerAd(placement: string, scope: string) {
+  return getBannerCampaignAd(placement, scope);
+}

--- a/components/shared/scroll-cta.tsx
+++ b/components/shared/scroll-cta.tsx
@@ -186,6 +186,7 @@ export function ScrollCTA() {
               adType="geographic"
               creative={ad.creative}
               scope={pathname}
+              campaignId={ad.campaignId}
             >
               <Link href={ad.href} className={ctaCls}>
                 {ad.ctaLabel}

--- a/lib/ad-campaigns.ts
+++ b/lib/ad-campaigns.ts
@@ -124,9 +124,17 @@ export function campaignGeoLabel(c: AdCampaign): string {
  * narrowing dimension (creative, scope) matches too. A null creative/scope
  * means "any" for that dimension — e.g. a state-banner campaign scoped to
  * "Texas" but any creative.
+ *
+ * Events tracked since ad rotation shipped carry the serving campaign's id, and
+ * that wins outright: once a position rotates several campaigns, the
+ * placement/creative/scope heuristic below can no longer tell them apart (two
+ * campaigns can advertise the same entity, and a campaign with a null creative
+ * would otherwise claim every other advertiser's impressions on the slot). The
+ * heuristic stays for events recorded before campaign_id existed.
  */
 export function eventMatchesCampaign(ev: AdEvent, c: AdCampaign): boolean {
   const m = ev.metadata || {};
+  if (m.campaign_id) return m.campaign_id === c.id;
   if (m.placement !== c.placement) return false;
   if (c.creative && m.creative !== c.creative) return false;
   // Scope compared case/whitespace-insensitively to stay consistent with how

--- a/lib/ad-rotation.test.ts
+++ b/lib/ad-rotation.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { AD_ROTATION_CYCLE, adRotationKey, rotatedFrom, rotationOrder } from "@/lib/ad-rotation";
+
+// The rotation index is computed in SQL (claim_ad_rotation_slot). Mirrored here
+// so the fairness guarantee the placement is sold on — every eligible campaign
+// gets its share of each block of 10 impressions — is actually asserted, not
+// just asserted in a comment.
+const indexForServe = (serve: number, poolSize: number) => (serve - 1) % poolSize;
+
+/** Which campaign a given serve number lands on, end to end. */
+function servedCampaign(pool: string[], serve: number): string {
+  return rotatedFrom(pool, indexForServe(serve, pool.length))[0];
+}
+
+describe("rotationOrder", () => {
+  it("orders by id so the index→campaign mapping doesn't depend on query order", () => {
+    const a = { id: "aaa" };
+    const b = { id: "bbb" };
+    const c = { id: "ccc" };
+    expect(rotationOrder([c, a, b]).map((x) => x.id)).toEqual(["aaa", "bbb", "ccc"]);
+    expect(rotationOrder([a, b, c])).toEqual(rotationOrder([b, c, a]));
+  });
+
+  it("leaves the caller's array untouched", () => {
+    const pool = [{ id: "z" }, { id: "a" }];
+    rotationOrder(pool);
+    expect(pool.map((p) => p.id)).toEqual(["z", "a"]);
+  });
+});
+
+describe("adRotationKey", () => {
+  it("is the same for the same pool in any order", () => {
+    expect(adRotationKey("shop_profile", ["a", "b", "c"])).toBe(adRotationKey("shop_profile", ["c", "a", "b"]));
+  });
+
+  it("changes when the pool changes, so selling or pausing a campaign starts a fresh cycle", () => {
+    expect(adRotationKey("shop_profile", ["a", "b"])).not.toBe(adRotationKey("shop_profile", ["a", "b", "c"]));
+  });
+
+  it("separates placements that happen to have the same pool", () => {
+    expect(adRotationKey("shop_profile", ["a", "b"])).not.toBe(adRotationKey("salon_profile", ["a", "b"]));
+  });
+});
+
+describe("rotatedFrom", () => {
+  it("puts the picked index first and wraps the rest", () => {
+    expect(rotatedFrom(["a", "b", "c", "d"], 2)).toEqual(["c", "d", "a", "b"]);
+  });
+
+  it("wraps an index past the end of the pool", () => {
+    expect(rotatedFrom(["a", "b", "c"], 4)).toEqual(["b", "c", "a"]);
+  });
+
+  it("handles pools too small to rotate", () => {
+    expect(rotatedFrom([], 3)).toEqual([]);
+    expect(rotatedFrom(["a"], 7)).toEqual(["a"]);
+  });
+});
+
+describe("rotation fairness", () => {
+  const poolOf = (n: number) => Array.from({ length: n }, (_, i) => `campaign-${i}`);
+
+  it("shows one ad per serve and every campaign within the first pass", () => {
+    const pool = poolOf(10);
+    const firstPass = pool.map((_, i) => servedCampaign(pool, i + 1));
+    expect(new Set(firstPass).size).toBe(10);
+  });
+
+  // The formula as sold: over 10 impressions on a position, each eligible
+  // campaign gets at least its floor share, and the leftovers move on rather
+  // than always going to the same advertiser.
+  it("gives every campaign its floor share of each 10-impression block", () => {
+    for (let poolSize = 1; poolSize <= 12; poolSize++) {
+      const pool = poolOf(poolSize);
+      const floorShare = Math.floor(AD_ROTATION_CYCLE / poolSize);
+      // Every window of 10 consecutive serves, not just the aligned blocks.
+      for (let start = 1; start <= 40; start++) {
+        const window = Array.from({ length: AD_ROTATION_CYCLE }, (_, i) => servedCampaign(pool, start + i));
+        for (const campaign of pool) {
+          const shown = window.filter((c) => c === campaign).length;
+          expect(shown).toBeGreaterThanOrEqual(floorShare);
+        }
+      }
+    }
+  });
+
+  it("splits a full lap exactly evenly, with no campaign stuck first", () => {
+    for (let poolSize = 2; poolSize <= 12; poolSize++) {
+      const pool = poolOf(poolSize);
+      const counts = new Map<string, number>();
+      const laps = AD_ROTATION_CYCLE; // 10 laps of the pool
+      for (let serve = 1; serve <= poolSize * laps; serve++) {
+        const c = servedCampaign(pool, serve);
+        counts.set(c, (counts.get(c) || 0) + 1);
+      }
+      expect([...counts.values()]).toEqual(pool.map(() => laps));
+      // The campaign that opened the first block doesn't open every block.
+      const blockOpeners = new Set(
+        Array.from({ length: 4 }, (_, b) => servedCampaign(pool, b * AD_ROTATION_CYCLE + 1))
+      );
+      if (AD_ROTATION_CYCLE % poolSize !== 0) expect(blockOpeners.size).toBeGreaterThan(1);
+    }
+  });
+});

--- a/lib/ad-rotation.ts
+++ b/lib/ad-rotation.ts
@@ -1,0 +1,118 @@
+import { createHash } from "node:crypto";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Ad rotation — one ad shows per position, but WHICH one changes per render.
+ *
+ * Before this, every serving function took the first match of a created_at-DESC
+ * list, so a placement effectively held exactly one campaign: the newest one
+ * won every impression and everybody sold after it never appeared. Rotation
+ * lets a position hold as many campaigns as we can sell.
+ *
+ * The formula (see supabase/migrations/20260727140000_add_ad_rotation.sql):
+ *
+ *     rotation_index = (served_count - 1) % pool_size
+ *
+ * over a block of AD_ROTATION_CYCLE (10) impressions per position. Round-robin
+ * guarantees each eligible campaign at least floor(10 / pool_size) of every 10
+ * consecutive serves, with the remainder carrying into the next block instead
+ * of always landing on the same campaign.
+ *
+ * The cursor is keyed by the POOL (placement + hash of the eligible campaign
+ * ids), not by page or geography — so a pool shared by many pages rotates as
+ * one, and selling/pausing a campaign starts a fresh cycle.
+ *
+ * Every failure path here falls back to index 0 (the behaviour before
+ * rotation): a rotation problem must never blank an advertiser's ad.
+ */
+
+/** Impressions per rotation block, per ad position. */
+export const AD_ROTATION_CYCLE = 10;
+
+export interface RotationSlot {
+  /** Index into the id-sorted eligible pool. */
+  index: number;
+  /** Lifetime serves for this pool (0 when no cursor was claimed). */
+  servedCount: number;
+  /** Position within the current block of AD_ROTATION_CYCLE impressions. */
+  cyclePosition: number;
+}
+
+const FIRST_SLOT: RotationSlot = { index: 0, servedCount: 0, cyclePosition: 0 };
+
+/**
+ * Identifies a rotation pool. Ids are sorted so the key is independent of the
+ * order rows came back in, and hashed to keep the key short for pools of ten-
+ * plus campaigns.
+ */
+export function adRotationKey(placement: string, campaignIds: string[]): string {
+  const signature = createHash("sha1")
+    .update([...campaignIds].sort().join(","))
+    .digest("hex")
+    .slice(0, 16);
+  return `${placement}:${signature}`;
+}
+
+/**
+ * Sorts a pool into the canonical rotation order. Rotation is only fair if the
+ * index→campaign mapping is stable across renders, so it can't depend on query
+ * order (created_at ties, changing sort) — id order is stable and matches the
+ * ids the rotation key is built from.
+ */
+export function rotationOrder<T extends { id: string }>(pool: T[]): T[] {
+  return [...pool].sort((a, b) => a.id.localeCompare(b.id));
+}
+
+/** Claims the next slot for this pool, incrementing its cursor by one serve. */
+export async function claimRotationSlot(
+  admin: SupabaseClient,
+  placement: string,
+  campaignIds: string[],
+  cycleSize: number = AD_ROTATION_CYCLE
+): Promise<RotationSlot> {
+  // Nothing to rotate through — skip the write entirely so single-campaign
+  // placements (most of them) cost exactly what they did before.
+  if (campaignIds.length <= 1) return FIRST_SLOT;
+  try {
+    const { data, error } = await (admin as any).rpc("claim_ad_rotation_slot", {
+      p_rotation_key: adRotationKey(placement, campaignIds),
+      p_placement: placement,
+      p_pool_ids: campaignIds,
+      p_cycle_size: cycleSize,
+    });
+    const row = Array.isArray(data) ? data[0] : data;
+    if (error || !row) return FIRST_SLOT;
+    return {
+      index: Number(row.rotation_index) || 0,
+      servedCount: Number(row.served) || 0,
+      cyclePosition: Number(row.cycle_position) || 0,
+    };
+  } catch {
+    return FIRST_SLOT;
+  }
+}
+
+/** Rotates a pool so `index` is first, wrapping around. */
+export function rotatedFrom<T>(pool: T[], index: number): T[] {
+  if (pool.length <= 1) return pool;
+  const start = ((index % pool.length) + pool.length) % pool.length;
+  return [...pool.slice(start), ...pool.slice(0, start)];
+}
+
+/**
+ * The whole rotation in one call: takes the campaigns eligible for a position
+ * and returns them ordered by this serve's rotation slot. Callers serve the
+ * first entry, and can walk further down the list when a candidate turns out
+ * to be unservable (missing entity, no photo) so a rotation tick never wastes
+ * the slot on a broken ad.
+ */
+export async function rotateEligible<T extends { id: string }>(
+  admin: SupabaseClient,
+  placement: string,
+  pool: T[]
+): Promise<T[]> {
+  if (pool.length <= 1) return pool;
+  const ordered = rotationOrder(pool);
+  const { index } = await claimRotationSlot(admin, placement, ordered.map((c) => c.id));
+  return rotatedFrom(ordered, index);
+}

--- a/lib/profile-ad.ts
+++ b/lib/profile-ad.ts
@@ -1,5 +1,6 @@
 import { createAdminClient } from "@/lib/supabase/admin";
 import { entityTypeConfig, entityHref } from "@/lib/ad-campaigns";
+import { rotateEligible, rotationOrder } from "@/lib/ad-rotation";
 import type { FeaturedEntity } from "@/components/ads/SponsoredEntityAd";
 
 // Serves a campaign-driven on-profile ad (placement "shop_profile" /
@@ -7,19 +8,62 @@ import type { FeaturedEntity } from "@/components/ads/SponsoredEntityAd";
 // the campaign ad renders through SponsoredEntityAd with an identical look —
 // just real advertiser data instead of the hardcoded demo. Returns null when
 // there's no active campaign (or the entity has no photo), so the caller can
-// fall back to the demo ad. Most-recently-created active campaign wins.
+// fall back to the demo ad.
+//
+// When several campaigns are eligible for the same position they ROTATE — one
+// ad still shows, but which one is decided per serve by lib/ad-rotation.ts, so
+// every advertiser on the slot gets a share of its impressions instead of the
+// newest campaign taking all of them.
 
 export interface ProfileAd {
   featured: FeaturedEntity;
   entityLabel: string;
   entityHref: string;
+  /** Which campaign was served — carried into the pixel for exact attribution. */
+  campaignId: string;
 }
 
-// The location of the page an on-profile ad is being served on (the viewed
-// entity), used to match a campaign's geo-targeting.
+// How far down the rotated pool to keep looking when the campaign whose turn it
+// is can't actually be rendered (entity row gone, no usable photo). Bounded so
+// a slot with many broken campaigns can't turn one page render into a dozen
+// entity lookups; past this we fall back to the demo ad.
+const MAX_ROTATION_CANDIDATES = 5;
+
+export interface AdServingOptions {
+  /**
+   * Whether to advance the position's rotation cursor (i.e. count this as a
+   * serve and take the next campaign's turn).
+   *
+   * `false` — "peek" — returns the first campaign in the pool's canonical order
+   * without touching the cursor. That's for slots rendered inside a CACHED page
+   * (salon/store profiles and the hub banners are `revalidate = 3600`): their
+   * HTML is reused for an hour, so claiming a turn there would burn rotation
+   * slots that nobody sees and, worse, double-advance the cursor on top of the
+   * per-load claim the client rotator makes — with an even-sized pool, steps of
+   * two mean half the advertisers never show at all. The peek fills the cached
+   * HTML with a real ad for the instant paint, and the client re-resolves the
+   * actual turn on every page load.
+   */
+  rotate?: boolean;
+}
+
+// The page an on-profile ad is being served on (the viewed entity): its
+// location, used to match a campaign's geo-targeting, and its slug, used to keep
+// an entity from being advertised on its own profile page.
 export interface AdViewerContext {
   city?: string | null;
   address?: string | null;
+  /**
+   * Slug of the entity whose page this is. Campaigns advertising it are dropped
+   * from the pool before the rotation picks, so its turn goes to the next
+   * advertiser instead of rendering an empty slot — SponsoredEntityAd hides
+   * itself when it would advertise the page you're already on, which used to
+   * mean the advertiser saw a blank space on the one page they check most.
+   *
+   * Compared by slug alone: every slug carries a uuid suffix, so it identifies
+   * one entity across all the tables without needing the viewed entity's type.
+   */
+  slug?: string | null;
 }
 
 function stateFromAddress(addr?: string | null): string | null {
@@ -62,42 +106,69 @@ function chips(row: any): string[] {
   return out.slice(0, 3);
 }
 
-export async function getProfileCampaignAd(placement: string, ctx: AdViewerContext = {}): Promise<ProfileAd | null> {
+// Builds the renderable ad for one campaign. Null when the campaign can't be
+// served — unknown entity type, entity row gone, or no usable photo.
+async function buildProfileAd(admin: any, camp: any): Promise<ProfileAd | null> {
+  const cfg = entityTypeConfig(camp.entity_type);
+  if (!cfg) return null;
+
+  const { data: ent } = await admin.from(cfg.table).select("*").eq("slug", camp.creative).maybeSingle();
+  if (!ent) return null;
+  const row = ent as any;
+
+  // The demo look is photo-forward; without an image the card wouldn't match,
+  // so fall back to the demo rather than render a broken-looking ad.
+  const image = firstImage(row);
+  if (!image) return null;
+
+  const featured: FeaturedEntity = {
+    slug: camp.creative,
+    name: row.shop_name || row.name || row.school_name || row.title || camp.creative,
+    city: row.city || row.metro_area || row.formatted_address || "",
+    rating: Number(row.rating ?? row.booksy_rating ?? 0),
+    reviews: Number(row.total_reviews ?? row.google_review_count ?? row.booksy_review_count ?? 0),
+    taglineChips: chips(row),
+    image,
+  };
+
+  return {
+    featured,
+    entityLabel: `Featured ${cfg.label}`,
+    entityHref: `${cfg.route}/${camp.creative}`,
+    campaignId: camp.id,
+  };
+}
+
+export async function getProfileCampaignAd(
+  placement: string,
+  ctx: AdViewerContext = {},
+  { rotate = true }: AdServingOptions = {}
+): Promise<ProfileAd | null> {
   try {
     const admin = createAdminClient();
     const { data: camps } = await (admin as any)
       .from("ad_campaigns")
-      .select("entity_type, creative, target_states, target_cities, created_at")
+      .select("id, entity_type, creative, target_states, target_cities, created_at")
       .eq("placement", placement)
       .eq("status", "active")
       .order("created_at", { ascending: false });
 
-    const match = ((camps as any[]) || []).find((c) => c.entity_type && c.creative && geoMatches(c, ctx));
-    if (!match) return null;
+    // Every campaign that could serve on this page — geo-targeting and the
+    // don't-advertise-this-page's-own-entity rule are what narrow the pool, so
+    // two pages can have different (or overlapping) pools on the same placement.
+    const eligible = ((camps as any[]) || []).filter(
+      (c) => c.entity_type && c.creative && c.creative !== ctx.slug && geoMatches(c, ctx)
+    );
+    if (!eligible.length) return null;
 
-    const cfg = entityTypeConfig(match.entity_type);
-    if (!cfg) return null;
-
-    const { data: ent } = await (admin as any).from(cfg.table).select("*").eq("slug", match.creative).maybeSingle();
-    if (!ent) return null;
-    const row = ent as any;
-
-    // The demo look is photo-forward; without an image the card wouldn't match,
-    // so fall back to the demo rather than render a broken-looking ad.
-    const image = firstImage(row);
-    if (!image) return null;
-
-    const featured: FeaturedEntity = {
-      slug: match.creative,
-      name: row.shop_name || row.name || row.school_name || row.title || match.creative,
-      city: row.city || row.metro_area || row.formatted_address || "",
-      rating: Number(row.rating ?? row.booksy_rating ?? 0),
-      reviews: Number(row.total_reviews ?? row.google_review_count ?? row.booksy_review_count ?? 0),
-      taglineChips: chips(row),
-      image,
-    };
-
-    return { featured, entityLabel: `Featured ${cfg.label}`, entityHref: `${cfg.route}/${match.creative}` };
+    const rotated = rotate
+      ? await rotateEligible(admin as any, placement, eligible)
+      : rotationOrder(eligible);
+    for (const camp of rotated.slice(0, MAX_ROTATION_CANDIDATES)) {
+      const ad = await buildProfileAd(admin, camp);
+      if (ad) return ad;
+    }
+    return null;
   } catch {
     return null;
   }
@@ -110,6 +181,7 @@ export interface EntityBottomBannerAd {
   ctaLabel: string;
   href: string; // the linked entity's profile
   creative: string; // for ad tracking
+  campaignId: string; // which campaign this serve belongs to
 }
 
 // Each entity route → the candidate table(s) with their SPECIFIC entity-type key.
@@ -155,7 +227,7 @@ export async function getEntityBottomBannerAd(pathname: string): Promise<EntityB
     const admin = createAdminClient();
     const { data: camps } = await (admin as any)
       .from("ad_campaigns")
-      .select("entity_type, creative, target_states, target_cities, banner_page_types, ad_eyebrow, ad_headline, ad_cta_label, created_at")
+      .select("id, entity_type, creative, target_states, target_cities, banner_page_types, ad_eyebrow, ad_headline, ad_cta_label, created_at")
       .eq("placement", "entity_bottom_banner")
       .eq("status", "active")
       .order("created_at", { ascending: false });
@@ -163,17 +235,25 @@ export async function getEntityBottomBannerAd(pathname: string): Promise<EntityB
 
     const viewed = await resolveViewedEntity(admin, route, slug);
     if (!viewed) return null;
-    const match = (camps as any[]).find(
+    const eligible = (camps as any[]).filter(
       (c) =>
         c.entity_type &&
         c.creative &&
+        // Same rule as the profile ads: don't run a banner pitching the very
+        // page it's sitting on. Here it wouldn't blank the slot, it would just
+        // link the visitor back where they already are — a wasted impression
+        // the advertiser still gets billed a turn for.
+        c.creative !== slug &&
         (!c.banner_page_types?.length || c.banner_page_types.includes(viewed.type)) &&
-        geoMatches(c, viewed.ctx)
+        geoMatches(c, viewed.ctx) &&
+        entityHref(c.entity_type, c.creative)
     );
-    if (!match) return null;
+    if (!eligible.length) return null;
 
-    const href = entityHref(match.entity_type, match.creative);
-    if (!href) return null;
+    // Whose turn it is on this slot. Everything the banner needs is already on
+    // the campaign row, so the rotation pick is always servable.
+    const [match] = await rotateEligible(admin as any, "entity_bottom_banner", eligible);
+    const href = entityHref(match.entity_type, match.creative)!;
 
     return {
       eyebrow: (match.ad_eyebrow || "Sponsored").trim(),
@@ -181,6 +261,7 @@ export async function getEntityBottomBannerAd(pathname: string): Promise<EntityB
       ctaLabel: (match.ad_cta_label || "Learn more").trim(),
       href,
       creative: match.creative,
+      campaignId: match.id,
     };
   } catch {
     return null;
@@ -192,6 +273,7 @@ export interface BannerAd {
   href: string;
   external: boolean; // true when href is an external click_url (open in new tab)
   creative: string | null; // the campaign's creative, so the banner's tracked event matches the campaign
+  campaignId: string; // which campaign this serve belongs to
 }
 
 // Serves a campaign banner for a state/city hub. Matches an active
@@ -199,33 +281,42 @@ export interface BannerAd {
 // the hub's scope, or be blank = any). Destination is the external click_url
 // when set, else the advertised entity's profile. Returns null (→ demo banner)
 // when there's no campaign or it has no uploaded image.
-export async function getBannerCampaignAd(placement: string, scope: string): Promise<BannerAd | null> {
+export async function getBannerCampaignAd(
+  placement: string,
+  scope: string,
+  { rotate = true }: AdServingOptions = {}
+): Promise<BannerAd | null> {
   try {
     const admin = createAdminClient();
     const { data: camps } = await (admin as any)
       .from("ad_campaigns")
-      .select("entity_type, creative, scope, banner_image_url, click_url, created_at")
+      .select("id, entity_type, creative, scope, banner_image_url, click_url, created_at")
       .eq("placement", placement)
       .eq("status", "active")
       .order("created_at", { ascending: false });
 
     const target = (scope || "").trim().toLowerCase();
-    const match = ((camps as any[]) || []).find(
+    const eligible = ((camps as any[]) || []).filter(
       (c) =>
         c.banner_image_url &&
         (!c.scope || c.scope.trim().toLowerCase() === target) &&
-        (c.click_url || (c.entity_type && c.creative))
+        (c.click_url || entityHref(c.entity_type, c.creative))
     );
-    if (!match) return null;
+    if (!eligible.length) return null;
 
-    const href = match.click_url || entityHref(match.entity_type, match.creative);
-    if (!href) return null;
+    // Whose turn it is for this hub's banner slot. Every eligible campaign
+    // already has an image and a destination, so the pick always renders.
+    const [match] = rotate
+      ? await rotateEligible(admin as any, placement, eligible)
+      : rotationOrder(eligible);
+    const href = match.click_url || entityHref(match.entity_type, match.creative)!;
 
     return {
       imageUrl: match.banner_image_url,
       href,
       external: !!match.click_url,
       creative: match.creative || null,
+      campaignId: match.id,
     };
   } catch {
     return null;

--- a/supabase/migrations/20260727140000_add_ad_rotation.sql
+++ b/supabase/migrations/20260727140000_add_ad_rotation.sql
@@ -1,0 +1,92 @@
+-- Ad rotation: lets a single ad position hold MANY eligible campaigns and serve
+-- a different one on each render, instead of only ever showing the newest
+-- campaign (every serving function in lib/profile-ad.ts used to take the first
+-- match of a created_at-DESC list, so campaign #2 onward never appeared).
+--
+-- One ad still shows per position. Which one is decided by a plain round-robin
+-- over the eligible pool, driven by a persistent per-pool cursor:
+--
+--     rotation_index = (served_count - 1) % pool_size
+--
+-- `cycle_size` (default 10) is the impression block the rotation is specified
+-- in: across any window of `cycle_size` consecutive serves, every campaign in
+-- the pool gets at least floor(cycle_size / pool_size) of them, and the
+-- leftover serves carry into the next block rather than always going to the
+-- same campaign. 10 impressions over 4 campaigns → 3/3/2/2 in the first block,
+-- 2/2/3/3 in the next, so nobody is permanently first. It's stored per cursor
+-- so later work (weighted share, priority tiers) has a block size to divide up.
+--
+-- The "rotation key" identifies the POOL, not the page: it's the placement plus
+-- a hash of the eligible campaign ids (see lib/ad-rotation.ts). Two pages with
+-- the same eligible set share one cursor, and changing that set — selling a new
+-- campaign, pausing one — starts a fresh cursor at zero.
+--
+-- `served_count` counts ad SERVES (a rendered ad), not viewable impressions —
+-- those still come from the pixel's ad_impression events, which is what the
+-- advertiser-facing reports use.
+
+CREATE TABLE IF NOT EXISTS public.ad_rotation_cursors (
+  rotation_key text PRIMARY KEY,
+  placement    text NOT NULL,
+  pool_ids     uuid[] NOT NULL DEFAULT '{}',   -- the eligible campaigns, for debugging
+  pool_size    integer NOT NULL,
+  cycle_size   integer NOT NULL DEFAULT 10,
+  served_count bigint NOT NULL DEFAULT 0,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS ad_rotation_cursors_placement_idx
+  ON public.ad_rotation_cursors (placement);
+
+ALTER TABLE public.ad_rotation_cursors ENABLE ROW LEVEL SECURITY;
+
+-- Server-side only: ads are served by the service-role admin client, and the
+-- cursor is an internal serving detail (no browser ever reads or writes it).
+CREATE POLICY "Service role full access to ad_rotation_cursors"
+  ON public.ad_rotation_cursors FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- Claim the next rotation slot for a pool and return which campaign index to
+-- serve. The increment and the read are a single statement, so concurrent
+-- renders can't hand two visitors the same slot.
+CREATE OR REPLACE FUNCTION public.claim_ad_rotation_slot(
+  p_rotation_key text,
+  p_placement    text,
+  p_pool_ids     uuid[],
+  p_cycle_size   integer DEFAULT 10
+)
+RETURNS TABLE (served bigint, rotation_index integer, cycle_position integer)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  -- array_length is NULL for an empty array and GREATEST ignores NULLs, so an
+  -- empty pool degrades to size 1 (index 0) instead of dividing by zero.
+  v_pool_size  integer := GREATEST(array_length(p_pool_ids, 1), 1);
+  v_cycle_size integer := GREATEST(COALESCE(p_cycle_size, 10), 1);
+  v_served     bigint;
+BEGIN
+  INSERT INTO ad_rotation_cursors AS c
+    (rotation_key, placement, pool_ids, pool_size, cycle_size, served_count)
+  VALUES
+    (p_rotation_key, p_placement, p_pool_ids, v_pool_size, v_cycle_size, 1)
+  ON CONFLICT (rotation_key) DO UPDATE
+    SET served_count = c.served_count + 1,
+        -- Same key means the same id set, so these only ever rewrite equal
+        -- values — kept so a cursor row stays self-describing if the key
+        -- derivation ever changes.
+        pool_ids   = EXCLUDED.pool_ids,
+        pool_size  = EXCLUDED.pool_size,
+        cycle_size = EXCLUDED.cycle_size,
+        updated_at = now()
+  RETURNING c.served_count INTO v_served;
+
+  RETURN QUERY SELECT
+    v_served,
+    ((v_served - 1) % v_pool_size)::integer,
+    ((v_served - 1) % v_cycle_size)::integer;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.claim_ad_rotation_slot(text, text, uuid[], integer) TO service_role;

--- a/supabase/migrations/20260727141000_lock_down_ad_rotation_rpc.sql
+++ b/supabase/migrations/20260727141000_lock_down_ad_rotation_rpc.sql
@@ -1,0 +1,19 @@
+-- Lock down claim_ad_rotation_slot. Granting EXECUTE to service_role in
+-- 20260727140000 was not enough: Postgres grants EXECUTE on a new function to
+-- PUBLIC by default, so anon/authenticated could call it too — and because it's
+-- SECURITY DEFINER, a visitor could spin a placement's cursor (skewing whose ad
+-- shows) or write arbitrary cursor rows straight past the table's RLS. Verified
+-- against the live database with the anon key before this fix.
+--
+-- Ads are only ever served by the service-role admin client, so nothing else
+-- needs to call this.
+
+REVOKE ALL ON FUNCTION public.claim_ad_rotation_slot(text, text, uuid[], integer) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.claim_ad_rotation_slot(text, text, uuid[], integer) FROM anon;
+REVOKE ALL ON FUNCTION public.claim_ad_rotation_slot(text, text, uuid[], integer) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_ad_rotation_slot(text, text, uuid[], integer) TO service_role;
+
+-- Clear anything written through that window before it was closed (cursor rows
+-- are pure serving state — dropping one just restarts that pool's cycle).
+DELETE FROM public.ad_rotation_cursors
+WHERE rotation_key NOT LIKE '%:%';

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
         globals: true,
         environment: "jsdom",
         setupFiles: ["./vitest.setup.ts"],
-        include: ["features/**/*.test.{ts,tsx}", "components/**/*.test.{ts,tsx}", "app/**/*.test.{ts,tsx}"],
+        include: ["features/**/*.test.{ts,tsx}", "components/**/*.test.{ts,tsx}", "app/**/*.test.{ts,tsx}", "lib/**/*.test.{ts,tsx}"],
         exclude: ["node_modules", ".next", "supabase"],
         coverage: {
             provider: "v8",


### PR DESCRIPTION
A placement could only ever hold one advertiser: every serving function took the first match of a created_at-DESC list, so the newest campaign won every impression and everyone sold after it never appeared. With ten Houston barbershops signing up, the slots had to hold more than one.

One ad still shows per position. Which one is a round-robin over the eligible pool, driven by a persistent cursor:

    rotation_index = (served_count - 1) % pool_size

Across any 10 consecutive impressions each eligible campaign gets at least floor(10 / pool_size) of them, with the remainder carrying into the next block instead of always landing on the same advertiser. The cursor is keyed by the pool (placement + hash of the sorted campaign ids), so selling or pausing a campaign starts a fresh cycle. Any failure serves index 0 rather than blanking the ad.

Cached pages get a peek/claim split rather than losing their cache: salon/store profiles and the state/city hubs are revalidate = 3600, so the server renders a peek (first campaign in id order, no cursor claim) for the instant paint and the client claims the load's real turn through a server action. SSR must never claim on those slots — SSR claim plus client claim steps the cursor by two, and on an even pool that means half the advertisers never show. Shop pages stay server-side; /shop/[slug] is force-dynamic and already rotates per request.

Also in this change:

- campaign_id rides in the AdTracker pixel metadata and wins in eventMatchesCampaign. Placement + creative + scope can't tell rotating advertisers apart: two campaigns can advertise the same entity, and one with a null creative would claim everyone else's impressions.
- Search results served EVERY matching campaign, which would stack a dozen sponsored cards above the organic results. Now one rotating card (SEARCH_ADS_PER_TAB).
- Campaigns advertising the page you're on are dropped before the pick, so an advertiser's turn on their own profile no longer renders the empty slot SponsoredEntityAd's self-hide leaves behind.
- A campaign whose entity has no usable photo no longer wastes its turn; the pick walks up to 5 rotated candidates.
- claim_ad_rotation_slot is revoked from PUBLIC. Postgres grants EXECUTE on new functions to PUBLIC by default, so the SECURITY DEFINER function was callable with the anon key — a visitor could spin a placement's cursor or write cursor rows past the table's RLS. Confirmed against the live database, then closed.

Verified in a browser with throwaway campaigns on a zero-traffic city: served ads matched (n-1) % pool_size exactly, the hub banner swapped both creative and destination, and served_count tracked page loads 1:1 with no double-claim. Fairness is asserted in lib/ad-rotation.test.ts.


Claude-Session: https://claude.ai/code/session_01RTF3ibrf1oSQ8sHtx969wf