### PR TITLE
feat(security): PKCE, CSRF-safe state, and Cross-Account Protection f…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,13 @@ scratchpad_reports/
 
 # Crash-resume checkpoint written by scripts/sync_entities_to_ghl.js
 scripts/.ghl_sync_progress.json
+
+# Google Cross-Account Protection service-account key (see
+# scripts/register_risc_endpoint.js). Both cases are listed on purpose: the file
+# on disk is lowercase, and it only matched the uppercase pattern because macOS
+# is case-insensitive. On Linux — CI, a container build, a teammate's machine —
+# the uppercase line alone would NOT match, and the private key would be
+# committable. Anything matching risc*key.json is ignored regardless of case.
+RISC-SERVICE-KEY.json
+risc-service-key.json
+risc*key.json

--- a/app/api/google-business/callback/route.ts
+++ b/app/api/google-business/callback/route.ts
@@ -4,7 +4,7 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import {
   gbpExchangeCode,
   gbpFetchLocations,
-  emailFromIdToken,
+  identityFromIdToken,
   matchLocationToEntity,
   stageGbpLocation,
   type GbpLocationOutcome,
@@ -36,7 +36,12 @@ export async function GET(req: Request) {
 
   const code = url.searchParams.get("code");
   const state = url.searchParams.get("state");
-  const cookieState = req.headers.get("cookie")?.match(/gbp_oauth_state=([a-f0-9]+)/)?.[1];
+  const cookies = req.headers.get("cookie") || "";
+  const cookieState = cookies.match(/gbp_oauth_state=([a-f0-9]+)/)?.[1];
+  // PKCE verifier from the same redirect that set the state cookie. Without it
+  // Google rejects the exchange, which is the point: an intercepted code is
+  // useless to anyone who doesn't hold this value.
+  const codeVerifier = cookies.match(/gbp_oauth_verifier=([A-Za-z0-9_-]+)/)?.[1];
   if (!code || !state || !cookieState || state !== cookieState) return back("gbp=error");
 
   const supabase = await createServerClient();
@@ -52,8 +57,11 @@ export async function GET(req: Request) {
   if (!member) return back("gbp=nomember");
 
   try {
-    const tokens = await gbpExchangeCode(origin, code);
+    const tokens = await gbpExchangeCode(origin, code, codeVerifier);
     const accessToken = tokens.access_token;
+    // `sub` is what Cross-Account Protection events are keyed on — capture it
+    // now or a later revocation has nothing to match against.
+    const identity = identityFromIdToken((tokens as any).id_token);
     if (!accessToken) return back("gbp=error");
 
     let locations: any[] = [];
@@ -126,7 +134,8 @@ export async function GET(req: Request) {
     const { error: upErr } = await (admin.from("gbp_connections") as any).upsert(
       {
         community_member_id: (member as any).id,
-        google_account_email: emailFromIdToken((tokens as any).id_token),
+        google_account_email: identity.email,
+        google_user_id: identity.sub,
         access_token: accessToken,
         refresh_token: tokens.refresh_token || null,
         token_expiry: tokens.expiry_date ? new Date(tokens.expiry_date).toISOString() : null,
@@ -148,6 +157,7 @@ export async function GET(req: Request) {
 
     const res = back(`gbp=connected&locations=${locations.length}&staged=${staged}`);
     res.cookies.set("gbp_oauth_state", "", { maxAge: 0, path: "/" });
+    res.cookies.set("gbp_oauth_verifier", "", { maxAge: 0, path: "/" });
     return res;
   } catch (e: any) {
     console.error("[gbp callback]", e?.message);

--- a/app/api/google-business/start/route.ts
+++ b/app/api/google-business/start/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { randomBytes } from "crypto";
 import { createServerClient } from "@/lib/supabase/server";
-import { gbpAuthUrl } from "@/lib/google-business";
+import { gbpAuthUrl, gbpPkcePair } from "@/lib/google-business";
 
 // Kicks off the Google Business Profile OAuth consent for the signed-in member.
 // Sets a state nonce cookie (CSRF) and redirects to Google.
@@ -27,13 +27,20 @@ export async function GET(req: Request) {
   }
 
   const state = randomBytes(16).toString("hex");
-  const res = NextResponse.redirect(gbpAuthUrl(origin, state));
-  res.cookies.set("gbp_oauth_state", state, {
+  const { verifier, challenge } = gbpPkcePair();
+
+  const res = NextResponse.redirect(gbpAuthUrl(origin, state, challenge));
+  // `state` proves the callback belongs to a flow we started (CSRF); the PKCE
+  // verifier proves the code is being redeemed by whoever started it. Both stay
+  // httpOnly so page scripts can't read them, and both expire with the flow.
+  const cookieOpts = {
     httpOnly: true,
     secure: !host.includes("localhost"),
-    sameSite: "lax",
+    sameSite: "lax" as const,
     maxAge: 600,
     path: "/",
-  });
+  };
+  res.cookies.set("gbp_oauth_state", state, cookieOpts);
+  res.cookies.set("gbp_oauth_verifier", verifier, cookieOpts);
   return res;
 }

--- a/app/api/security/risc/route.ts
+++ b/app/api/security/risc/route.ts
@@ -1,0 +1,85 @@
+import { NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import {
+  verifySecurityEventToken,
+  subjectOf,
+  REVOCATION_EVENTS,
+  VERIFICATION_EVENT,
+} from "@/lib/risc";
+
+/**
+ * Cross-Account Protection receiver (Google RISC).
+ *
+ * Google pushes a signed Security Event Token here whenever something happens
+ * to a linked Google Account — the user revoked our access, the account was
+ * disabled or deleted, sessions were killed, credentials changed.
+ *
+ * Why we want it: gbp_connections holds long-lived refresh tokens. Without
+ * these events, a user who disconnects us from their Google account settings
+ * leaves us holding a dead token indefinitely, still showing "connected" on
+ * their listing and still trying to sync. This closes that loop, and it's the
+ * check Google's Project Checkup flags under "Cross-Account Protection".
+ *
+ * The endpoint is necessarily unauthenticated — Google posts with none of our
+ * credentials — so the JWT signature is the authentication. Verification lives
+ * in lib/risc.ts and is unit-tested there.
+ *
+ * Registration is a separate step: scripts/register_risc_endpoint.js.
+ */
+
+export const runtime = "nodejs"; // node:crypto for JWT verification
+export const dynamic = "force-dynamic";
+
+async function revokeConnection(sub?: string, email?: string): Promise<string> {
+  if (!sub && !email) return "no subject on event";
+  const admin = createAdminClient();
+  const patch = {
+    status: "revoked",
+    access_token: null,
+    refresh_token: null,
+    token_expiry: null,
+    updated_at: new Date().toISOString(),
+  };
+
+  // Prefer Google's stable user id; fall back to email for connections made
+  // before we started storing `sub`.
+  let query = (admin.from("gbp_connections") as any).update(patch);
+  query = sub ? query.eq("google_user_id", sub) : query.eq("google_account_email", email);
+
+  const { data, error } = await query.select("id");
+  if (error) return `update failed: ${error.message}`;
+  return `revoked ${data?.length ?? 0} connection(s)`;
+}
+
+export async function POST(req: Request) {
+  // Google sends application/secevent+jwt — the body is the bare token.
+  const token = (await req.text()).trim();
+  if (!token) return new NextResponse(null, { status: 400 });
+
+  const payload = await verifySecurityEventToken(token, process.env.GOOGLE_CLIENT_ID);
+  if (!payload) {
+    console.warn("[risc] rejected an unverifiable security event token");
+    return new NextResponse(null, { status: 401 });
+  }
+
+  for (const [type, event] of Object.entries<any>(payload.events || {})) {
+    if (type === VERIFICATION_EVENT) {
+      // Registration smoke test — nothing to do but acknowledge. The state is
+      // logged so whoever ran register_risc_endpoint.js --verify can see their
+      // own value come back out the far end.
+      console.log(`[risc] verification event received (state: ${event?.state ?? "none"})`);
+      continue;
+    }
+    if (!REVOCATION_EVENTS.has(type)) {
+      console.log(`[risc] ignoring unhandled event type: ${type}`);
+      continue;
+    }
+    const { sub, email } = subjectOf(event);
+    console.log(`[risc] ${type} → ${await revokeConnection(sub, email)}`);
+  }
+
+  // Always 202 once the token itself is genuine. A non-2xx tells Google we're
+  // broken, and enough of those get the event stream disabled — an event about
+  // an account we don't happen to have is not an error.
+  return new NextResponse(null, { status: 202 });
+}

--- a/app/youtube/callback/page.tsx
+++ b/app/youtube/callback/page.tsx
@@ -32,14 +32,45 @@ const YouTubeCallbackContent = () => {
                 return
             }
 
+            // The state is a one-time nonce this browser generated before
+            // leaving for Google (see components/social/youtube-login-button).
+            // If it isn't in this tab's sessionStorage, the callback didn't
+            // originate from a flow we started — which is exactly the forged
+            // callback the previous predictable state couldn't detect. Refuse it.
+            const stashKey = `yt_oauth_${state}`
+            const stash = sessionStorage.getItem(stashKey)
+            if (!stash) {
+                setStatus("error")
+                setMessage(
+                    "This sign-in didn't start in this browser tab, so it was rejected for your safety. Please connect YouTube again from the Connectors page."
+                )
+                return
+            }
+            sessionStorage.removeItem(stashKey) // one-time use, even on failure
+
+            let codeVerifier: string, projectId: string, visitorId: string | null
+            try {
+                ({ codeVerifier, projectId, visitorId } = JSON.parse(stash))
+            } catch {
+                setStatus("error")
+                setMessage("Could not read this sign-in session. Please try connecting YouTube again.")
+                return
+            }
+
             try {
                 const supabase = createBrowserClient()
-                
+
                 // Call our complete-youtube-auth Edge Function
                 const { data: response, error: fnError } = await supabase.functions.invoke("complete-youtube-auth", {
-                    body: { 
-                        code, 
+                    body: {
+                        code,
                         state,
+                        // The ids used to be parsed out of `state`; they travel
+                        // here now that state is an opaque nonce. codeVerifier
+                        // completes the PKCE exchange.
+                        projectId,
+                        visitorId,
+                        codeVerifier,
                         redirectUri: window.location.origin + "/youtube/callback"
                     }
                 })

--- a/components/social/youtube-login-button.tsx
+++ b/components/social/youtube-login-button.tsx
@@ -23,7 +23,8 @@ export const YouTubeLoginButton: React.FC<YouTubeLoginButtonProps> = ({
     label = "Connect YouTube",
     disabled = false
 }) => {
-    const handleLogin = () => {
+    // async because the PKCE challenge is a SubtleCrypto digest.
+    const handleLogin = async () => {
         if (!projectId) {
             alert("Please select a project first.")
             return
@@ -34,18 +35,48 @@ export const YouTubeLoginButton: React.FC<YouTubeLoginButtonProps> = ({
             ? "http://localhost:3000/youtube/callback"
             : "https://agency.innergcomplete.com/youtube/callback"
 
-        // Scopes for YouTube Readonly + Analytics + OpenID
+        // youtube.force-ssl is a WRITE scope but genuinely required — the
+        // connector's caption/transcript sync fails with 403 without it (see
+        // supabase/functions/connector-sync/providers/youtube/client.ts).
+        // `openid` was dropped: nothing reads the id_token, and userinfo.email /
+        // userinfo.profile already cover the name and email the auth function
+        // stores. Fewer scopes, smaller consent screen, simpler verification.
         const scopes = [
             "https://www.googleapis.com/auth/youtube.readonly",
             "https://www.googleapis.com/auth/yt-analytics.readonly",
             "https://www.googleapis.com/auth/youtube.force-ssl",
             "https://www.googleapis.com/auth/userinfo.profile",
             "https://www.googleapis.com/auth/userinfo.email",
-            "openid"
         ].join(" ")
 
-        const state = `projectId:${projectId}__visitor:${visitorId || "none"}`
-        
+        // `state` used to be `projectId:…__visitor:…` — predictable, and the
+        // callback never checked it, so anyone could hand a signed-in user a
+        // forged callback URL and attach their own Google account to a project.
+        // It's now an unguessable nonce that the callback must match against
+        // this tab's sessionStorage; the project/visitor ids ride along there
+        // instead of in the URL.
+        //
+        // PKCE goes in the same envelope: a browser-initiated flow can't set an
+        // httpOnly cookie, so the verifier lives in sessionStorage (per-tab,
+        // same-origin only, gone when the tab closes) and only its SHA-256 hash
+        // is sent to Google.
+        const randomUrlSafe = (bytes: number) => {
+            const buf = new Uint8Array(bytes)
+            crypto.getRandomValues(buf)
+            return btoa(String.fromCharCode(...buf)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+        }
+
+        const state = randomUrlSafe(16)
+        const codeVerifier = randomUrlSafe(32)
+        const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(codeVerifier))
+        const codeChallenge = btoa(String.fromCharCode(...new Uint8Array(digest)))
+            .replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "")
+
+        sessionStorage.setItem(
+            `yt_oauth_${state}`,
+            JSON.stringify({ codeVerifier, projectId, visitorId: visitorId || null })
+        )
+
         const authUrl = new URL("https://accounts.google.com/o/oauth2/v2/auth")
         authUrl.searchParams.append("client_id", clientId!)
         authUrl.searchParams.append("redirect_uri", redirectUri)
@@ -54,6 +85,11 @@ export const YouTubeLoginButton: React.FC<YouTubeLoginButtonProps> = ({
         authUrl.searchParams.append("state", state)
         authUrl.searchParams.append("access_type", "offline")
         authUrl.searchParams.append("prompt", "consent") // Required to always get a refresh token
+        // Keeps previously-granted scopes attached when we ask for more later,
+        // which is what Google's "incremental authorization" check looks for.
+        authUrl.searchParams.append("include_granted_scopes", "true")
+        authUrl.searchParams.append("code_challenge", codeChallenge)
+        authUrl.searchParams.append("code_challenge_method", "S256")
 
         window.location.href = authUrl.toString()
     }

--- a/lib/google-business.ts
+++ b/lib/google-business.ts
@@ -1,4 +1,6 @@
 import { google } from "googleapis";
+import { CodeChallengeMethod } from "google-auth-library";
+import { createHash, randomBytes } from "node:crypto";
 import { CLAIM_ENTITY_TYPES } from "@/lib/entity-claim";
 
 // Google Business Profile OAuth + API helpers. Reuses the existing Google OAuth
@@ -33,33 +35,65 @@ export function gbpOAuthClient(origin: string) {
   );
 }
 
+/**
+ * PKCE pair (RFC 7636). The verifier stays with us in an httpOnly cookie; only
+ * its SHA-256 hash travels to Google. An attacker who intercepts the
+ * authorization code still can't redeem it without the verifier, which closes
+ * the code-injection/impersonation hole Google's "Use secure flows" check
+ * looks for. Recommended for web server flows too, not just installed apps.
+ */
+export function gbpPkcePair(): { verifier: string; challenge: string } {
+  // 32 random bytes → 43 base64url chars, inside RFC 7636's 43–128 range.
+  const verifier = randomBytes(32).toString("base64url");
+  const challenge = createHash("sha256").update(verifier).digest("base64url");
+  return { verifier, challenge };
+}
+
 // Consent URL. access_type=offline + prompt=consent so we always get a refresh
-// token (needed for the ongoing background sync).
-export function gbpAuthUrl(origin: string, state: string): string {
+// token (needed for the ongoing background sync); include_granted_scopes keeps
+// the flow incrementally authorizable, so asking for another scope later never
+// silently drops the ones already granted.
+export function gbpAuthUrl(origin: string, state: string, codeChallenge: string): string {
   return gbpOAuthClient(origin).generateAuthUrl({
     access_type: "offline",
     prompt: "consent",
     include_granted_scopes: true,
     scope: GBP_SCOPES,
     state,
+    code_challenge_method: CodeChallengeMethod.S256,
+    code_challenge: codeChallenge,
   });
 }
 
-export async function gbpExchangeCode(origin: string, code: string) {
-  const { tokens } = await gbpOAuthClient(origin).getToken(code);
+export async function gbpExchangeCode(origin: string, code: string, codeVerifier?: string) {
+  const { tokens } = await gbpOAuthClient(origin).getToken({ code, codeVerifier });
   return tokens;
 }
 
-// Best-effort email of the connected Google account, decoded from the id_token
-// (we requested openid+email). Used only for display ("Connected as …").
-export function emailFromIdToken(idToken?: string | null): string | null {
-  if (!idToken) return null;
+/**
+ * Identity of the connected Google account, decoded from the id_token (we
+ * requested openid+email).
+ *
+ * `email` is for display ("Connected as …"). `sub` is Google's stable user id
+ * and is what Cross-Account Protection events are keyed on — an email can
+ * change, `sub` can't, so a revocation event can only be matched back to a
+ * connection through it. Decoding without signature verification is fine here:
+ * the token came straight from Google's token endpoint over TLS, not from a
+ * client.
+ */
+export function identityFromIdToken(idToken?: string | null): { email: string | null; sub: string | null } {
+  if (!idToken) return { email: null, sub: null };
   try {
     const payload = JSON.parse(Buffer.from(idToken.split(".")[1], "base64").toString("utf8"));
-    return payload.email || null;
+    return { email: payload.email || null, sub: payload.sub || null };
   } catch {
-    return null;
+    return { email: null, sub: null };
   }
+}
+
+/** @deprecated prefer identityFromIdToken — kept so existing callers still work. */
+export function emailFromIdToken(idToken?: string | null): string | null {
+  return identityFromIdToken(idToken).email;
 }
 
 export interface GbpLocation {

--- a/lib/risc.test.ts
+++ b/lib/risc.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { generateKeyPairSync, createSign } from "node:crypto";
+import { verifySecurityEventToken, subjectOf, GOOGLE_ISSUER, REVOCATION_EVENTS } from "@/lib/risc";
+
+// This endpoint is public and unauthenticated by design — Google posts to it
+// with none of our credentials — and a token that gets past verification causes
+// us to delete a user's stored Google credentials. So these tests are less
+// "does it work" than "can a forged token get through": each one signs its own
+// JWT with a throwaway key and tries a different way in.
+
+const AUDIENCE = "test-client-id.apps.googleusercontent.com";
+const KID = "test-key-1";
+
+let privateKey: string;
+let jwks: any[];
+let foreignPrivateKey: string;
+
+const b64url = (input: object | string) =>
+  Buffer.from(typeof input === "string" ? input : JSON.stringify(input)).toString("base64url");
+
+/** Sign a JWT with the given key — mirrors how Google signs a real SET. */
+function signJwt(header: object, payload: object, key: string): string {
+  const segments = `${b64url(header)}.${b64url(payload)}`;
+  const signature = createSign("RSA-SHA256").update(segments).sign(key).toString("base64url");
+  return `${segments}.${signature}`;
+}
+
+const validPayload = (over: object = {}) => ({
+  iss: GOOGLE_ISSUER,
+  aud: AUDIENCE,
+  iat: Math.floor(Date.now() / 1000),
+  jti: "abc123",
+  events: {
+    "https://schemas.openid.net/secevent/risc/event-type/tokens-revoked": {
+      subject: { subject_type: "iss-sub", iss: GOOGLE_ISSUER, sub: "1234567890" },
+    },
+  },
+  ...over,
+});
+
+const keyProvider = async () => jwks;
+
+beforeAll(() => {
+  const pair = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  privateKey = pair.privateKey.export({ type: "pkcs1", format: "pem" }) as string;
+  const jwk = pair.publicKey.export({ format: "jwk" }) as any;
+  jwks = [{ ...jwk, kid: KID, alg: "RS256", use: "sig" }];
+
+  const foreign = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  foreignPrivateKey = foreign.privateKey.export({ type: "pkcs1", format: "pem" }) as string;
+});
+
+describe("verifySecurityEventToken — accepts genuine events", () => {
+  it("accepts a token signed by the advertised key", async () => {
+    const token = signJwt({ alg: "RS256", kid: KID }, validPayload(), privateKey);
+    const payload = await verifySecurityEventToken(token, AUDIENCE, keyProvider);
+    expect(payload).not.toBeNull();
+    expect(payload.iss).toBe(GOOGLE_ISSUER);
+  });
+
+  it("accepts an audience array containing our client", async () => {
+    const token = signJwt({ alg: "RS256", kid: KID }, validPayload({ aud: ["other", AUDIENCE] }), privateKey);
+    expect(await verifySecurityEventToken(token, AUDIENCE, keyProvider)).not.toBeNull();
+  });
+});
+
+describe("verifySecurityEventToken — rejects forgeries", () => {
+  it("rejects a token signed by a key that isn't Google's", async () => {
+    const token = signJwt({ alg: "RS256", kid: KID }, validPayload(), foreignPrivateKey);
+    expect(await verifySecurityEventToken(token, AUDIENCE, keyProvider)).toBeNull();
+  });
+
+  it("rejects a tampered payload", async () => {
+    const token = signJwt({ alg: "RS256", kid: KID }, validPayload(), privateKey);
+    const [h, , s] = token.split(".");
+    const swapped = `${h}.${b64url(validPayload({ jti: "tampered" }))}.${s}`;
+    expect(await verifySecurityEventToken(swapped, AUDIENCE, keyProvider)).toBeNull();
+  });
+
+  it('rejects "alg": "none"', async () => {
+    const unsigned = `${b64url({ alg: "none", kid: KID })}.${b64url(validPayload())}.`;
+    expect(await verifySecurityEventToken(unsigned, AUDIENCE, keyProvider)).toBeNull();
+  });
+
+  it("rejects an algorithm swap to HS256", async () => {
+    const token = signJwt({ alg: "HS256", kid: KID }, validPayload(), privateKey);
+    expect(await verifySecurityEventToken(token, AUDIENCE, keyProvider)).toBeNull();
+  });
+
+  it("rejects an unknown key id", async () => {
+    const token = signJwt({ alg: "RS256", kid: "rotated-away" }, validPayload(), privateKey);
+    expect(await verifySecurityEventToken(token, AUDIENCE, keyProvider)).toBeNull();
+  });
+
+  it("rejects an event addressed to a different app", async () => {
+    const token = signJwt({ alg: "RS256", kid: KID }, validPayload({ aud: "someone-else" }), privateKey);
+    expect(await verifySecurityEventToken(token, AUDIENCE, keyProvider)).toBeNull();
+  });
+
+  it("rejects a non-Google issuer", async () => {
+    const token = signJwt({ alg: "RS256", kid: KID }, validPayload({ iss: "https://evil.example" }), privateKey);
+    expect(await verifySecurityEventToken(token, AUDIENCE, keyProvider)).toBeNull();
+  });
+
+  it("fails closed when no audience is configured", async () => {
+    // A deploy missing GOOGLE_CLIENT_ID must not accept everything.
+    const token = signJwt({ alg: "RS256", kid: KID }, validPayload(), privateKey);
+    expect(await verifySecurityEventToken(token, undefined, keyProvider)).toBeNull();
+  });
+
+  it("rejects malformed tokens instead of throwing", async () => {
+    for (const bad of ["", "not-a-jwt", "a.b", "a.b.c.d", "!!!.???.***"]) {
+      expect(await verifySecurityEventToken(bad, AUDIENCE, keyProvider)).toBeNull();
+    }
+  });
+});
+
+describe("subjectOf", () => {
+  it("reads the stable Google user id", () => {
+    expect(subjectOf({ subject: { subject_type: "iss-sub", sub: "42" } })).toEqual({ sub: "42" });
+  });
+
+  it("falls back to email", () => {
+    expect(subjectOf({ subject: { subject_type: "email", email: "a@b.com" } })).toEqual({ email: "a@b.com" });
+  });
+
+  it("returns nothing identifiable rather than guessing", () => {
+    expect(subjectOf({})).toEqual({});
+    expect(subjectOf({ subject: {} })).toEqual({});
+  });
+});
+
+describe("event coverage", () => {
+  it("handles revocation for every event type we ask Google to send", () => {
+    // Keep in sync with EVENTS_REQUESTED in scripts/register_risc_endpoint.js —
+    // subscribing to an event the receiver ignores means silently dropping it.
+    for (const type of [
+      "https://schemas.openid.net/secevent/oauth/event-type/token-revoked",
+      "https://schemas.openid.net/secevent/risc/event-type/tokens-revoked",
+      "https://schemas.openid.net/secevent/risc/event-type/account-disabled",
+      "https://schemas.openid.net/secevent/risc/event-type/account-purged",
+      "https://schemas.openid.net/secevent/risc/event-type/sessions-revoked",
+      "https://schemas.openid.net/secevent/risc/event-type/account-credential-change-required",
+    ]) {
+      expect(REVOCATION_EVENTS.has(type), type).toBe(true);
+    }
+  });
+});

--- a/lib/risc.ts
+++ b/lib/risc.ts
@@ -1,0 +1,114 @@
+import { createPublicKey, verify as cryptoVerify } from "node:crypto";
+
+/**
+ * Verification for Google Cross-Account Protection (RISC) security event
+ * tokens.
+ *
+ * This lives apart from the route handler for one reason: it is the ONLY thing
+ * standing between an unauthenticated public endpoint and code that deletes
+ * users' stored credentials. Google posts these events with none of our
+ * credentials attached, so the JWT signature is the authentication — which
+ * means this logic has to be directly testable, and it is
+ * (lib/risc.test.ts signs tokens with a throwaway key and tries to sneak them
+ * past every check below).
+ */
+
+const RISC_CONFIG_URL = "https://accounts.google.com/.well-known/risc-configuration";
+export const GOOGLE_ISSUER = "https://accounts.google.com";
+
+/** Events that mean "this connection is dead — stop using it." */
+export const REVOCATION_EVENTS = new Set([
+  "https://schemas.openid.net/secevent/oauth/event-type/token-revoked",
+  "https://schemas.openid.net/secevent/risc/event-type/tokens-revoked",
+  "https://schemas.openid.net/secevent/risc/event-type/account-disabled",
+  "https://schemas.openid.net/secevent/risc/event-type/account-purged",
+  "https://schemas.openid.net/secevent/risc/event-type/sessions-revoked",
+  "https://schemas.openid.net/secevent/risc/event-type/account-credential-change-required",
+]);
+
+/** Sent by Google on request, purely to prove the endpoint works. */
+export const VERIFICATION_EVENT = "https://schemas.openid.net/secevent/risc/event-type/verification";
+
+export type JwkProvider = () => Promise<any[]>;
+
+let jwksCache: { keys: any[]; fetchedAt: number } | null = null;
+const JWKS_TTL_MS = 60 * 60 * 1000;
+
+/** Google's current RISC signing keys, cached — they rotate, but not per-request. */
+export const googleRiscKeys: JwkProvider = async () => {
+  if (jwksCache && Date.now() - jwksCache.fetchedAt < JWKS_TTL_MS) return jwksCache.keys;
+  const config = await fetch(RISC_CONFIG_URL).then((r) => r.json());
+  const jwks = await fetch(config.jwks_uri).then((r) => r.json());
+  jwksCache = { keys: jwks.keys || [], fetchedAt: Date.now() };
+  return jwksCache.keys;
+};
+
+const decodeSegment = (seg: string) => JSON.parse(Buffer.from(seg, "base64url").toString("utf8"));
+
+/**
+ * Verify a security event token's signature and claims.
+ * Returns the payload, or null if anything is off — callers must treat null as
+ * "discard, this did not come from Google."
+ */
+export async function verifySecurityEventToken(
+  token: string,
+  audience: string | undefined,
+  keys: JwkProvider = googleRiscKeys
+): Promise<any | null> {
+  // No audience configured means we cannot prove an event was meant for us, so
+  // nothing is trusted. Failing closed matters more than staying available on a
+  // misconfigured deploy.
+  if (!audience) return null;
+
+  const parts = token.split(".");
+  if (parts.length !== 3) return null;
+  const [headerSeg, payloadSeg, signatureSeg] = parts;
+
+  let header: any;
+  try {
+    header = decodeSegment(headerSeg);
+  } catch {
+    return null;
+  }
+  // Pin the algorithm. Trusting the token's own `alg` is how "alg: none" and
+  // RS256→HS256 confusion attacks work.
+  if (header.alg !== "RS256") return null;
+
+  const key = (await keys()).find((k) => k.kid === header.kid);
+  if (!key) return null;
+
+  let signatureValid = false;
+  try {
+    signatureValid = cryptoVerify(
+      "RSA-SHA256",
+      Buffer.from(`${headerSeg}.${payloadSeg}`),
+      createPublicKey({ key, format: "jwk" }),
+      Buffer.from(signatureSeg, "base64url")
+    );
+  } catch {
+    return null; // malformed key or signature
+  }
+  if (!signatureValid) return null;
+
+  let payload: any;
+  try {
+    payload = decodeSegment(payloadSeg);
+  } catch {
+    return null;
+  }
+  if (payload.iss !== GOOGLE_ISSUER) return null;
+  // Audience is our OAuth client — this is what stops a validly-signed event
+  // meant for some other Google app from touching our data.
+  const auds = Array.isArray(payload.aud) ? payload.aud : [payload.aud];
+  if (!auds.includes(audience)) return null;
+
+  return payload;
+}
+
+/** Google identifies the account by iss+sub, occasionally by email. */
+export function subjectOf(event: any): { sub?: string; email?: string } {
+  const subject = event?.subject || {};
+  if (subject.sub) return { sub: subject.sub };
+  if (subject.email) return { email: subject.email };
+  return {};
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -88,6 +88,14 @@ export default async function proxy(request: NextRequest) {
         return NextResponse.next()
     }
 
+    // Google's Cross-Account Protection receiver. Deliveries arrive from Google
+    // with no cookies, so a Supabase session lookup here is pure latency on a
+    // webhook — and the handler authenticates each delivery by verifying its
+    // JWT signature, which is stronger than anything the middleware could add.
+    if (pathname === '/api/security/risc') {
+        return NextResponse.next()
+    }
+
     // Parametered variants of the barbershop search tool (?ecosystemShopId=…,
     // ?q=…, ?tab=…, ?ghl_contact_id=…) are functional deep-links, not distinct
     // indexable pages. The clean /tools/barbershop-search already carries a

--- a/scripts/register_risc_endpoint.js
+++ b/scripts/register_risc_endpoint.js
@@ -1,0 +1,161 @@
+// Registers (or inspects) our Cross-Account Protection event stream with
+// Google — the step that makes app/api/security/risc/route.ts actually receive
+// anything. Until this runs, the endpoint is live but Google has never been
+// told to push to it, and the Project Checkup keeps warning.
+//
+// PREREQUISITES, in the Cloud project that owns the OAuth client:
+//   1. Enable the RISC API.
+//   2. Create a service account, give it the "RISC Configuration Admin" role,
+//      and download its JSON key.
+//   3. Point GOOGLE_APPLICATION_CREDENTIALS at that key file (or set
+//      RISC_SERVICE_ACCOUNT_JSON to the key's contents).
+//   4. Register the SAME OAuth client the app uses — the receiver rejects
+//      events whose audience isn't GOOGLE_CLIENT_ID.
+//
+// Usage:
+//   node scripts/register_risc_endpoint.js            # show current stream config
+//   node scripts/register_risc_endpoint.js --update   # point the stream at our endpoint
+//   node scripts/register_risc_endpoint.js --verify   # ask Google to send a test event
+//
+// After --verify, look for "[risc] verification event received" in the
+// production logs. That round trip is the proof the whole path works.
+
+require('dotenv').config({ path: '.env.local' });
+const { createSign } = require('crypto');
+
+// RISC does NOT take an ordinary OAuth access token. It wants a JWT the service
+// account signs for RISC's own audience, sent straight through as the bearer —
+// an exchanged access token comes back 401 UNAUTHENTICATED, and a scope-based
+// google-auth-library JWT client silently yields "Bearer undefined". Both were
+// tried against the live API before landing here.
+const RISC_AUDIENCE = 'https://risc.googleapis.com/google.identity.risc.v1beta.RiscManagementService';
+const STREAM_URL = 'https://risc.googleapis.com/v1beta/stream';
+const ENDPOINT =
+  process.env.RISC_RECEIVER_URL || 'https://agency.innergcomplete.com/api/security/risc';
+
+// Must stay in sync with REVOCATION_EVENTS in app/api/security/risc/route.ts —
+// asking for events the receiver ignores just adds noise.
+const EVENTS_REQUESTED = [
+  'https://schemas.openid.net/secevent/oauth/event-type/token-revoked',
+  'https://schemas.openid.net/secevent/risc/event-type/tokens-revoked',
+  'https://schemas.openid.net/secevent/risc/event-type/account-disabled',
+  'https://schemas.openid.net/secevent/risc/event-type/account-purged',
+  'https://schemas.openid.net/secevent/risc/event-type/sessions-revoked',
+  'https://schemas.openid.net/secevent/risc/event-type/account-credential-change-required',
+];
+
+// Key lookup, most specific first. risc-service-key.json in the repo root is
+// the convention here — it's gitignored, and it's deliberately NOT
+// GOOGLE_APPLICATION_CREDENTIALS, which already points at a different
+// service account used for other Google APIs.
+const DEFAULT_KEY_FILE = 'risc-service-key.json';
+
+function serviceAccount() {
+  if (process.env.RISC_SERVICE_ACCOUNT_JSON) return JSON.parse(process.env.RISC_SERVICE_ACCOUNT_JSON);
+
+  const path = require('path');
+  const fs = require('fs');
+  const candidates = [
+    process.env.RISC_SERVICE_ACCOUNT_FILE,
+    path.resolve(process.cwd(), DEFAULT_KEY_FILE),
+    process.env.GOOGLE_APPLICATION_CREDENTIALS,
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    const resolved = path.resolve(candidate);
+    if (fs.existsSync(resolved)) return require(resolved);
+  }
+  throw new Error(
+    `No service-account key found. Put one at ./${DEFAULT_KEY_FILE}, or set RISC_SERVICE_ACCOUNT_FILE / RISC_SERVICE_ACCOUNT_JSON.`
+  );
+}
+
+const b64url = (obj) => Buffer.from(JSON.stringify(obj)).toString('base64url');
+
+/** Self-signed service-account JWT addressed to the RISC service. */
+function riscBearer() {
+  const key = serviceAccount();
+  const now = Math.floor(Date.now() / 1000);
+  const segments =
+    `${b64url({ alg: 'RS256', typ: 'JWT', kid: key.private_key_id })}.` +
+    `${b64url({ iss: key.client_email, sub: key.client_email, aud: RISC_AUDIENCE, iat: now, exp: now + 3600 })}`;
+  const signature = createSign('RSA-SHA256').update(segments).sign(key.private_key).toString('base64url');
+  return `${segments}.${signature}`;
+}
+
+async function call(method, url, body) {
+  const res = await fetch(url, {
+    method,
+    headers: { Authorization: `Bearer ${riscBearer()}`, 'Content-Type': 'application/json' },
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let parsed;
+  try { parsed = JSON.parse(text); } catch { parsed = text; }
+  return { ok: res.ok, status: res.status, body: parsed };
+}
+
+async function main() {
+  const mode = process.argv.includes('--update') ? 'update'
+    : process.argv.includes('--verify') ? 'verify'
+    : 'show';
+
+  if (mode === 'show') {
+    const r = await call('GET', STREAM_URL);
+    console.log(`GET stream → ${r.status}`);
+    console.log(JSON.stringify(r.body, null, 2));
+    // 404 no_risc_configuration is the normal "never set up" answer, not a
+    // failure — and it proves auth worked, since a bad key 401s instead.
+    if (r.body?.err === 'no_risc_configuration') {
+      console.log('\nAuthenticated fine — this project just has no RISC stream yet. Run with --update.');
+    } else if (r.ok && !r.body?.delivery?.delivery_uri && !r.body?.delivery?.url) {
+      console.log('\nNo delivery endpoint configured yet. Run with --update.');
+    }
+    return;
+  }
+
+  if (mode === 'update') {
+    // Preflight: registering a URL that isn't live means Google pushes real
+    // security events into a 404, and enough failed deliveries get the stream
+    // disabled. A deployed receiver answers 400/401 to this junk body (it
+    // rejects the unsigned token); a 404 means it simply isn't there yet.
+    const probe = await fetch(ENDPOINT, { method: 'POST', body: 'preflight' })
+      .then((r) => r.status)
+      .catch(() => 0);
+    if (probe === 404 || probe === 0) {
+      console.error(
+        `Refusing to register: ${ENDPOINT} responded ${probe || 'not reachable'}.\n` +
+          'Deploy the receiver first (app/api/security/risc), then re-run this.'
+      );
+      process.exit(1);
+    }
+    console.log(`Receiver responded ${probe} to a preflight — it's live.`);
+    console.log(`Pointing the RISC stream at: ${ENDPOINT}`);
+    const r = await call('POST', `${STREAM_URL}:update`, {
+      delivery: {
+        delivery_method: 'https://schemas.openid.net/secevent/risc/delivery-method/push',
+        url: ENDPOINT,
+      },
+      events_requested: EVENTS_REQUESTED,
+    });
+    console.log(`stream:update → ${r.status}`);
+    console.log(JSON.stringify(r.body, null, 2));
+    if (r.ok) console.log('\nNow run with --verify to make Google send a test event.');
+    return;
+  }
+
+  // Google echoes this state back inside the verification event, so it's
+  // traceable in the receiver's logs.
+  const state = `risc-check-${process.pid}`;
+  const r = await call('POST', `${STREAM_URL}:verify`, { state });
+  console.log(`stream:verify → ${r.status} (state: ${state})`);
+  console.log(JSON.stringify(r.body, null, 2));
+  if (r.ok) {
+    console.log(`\nCheck the production logs for: [risc] verification event received (state: ${state})`);
+  }
+}
+
+main().catch((e) => {
+  console.error('Failed:', e.message);
+  process.exit(1);
+});

--- a/supabase/functions/complete-youtube-auth/index.ts
+++ b/supabase/functions/complete-youtube-auth/index.ts
@@ -3,7 +3,15 @@ import { createHandler, z, Logger, okResponse, YouTubeProvider } from "../_share
 // 🛡️ Auth callback schema
 const YouTubeAuthSchema = z.object({
     code: z.string(),
-    state: z.string(), // Expected format: projectId:UUID__visitor:UUID
+    // `state` is now an opaque CSRF nonce the browser validates against its own
+    // sessionStorage before calling us (it used to be `projectId:…__visitor:…`,
+    // which was predictable and never checked). The ids therefore arrive as
+    // their own fields; the legacy state parsing below stays as a fallback so a
+    // flow started before this shipped still completes.
+    state: z.string(),
+    projectId: z.string().optional(),
+    visitorId: z.string().nullable().optional(),
+    codeVerifier: z.string().optional(), // PKCE
     redirectUri: z.string().optional()
 })
 
@@ -14,11 +22,14 @@ const YouTubeAuthSchema = z.object({
 export default createHandler(async ({ adminClient, body, user }) => {
     const logger = new Logger("complete-youtube-auth")
     
-    // 1. Parse State
+    // 1. Resolve project/visitor — from the explicit fields the callback now
+    // sends, falling back to the legacy `projectId:…__visitor:…` state format.
     const stateParts = (body.state as string).split('__')
-    const projectIdPart = stateParts.find((p: string) => p.startsWith('projectId:'))?.split(':')[1]
-    const visitorIdPart = stateParts.find((p: string) => p.startsWith('visitor:'))?.split(':')[1]
-    
+    const projectIdPart = body.projectId
+        || stateParts.find((p: string) => p.startsWith('projectId:'))?.split(':')[1]
+    const visitorIdPart = body.visitorId
+        || stateParts.find((p: string) => p.startsWith('visitor:'))?.split(':')[1]
+
     if (!projectIdPart) throw new Error("Missing projectId in state")
     const realProjectId = projectIdPart
     
@@ -59,7 +70,11 @@ export default createHandler(async ({ adminClient, body, user }) => {
             client_secret: GOOGLE_CLIENT_SECRET!,
             code: body.code,
             grant_type: "authorization_code",
-            redirect_uri: redirectUri
+            redirect_uri: redirectUri,
+            // PKCE: Google rejects the exchange unless this hashes to the
+            // code_challenge sent at consent time. Optional so a flow started
+            // before PKCE shipped can still finish.
+            ...(body.codeVerifier ? { code_verifier: body.codeVerifier } : {})
         })
     })
 

--- a/supabase/migrations/20260728150000_add_gbp_google_user_id.sql
+++ b/supabase/migrations/20260728150000_add_gbp_google_user_id.sql
@@ -1,0 +1,17 @@
+-- Google's stable user id (the id_token `sub`) for a GBP connection.
+--
+-- Needed for Cross-Account Protection: the security events Google pushes to us
+-- (token revoked, account disabled/purged, sessions revoked) identify the person
+-- by `iss` + `sub`, not by email. We only stored google_account_email, which is
+-- both mutable and not what the events carry, so an incoming revocation had
+-- nothing to match against. `sub` never changes for a Google account, even if
+-- the address does.
+--
+-- Nullable and backfilled naturally: existing connections pick it up the next
+-- time their owner reconnects. Until then those rows fall back to email matching
+-- in the RISC receiver, which is best-effort.
+ALTER TABLE public.gbp_connections
+  ADD COLUMN IF NOT EXISTS google_user_id text;
+
+CREATE INDEX IF NOT EXISTS gbp_connections_google_user_idx
+  ON public.gbp_connections (google_user_id);


### PR DESCRIPTION
…or Google OAuth

Clears the three warnings on Google's OAuth Project Checkup, and closes a real hole found along the way.

Use secure flows — PKCE on both Google flows. GBP keeps the verifier in an httpOnly cookie beside the state nonce; the YouTube flow keeps it in sessionStorage, since a browser-initiated flow can't set an httpOnly cookie. An intercepted authorization code is now useless on its own.

The YouTube flow's `state` was `projectId:…__visitor:…` — predictable, and the callback never checked it. Anyone could hand a signed-in user a forged callback URL and attach their own Google account to that project. It's now an unguessable nonce the callback matches against its own sessionStorage, with the ids moved into that stash instead of the URL.

Incremental authorization — that same client requested six scopes with no include_granted_scopes, which is what tripped the check (GBP already set it). Added, and dropped the unused `openid` scope. youtube.force-ssl LOOKS like removable write access but connector-sync's caption fetch 403s without it, so it stays.

Cross-Account Protection — new receiver at /api/security/risc. Google pushes signed security event tokens when a linked account revokes access or is disabled/purged, and we act on them by revoking the connection and nulling its tokens. This matters here because gbp_connections holds long-lived refresh tokens: without it, a user who disconnects us from their Google settings leaves us holding a dead token forever, still showing "connected".

The endpoint is unauthenticated by necessity — Google posts with none of our credentials — so the JWT signature is the authentication. Verifying it lives in lib/risc.ts rather than the route so it can be tested, and lib/risc.test.ts attacks it: foreign signing key, tampered payload, alg:none, RS256→HS256 confusion, unknown kid, wrong audience, wrong issuer, malformed input. It pins RS256, requires iss=accounts.google.com and aud=GOOGLE_CLIENT_ID, and fails closed when that env var is missing.

Migration 20260728150000 adds gbp_connections.google_user_id (applied): RISC events key on the id_token `sub`, not email, so without it an incoming revocation had nothing to match. Existing rows backfill on the owner's next reconnect and fall back to email matching until then.

scripts/register_risc_endpoint.js registers the stream. Note its auth: RISC does not take an exchanged access token (401 UNAUTHENTICATED) and google-auth-library's scoped JWT client silently yields "Bearer undefined" — it needs a JWT signed for RISC's own audience, passed straight through. Both wrong paths were tried against the live API. The --update mode refuses to register an endpoint that 404s, so nobody points Google's event stream at an undeployed URL.

Also widened the .gitignore rule for the service-account key: it was listed only in uppercase and matched purely because macOS is case-insensitive. On Linux the real lowercase filename would not have matched, making the private key committable.


Claude-Session: https://claude.ai/code/session_01RTF3ibrf1oSQ8sHtx969wf