### PR TITLE
fix(security): correct the RISC event types Google actually delivers

### DIFF
--- a/lib/risc.test.ts
+++ b/lib/risc.test.ts
@@ -132,13 +132,14 @@ describe("subjectOf", () => {
 
 describe("event coverage", () => {
   it("handles revocation for every event type we ask Google to send", () => {
-    // Keep in sync with EVENTS_REQUESTED in scripts/register_risc_endpoint.js —
-    // subscribing to an event the receiver ignores means silently dropping it.
+    // Exactly the URIs in EVENTS_REQUESTED (scripts/register_risc_endpoint.js),
+    // which are in turn exactly what Google's live `events_supported` offers.
+    // The plural `tokens-revoked` is under the OAUTH namespace, not risc — the
+    // first registration got that wrong and Google dropped it silently.
     for (const type of [
       "https://schemas.openid.net/secevent/oauth/event-type/token-revoked",
-      "https://schemas.openid.net/secevent/risc/event-type/tokens-revoked",
+      "https://schemas.openid.net/secevent/oauth/event-type/tokens-revoked",
       "https://schemas.openid.net/secevent/risc/event-type/account-disabled",
-      "https://schemas.openid.net/secevent/risc/event-type/account-purged",
       "https://schemas.openid.net/secevent/risc/event-type/sessions-revoked",
       "https://schemas.openid.net/secevent/risc/event-type/account-credential-change-required",
     ]) {

--- a/lib/risc.ts
+++ b/lib/risc.ts
@@ -16,14 +16,33 @@ import { createPublicKey, verify as cryptoVerify } from "node:crypto";
 const RISC_CONFIG_URL = "https://accounts.google.com/.well-known/risc-configuration";
 export const GOOGLE_ISSUER = "https://accounts.google.com";
 
-/** Events that mean "this connection is dead — stop using it." */
+/**
+ * Events that mean "this connection is dead — stop using it."
+ *
+ * Every URI here was taken from the live `events_supported` list Google
+ * returned when the stream was registered, not from guesswork. Two corrections
+ * came out of that: plural `tokens-revoked` lives under the **oauth**
+ * namespace, not `risc` (getting it wrong is silent — Google just omits it from
+ * events_delivered), and `account-purged` isn't offered at all.
+ *
+ * The plural one is the important one: it's what fires when a user hits
+ * "Remove access" in their Google account settings, which is the main case this
+ * whole feature exists to catch.
+ *
+ * The legacy accounts.google.com aliases are accepted too, since Google still
+ * lists them as supported and they'd otherwise fall through as "unhandled".
+ */
 export const REVOCATION_EVENTS = new Set([
-  "https://schemas.openid.net/secevent/oauth/event-type/token-revoked",
-  "https://schemas.openid.net/secevent/risc/event-type/tokens-revoked",
+  "https://schemas.openid.net/secevent/oauth/event-type/token-revoked",   // one token
+  "https://schemas.openid.net/secevent/oauth/event-type/tokens-revoked",  // all tokens
   "https://schemas.openid.net/secevent/risc/event-type/account-disabled",
-  "https://schemas.openid.net/secevent/risc/event-type/account-purged",
   "https://schemas.openid.net/secevent/risc/event-type/sessions-revoked",
   "https://schemas.openid.net/secevent/risc/event-type/account-credential-change-required",
+  "https://accounts.google.com/risc/event/one-token-revoked",
+  "https://accounts.google.com/risc/event/all-token-revoked",
+  "https://accounts.google.com/risc/event/account-disabled",
+  "https://accounts.google.com/risc/event/sessions-revoked",
+  "https://accounts.google.com/risc/event/account-credential-change-required",
 ]);
 
 /** Sent by Google on request, purely to prove the endpoint works. */

--- a/scripts/register_risc_endpoint.js
+++ b/scripts/register_risc_endpoint.js
@@ -33,13 +33,19 @@ const STREAM_URL = 'https://risc.googleapis.com/v1beta/stream';
 const ENDPOINT =
   process.env.RISC_RECEIVER_URL || 'https://agency.innergcomplete.com/api/security/risc';
 
-// Must stay in sync with REVOCATION_EVENTS in app/api/security/risc/route.ts —
-// asking for events the receiver ignores just adds noise.
+// Must stay in sync with REVOCATION_EVENTS in lib/risc.ts.
+//
+// These are exactly the URIs Google reports under `events_supported` — verified
+// against the live stream, because requesting an unsupported one FAILS SILENTLY:
+// the call still returns 200 and Google simply leaves it out of
+// `events_delivered`. The first registration attempt asked for
+// `risc/event-type/tokens-revoked` (wrong namespace — it's `oauth/…`) and
+// `account-purged` (not offered), and both vanished without an error. The
+// script now diffs requested against delivered so that can't pass unnoticed.
 const EVENTS_REQUESTED = [
-  'https://schemas.openid.net/secevent/oauth/event-type/token-revoked',
-  'https://schemas.openid.net/secevent/risc/event-type/tokens-revoked',
+  'https://schemas.openid.net/secevent/oauth/event-type/token-revoked',   // one token
+  'https://schemas.openid.net/secevent/oauth/event-type/tokens-revoked',  // all tokens ("Remove access")
   'https://schemas.openid.net/secevent/risc/event-type/account-disabled',
-  'https://schemas.openid.net/secevent/risc/event-type/account-purged',
   'https://schemas.openid.net/secevent/risc/event-type/sessions-revoked',
   'https://schemas.openid.net/secevent/risc/event-type/account-credential-change-required',
 ];
@@ -140,7 +146,23 @@ async function main() {
     });
     console.log(`stream:update → ${r.status}`);
     console.log(JSON.stringify(r.body, null, 2));
-    if (r.ok) console.log('\nNow run with --verify to make Google send a test event.');
+
+    if (r.ok) {
+      // Google accepts unsupported event types with a 200 and just drops them.
+      // Surface the difference rather than letting a typo quietly cost us the
+      // one event that mattered.
+      const delivered = new Set(r.body?.events_delivered || []);
+      const dropped = EVENTS_REQUESTED.filter((e) => !delivered.has(e));
+      if (dropped.length) {
+        console.error('\nWARNING — Google did NOT accept these event types:');
+        dropped.forEach((e) => console.error(`  • ${e}`));
+        console.error('Check them against `events_supported` above; a wrong namespace fails silently.');
+        process.exitCode = 1;
+      } else {
+        console.log(`\nAll ${EVENTS_REQUESTED.length} requested event types accepted.`);
+        console.log('Now run with --verify to make Google send a test event.');
+      }
+    }
     return;
   }
 
@@ -152,6 +174,21 @@ async function main() {
   console.log(JSON.stringify(r.body, null, 2));
   if (r.ok) {
     console.log(`\nCheck the production logs for: [risc] verification event received (state: ${state})`);
+    return;
+  }
+  if (r.status === 403) {
+    // Seen in practice: stream:update succeeds (it only stores config) while
+    // stream:verify 403s, because verify is the first call that asks Google to
+    // actually DELIVER to the endpoint — which is where domain authorization
+    // gets enforced. Same credentials, same role, different gate.
+    console.error(
+      '\n403 on verify while update succeeded usually means the delivery domain\n' +
+        "isn't authorized for this project. Check, in Google Cloud Console:\n" +
+        '  • Google Auth Platform → Branding → Authorized domains includes innergcomplete.com\n' +
+        '  • that domain is verified in Search Console under the same Google account\n' +
+        '  • the service account still holds roles/riscconfigs.admin\n' +
+        'The stream config itself is already stored — re-run --verify after fixing.'
+    );
   }
 }
 


### PR DESCRIPTION
Registering the stream revealed that two of the six event types we asked for were never accepted — and Google says so only by omission. The call returns 200 and quietly leaves them out of `events_delivered`:

  • tokens-revoked was requested under the risc/ namespace; Google
    supports it as oauth/event-type/tokens-revoked
  • account-purged isn't in events_supported at all

The plural tokens-revoked is the one that matters most: it's what fires when a user clicks "Remove access" in their Google account settings, which is the case this feature exists to catch. We'd have shipped believing we handled it.

Requested types are now exactly what the live events_supported offers, the receiver additionally accepts the legacy accounts.google.com aliases Google still lists, and --update diffs requested against delivered and exits non-zero if anything was dropped, so a namespace typo can't pass unnoticed again.

Also: stream:verify returns 403 while stream:update succeeds with the same service account. update only stores config; verify is the first call that asks Google to deliver to the endpoint, which is where delivery domain authorization is enforced. The script now explains that instead of printing a bare permission error.


Claude-Session: https://claude.ai/code/session_01RTF3ibrf1oSQ8sHtx969wf