### PR TITLE
feat(gbp): cover photo, durable image copies, live Google reviews, po…

### DIFF
--- a/app/api/google-business/performance/route.ts
+++ b/app/api/google-business/performance/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { createServerClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { gbpAccessToken, gbpFetchPerformance } from "@/lib/google-business";
+
+/**
+ * Google's own performance numbers for the owner's claimed listing — how many
+ * people saw it on Search and Maps, and how many called, asked for directions,
+ * or clicked through to the website.
+ *
+ * Deliberately live rather than stored: it's a rolling 30-day window that
+ * changes daily, and persisting a snapshot would just create a number that goes
+ * stale and misleads. Sits alongside our first-party pixel data rather than
+ * replacing it — this is what happened ON Google, before anyone reached us.
+ */
+export async function GET() {
+  const supabase = await createServerClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ available: false });
+
+  const admin = createAdminClient();
+  const { data: member } = await admin
+    .from("community_members")
+    .select("id")
+    .eq("user_id", user.id)
+    .maybeSingle();
+  if (!member) return NextResponse.json({ available: false });
+
+  const { data: conn } = await (admin.from("gbp_connections") as any)
+    .select("refresh_token, selected_location, status")
+    .eq("community_member_id", (member as any).id)
+    .maybeSingle();
+
+  if (!conn?.refresh_token || conn.status === "revoked" || !conn.selected_location) {
+    return NextResponse.json({ available: false });
+  }
+
+  try {
+    const accessToken = await gbpAccessToken(conn.refresh_token);
+    const performance = await gbpFetchPerformance(accessToken, conn.selected_location);
+    if (!performance) return NextResponse.json({ available: false });
+    return NextResponse.json({ available: true, performance });
+  } catch {
+    return NextResponse.json({ available: false });
+  }
+}

--- a/app/api/google-business/sync/route.ts
+++ b/app/api/google-business/sync/route.ts
@@ -7,6 +7,8 @@ import {
   gbpFetchLocations,
   gbpFetchPhotos,
   gbpFetchReviews,
+  pickCoverPhoto,
+  cacheGbpPhotos,
   type GbpLocation,
 } from "@/lib/google-business";
 
@@ -137,10 +139,35 @@ export async function POST() {
   const notes: string[] = [];
   const imagesField = "google_images" in entity ? "google_images" : "google_photos" in entity ? "google_photos" : null;
 
-  if (imagesField && isBlank(entity[imagesField])) {
+  // Google's lh3 links aren't durable, so a listing already holding them counts
+  // as needing photos even though the column isn't empty — otherwise the rows
+  // synced before caching existed would keep expiring links forever.
+  const holdsGoogleUrls =
+    !!imagesField &&
+    Array.isArray(entity[imagesField]) &&
+    entity[imagesField].some((u: any) => typeof u === "string" && u.includes("googleusercontent.com"));
+  const needsPhotos = !!imagesField && (isBlank(entity[imagesField]) || holdsGoogleUrls);
+  const needsHero = "shop_image_url" in entity && isBlank(entity.shop_image_url);
+  if (needsPhotos || needsHero) {
     const media = await gbpFetchPhotos(accessToken, loc.name, loc.account);
-    if (media.disabled) notes.push("Photos need the Google My Business API enabled on the Cloud project.");
-    else if (media.photos.length) candidates[imagesField] = media.photos;
+    if (media.disabled) {
+      notes.push("Photos need the Google My Business API enabled on the Cloud project.");
+    } else if (media.photos.length) {
+      // Cover first, so the profile hero is the image the owner chose as their
+      // cover rather than whatever happened to come back first.
+      const cover = pickCoverPhoto(media.photos);
+      const ordered = [
+        ...(cover ? [cover] : []),
+        ...media.photos.map((p) => p.url).filter((u) => u !== cover),
+      ];
+      const durable = await cacheGbpPhotos(admin, conn.entity_id, ordered);
+      if (durable.length) {
+        if (needsPhotos && imagesField) candidates[imagesField] = durable;
+        if (needsHero) candidates.shop_image_url = durable[0];
+      } else {
+        notes.push("Couldn't copy the Google photos into storage — none were saved.");
+      }
+    }
   }
   if (isBlank(entity.rating) || isBlank(entity.total_reviews)) {
     const reviews = await gbpFetchReviews(accessToken, loc.name, loc.account);
@@ -156,11 +183,16 @@ export async function POST() {
   if (fields.amenities) candidates[fields.amenities] = loc.services?.length ? loc.services : null;
   if (fields.hours) candidates[fields.hours] = loc.hours;
 
+  // Columns allowed to overwrite an existing value. Only the image list, and
+  // only to replace expiring Google URLs with our own copies — everything else
+  // stays fill-only, because the owner's edits outrank Google.
+  const overwritable = new Set<string>(holdsGoogleUrls && imagesField ? [imagesField] : []);
+
   const patch: Record<string, any> = {};
   for (const [column, value] of Object.entries(candidates)) {
     if (isBlank(value)) continue;
     if (!(column in entity)) continue;      // table doesn't have it
-    if (!isBlank(entity[column])) continue; // owner (or an earlier sync) already filled it
+    if (!isBlank(entity[column]) && !overwritable.has(column)) continue; // owner already filled it
     patch[column] = value;
   }
 

--- a/app/salons/[slug]/page.tsx
+++ b/app/salons/[slug]/page.tsx
@@ -8,6 +8,8 @@ import { Navbar } from "@/components/layout/navbar";
 import { ClaimShopButton } from "@/components/shared/claim-shop-button";
 import { WriteReviewButton } from "@/components/shared/write-review-button";
 import { ReviewsSection } from "@/components/shared/reviews-section";
+import { GoogleReviews } from "@/components/shared/google-reviews";
+import { GooglePosts } from "@/components/shared/google-posts";
 import { ShopPhotoGallery } from "@/components/shared/shop-photo-gallery";
 import { NearbyEntitiesSection } from "@/components/shared/nearby-entities-section";
 import { SalonSponsoredAd } from "@/components/ads/SalonSponsoredAd";
@@ -467,6 +469,12 @@ export default async function SalonProfilePage(props: { params: Promise<{ slug: 
               entityName={salon.shop_name}
               action={<WriteReviewButton entityType="salon" entityId={salon.id} entityName={salon.shop_name} />}
             />
+
+            {/* Google reviews for an owner who connected their Business Profile.
+                Fetched live (never stored — Google's terms restrict caching
+                review content) and renders nothing when there's no connection. */}
+            <GooglePosts entityType="salon" entityId={salon.id} />
+            <GoogleReviews entityType="salon" entityId={salon.id} />
 
             {/* Your Market Ecosystem — salon/cosmetology side of the market only */}
             {ecosystemReport && (() => {

--- a/app/shop/[slug]/page.tsx
+++ b/app/shop/[slug]/page.tsx
@@ -10,6 +10,8 @@ import { buildEntityBreadcrumbJsonLd } from "@/lib/breadcrumb-jsonld";
 import { ClaimShopButton } from "@/components/shared/claim-shop-button";
 import { WriteReviewButton } from "@/components/shared/write-review-button";
 import { ReviewsSection } from "@/components/shared/reviews-section";
+import { GoogleReviews } from "@/components/shared/google-reviews";
+import { GooglePosts } from "@/components/shared/google-posts";
 import { NearbyEntitiesSection } from "@/components/shared/nearby-entities-section";
 import { ShopSponsoredAd } from "@/components/ads/ShopSponsoredAd";
 import { DynamicBackButton } from "@/components/shared/dynamic-back-button";
@@ -520,6 +522,12 @@ export default async function ShopProfilePage({ params }: Props) {
               entityName={shop.shop_name}
               action={<WriteReviewButton entityType="shop" entityId={shop.id} entityName={shop.shop_name} />}
             />
+
+            {/* Google reviews for an owner who connected their Business Profile.
+                Fetched live (never stored — Google's terms restrict caching
+                review content) and renders nothing when there's no connection. */}
+            <GooglePosts entityType="shop" entityId={shop.id} />
+            <GoogleReviews entityType="shop" entityId={shop.id} />
 
             {/* Your Market Ecosystem — barbershop side of the market only */}
             {ecosystemReport && (() => {

--- a/components/account/connect-google-business.tsx
+++ b/components/account/connect-google-business.tsx
@@ -46,6 +46,7 @@ export function ConnectGoogleBusiness() {
   const [retyping, setRetyping] = useState<string | null>(null);
   const [types, setTypes] = useState<{ key: string; label: string }[]>([]);
   const [syncing, setSyncing] = useState(false);
+  const [perf, setPerf] = useState<{ callClicks: number; websiteClicks: number; directionRequests: number; impressions: number; days: number } | null>(null);
 
   const refreshStatus = () =>
     fetch("/api/google-business/status", { credentials: "include" })
@@ -131,6 +132,13 @@ export function ConnectGoogleBusiness() {
       toast.error("Google Business Profile connect isn't configured on this site yet. We've been notified.");
     else if (p === "error") toast.error("Couldn't connect Google Business Profile. Please try again.");
     else if (p === "nomember") toast.error("Finish creating your membership first, then connect.");
+
+    // Google's own numbers for the listing — what happened on Search/Maps
+    // before anyone ever reached us. Silent when unavailable.
+    fetch("/api/google-business/performance", { credentials: "include" })
+      .then((r) => r.json())
+      .then((d) => d.available && setPerf(d.performance))
+      .catch(() => {});
 
     fetch("/api/google-business/business-type")
       .then((r) => r.json())
@@ -247,6 +255,20 @@ export function ConnectGoogleBusiness() {
                 })}
               </ul>
             )}
+          {perf && (
+            <div className="mt-3 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2">
+              <p className="text-[11px] font-black uppercase tracking-wider text-slate-500">
+                On Google · last {perf.days} days
+              </p>
+              <div className="mt-1 flex flex-wrap gap-x-5 gap-y-1 text-xs text-slate-600">
+                <span><b className="text-slate-900">{perf.impressions.toLocaleString()}</b> views</span>
+                <span><b className="text-slate-900">{perf.callClicks.toLocaleString()}</b> calls</span>
+                <span><b className="text-slate-900">{perf.websiteClicks.toLocaleString()}</b> website clicks</span>
+                <span><b className="text-slate-900">{perf.directionRequests.toLocaleString()}</b> direction requests</span>
+              </div>
+            </div>
+          )}
+
           <div className="mt-2 flex items-center gap-4">
             {/* Only meaningful once a published listing is attached to the
                 connection — before that there's nothing to fill. */}

--- a/components/shared/google-posts.tsx
+++ b/components/shared/google-posts.tsx
@@ -1,0 +1,70 @@
+import { ExternalLink, Megaphone } from "lucide-react";
+import { getGooglePostsForEntity } from "@/lib/gbp-reviews";
+
+/**
+ * The owner's recent Google Posts on their profile page.
+ *
+ * This is the freshness argument for connecting a Business Profile: posts are
+ * the one thing owners update regularly, so a directory page that mirrors them
+ * stops being a static record. Renders nothing when there's no connection or no
+ * posts, so it's safe to drop onto every profile.
+ */
+export async function GooglePosts({
+  entityType,
+  entityId,
+}: {
+  entityType: string;
+  entityId: string;
+}) {
+  const posts = await getGooglePostsForEntity(entityType, entityId);
+  if (!posts.length) return null;
+
+  return (
+    <section className="mb-8 rounded-2xl border border-slate-200 bg-white p-5 sm:p-6">
+      <div className="mb-4 flex items-center gap-2">
+        <Megaphone className="h-4 w-4 text-indigo-600" />
+        <h2 className="text-lg font-black text-slate-900">Latest updates</h2>
+        <span className="text-xs text-slate-400">from Google</span>
+      </div>
+
+      <ul className="space-y-4">
+        {posts.map((p) => (
+          <li key={p.id} className="flex gap-3 border-t border-slate-100 pt-4 first:border-0 first:pt-0">
+            {p.photo && (
+              // Google-hosted and not persisted, so plain <img> rather than
+              // next/image — no point optimizing a URL we don't keep.
+              // eslint-disable-next-line @next/next/no-img-element
+              <img
+                src={p.photo}
+                alt=""
+                className="h-16 w-16 shrink-0 rounded-lg object-cover"
+                loading="lazy"
+              />
+            )}
+            <div className="min-w-0">
+              <p className="text-sm leading-relaxed text-slate-700 line-clamp-4">{p.summary}</p>
+              <div className="mt-1.5 flex flex-wrap items-center gap-3">
+                {p.createdAt && (
+                  <span className="text-xs text-slate-400">
+                    {new Date(p.createdAt).toLocaleDateString(undefined, { year: "numeric", month: "short", day: "numeric" })}
+                  </span>
+                )}
+                {(p.ctaUrl || p.url) && (
+                  <a
+                    href={p.ctaUrl || p.url || "#"}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 text-xs font-bold capitalize text-indigo-600 hover:underline"
+                  >
+                    {p.ctaLabel || "View on Google"}
+                    <ExternalLink className="h-3 w-3" />
+                  </a>
+                )}
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/components/shared/google-reviews.tsx
+++ b/components/shared/google-reviews.tsx
@@ -1,0 +1,111 @@
+import { Star, ExternalLink, Flag } from "lucide-react";
+import { getGoogleReviewsForEntity } from "@/lib/gbp-reviews";
+
+/**
+ * Google reviews for a listing whose owner has connected their Google Business
+ * Profile. Renders nothing at all when there's no connection — which is most
+ * listings — so it can be dropped onto any profile page unconditionally.
+ *
+ * The three things here that aren't decoration are policy requirements of
+ * showing Google review content (see lib/gbp-reviews.ts): visible attribution
+ * to Google, a link out to the listing on Google, and a route for reporting a
+ * review — which has to be Google's own flow, since they own the moderation.
+ */
+
+function Stars({ value }: { value: number }) {
+  return (
+    <span className="inline-flex items-center gap-0.5" aria-label={`${value} out of 5 stars`}>
+      {[1, 2, 3, 4, 5].map((n) => (
+        <Star
+          key={n}
+          className={`h-3.5 w-3.5 ${n <= value ? "fill-amber-400 text-amber-400" : "text-slate-300"}`}
+        />
+      ))}
+    </span>
+  );
+}
+
+export async function GoogleReviews({
+  entityType,
+  entityId,
+}: {
+  entityType: string;
+  entityId: string;
+}) {
+  const data = await getGoogleReviewsForEntity(entityType, entityId);
+  if (!data || !data.reviews.length) return null;
+
+  return (
+    <section className="mb-8 rounded-2xl border border-slate-200 bg-white p-5 sm:p-6">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="text-lg font-black text-slate-900">Reviews from Google</h2>
+          <p className="mt-0.5 flex items-center gap-2 text-sm text-slate-600">
+            {data.rating != null && (
+              <>
+                <span className="font-bold text-slate-900">{data.rating.toFixed(1)}</span>
+                <Stars value={Math.round(data.rating)} />
+              </>
+            )}
+            {data.count != null && (
+              <span className="text-slate-500">
+                {data.count} review{data.count === 1 ? "" : "s"} on Google
+              </span>
+            )}
+          </p>
+        </div>
+        {data.mapsUri && (
+          <a
+            href={data.mapsUri}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-xs font-bold text-indigo-600 hover:underline"
+          >
+            View all on Google
+            <ExternalLink className="h-3.5 w-3.5" />
+          </a>
+        )}
+      </div>
+
+      <ul className="space-y-4">
+        {data.reviews.map((r) => (
+          <li key={r.id} className="border-t border-slate-100 pt-4 first:border-0 first:pt-0">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-bold text-slate-900">{r.author}</span>
+              <Stars value={r.stars} />
+              {r.createdAt && (
+                <span className="text-xs text-slate-400">
+                  {new Date(r.createdAt).toLocaleDateString(undefined, { year: "numeric", month: "short" })}
+                </span>
+              )}
+            </div>
+            <p className="mt-1.5 text-sm leading-relaxed text-slate-700">{r.text}</p>
+            {r.reply && (
+              <div className="mt-2 rounded-lg border-l-2 border-slate-200 bg-slate-50 px-3 py-2">
+                <p className="text-xs font-bold text-slate-600">Response from the owner</p>
+                <p className="mt-0.5 text-sm text-slate-700">{r.reply.text}</p>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      <div className="mt-4 flex flex-wrap items-center justify-between gap-2 border-t border-slate-100 pt-3">
+        <p className="text-[11px] text-slate-400">
+          Reviews and ratings powered by Google. Shown with the business owner&apos;s authorization.
+        </p>
+        {data.mapsUri && (
+          <a
+            href={data.mapsUri}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-[11px] font-medium text-slate-400 hover:text-slate-600"
+          >
+            <Flag className="h-3 w-3" />
+            Report a review on Google
+          </a>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/lib/gbp-reviews.ts
+++ b/lib/gbp-reviews.ts
@@ -1,0 +1,207 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import { gbpAccessToken } from "@/lib/google-business";
+
+/**
+ * Google reviews for a claimed listing, fetched LIVE at render time.
+ *
+ * Deliberately never written to the database. Google's API terms restrict
+ * storing or caching review content — the permitted pattern is to fetch it
+ * dynamically — so unlike every other enrichment field, review text does not
+ * get persisted onto the entity row. The only caching here is a short
+ * in-process TTL to stop a single page render (or a burst of them) hammering
+ * the API; it lives in memory, dies with the process, and is measured in
+ * minutes.
+ *
+ * Other terms this has to satisfy, and where:
+ *   • attribution — the UI must say these come from Google, and it does
+ *     (components/shared/google-reviews.tsx).
+ *   • a way to report content — the component links to the listing on Google,
+ *     which is where a report is actually filed.
+ *   • owner authorization — implied by the OAuth grant: we only fetch for a
+ *     location whose owner connected their own account to us.
+ */
+
+const REVIEW_TTL_MS = 10 * 60 * 1000;
+const STAR_VALUES: Record<string, number> = { ONE: 1, TWO: 2, THREE: 3, FOUR: 4, FIVE: 5 };
+const V4_BASE = "https://mybusiness.googleapis.com/v4";
+
+export interface GoogleReview {
+  id: string;
+  author: string;
+  authorPhoto: string | null;
+  stars: number;
+  text: string | null;
+  createdAt: string | null;
+  reply: { text: string; at: string | null } | null;
+}
+
+export interface GoogleReviewsResult {
+  rating: number | null;
+  count: number | null;
+  reviews: GoogleReview[];
+  /** Where a visitor can see all of them, and report one. */
+  mapsUri: string | null;
+}
+
+const cache = new Map<string, { at: number; value: GoogleReviewsResult }>();
+const postCache = new Map<string, { at: number; value: GooglePost[] }>();
+
+/**
+ * The connected Google location behind a claimed entity, plus a usable access
+ * token. Null when this listing has no live Google connection — which is most
+ * of them, so callers must treat it as the normal case, not an error.
+ */
+async function resolveConnection(
+  entityType: string,
+  entityId: string
+): Promise<{ accessToken: string; account: string; location: string; mapsUri: string | null } | null> {
+  const admin = createAdminClient();
+  const { data: conn } = await (admin.from("gbp_connections") as any)
+    .select("refresh_token, selected_location, locations, status")
+    .eq("entity_type", entityType)
+    .eq("entity_id", entityId)
+    .maybeSingle();
+
+  if (!conn?.refresh_token || conn.status === "revoked") return null;
+
+  const locations: any[] = Array.isArray(conn.locations) ? conn.locations : [];
+  const loc =
+    locations.find((l) => l?.name === conn.selected_location) ||
+    (locations.length === 1 ? locations[0] : null);
+  if (!loc?.name || !loc?.account) return null;
+
+  return {
+    accessToken: await gbpAccessToken(conn.refresh_token),
+    account: loc.account,
+    location: loc.name,
+    mapsUri: loc.mapsUri || null,
+  };
+}
+
+export interface GooglePost {
+  id: string;
+  summary: string;
+  url: string | null;
+  photo: string | null;
+  createdAt: string | null;
+  ctaLabel: string | null;
+  ctaUrl: string | null;
+}
+
+/**
+ * The owner's recent Google Posts, fetched live.
+ *
+ * This is the "freshness" half of connecting a profile: posts are the one part
+ * of a listing an owner updates regularly, so surfacing them keeps an otherwise
+ * static directory page genuinely current. Live-fetched and memory-cached only,
+ * on the same reasoning as reviews.
+ */
+export async function getGooglePostsForEntity(
+  entityType: string,
+  entityId: string,
+  limit = 3
+): Promise<GooglePost[]> {
+  const key = `${entityType}:${entityId}`;
+  const hit = postCache.get(key);
+  if (hit && Date.now() - hit.at < REVIEW_TTL_MS) return hit.value;
+
+  try {
+    const conn = await resolveConnection(entityType, entityId);
+    if (!conn) return [];
+
+    const res = await fetch(
+      `${V4_BASE}/${conn.account}/${conn.location}/localPosts?pageSize=${limit}`,
+      { headers: { Authorization: `Bearer ${conn.accessToken}` } }
+    );
+    if (!res.ok) return [];
+    const body = await res.json();
+
+    const value: GooglePost[] = (body.localPosts || [])
+      .filter((p: any) => p?.state !== "REJECTED" && typeof p?.summary === "string" && p.summary.trim())
+      .map((p: any) => ({
+        id: p.name,
+        summary: p.summary.trim(),
+        url: p.searchUrl || null,
+        photo: (p.media || []).find((m: any) => m?.mediaFormat === "PHOTO")?.googleUrl || null,
+        createdAt: p.createTime || null,
+        ctaLabel: p.callToAction?.actionType
+          ? String(p.callToAction.actionType).replace(/_/g, " ").toLowerCase()
+          : null,
+        ctaUrl: p.callToAction?.url || null,
+      }))
+      .slice(0, limit);
+
+    postCache.set(key, { at: Date.now(), value });
+    return value;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Reviews for the entity a member has connected and claimed, or null when this
+ * listing has no Google connection (the overwhelmingly common case, so it must
+ * be cheap and quiet).
+ */
+export async function getGoogleReviewsForEntity(
+  entityType: string,
+  entityId: string,
+  limit = 6
+): Promise<GoogleReviewsResult | null> {
+  const key = `${entityType}:${entityId}`;
+  const hit = cache.get(key);
+  if (hit && Date.now() - hit.at < REVIEW_TTL_MS) return hit.value;
+
+  try {
+    const admin = createAdminClient();
+    const { data: conn } = await (admin.from("gbp_connections") as any)
+      .select("refresh_token, selected_location, locations, status")
+      .eq("entity_type", entityType)
+      .eq("entity_id", entityId)
+      .maybeSingle();
+
+    if (!conn?.refresh_token || conn.status === "revoked") return null;
+
+    const locations: any[] = Array.isArray(conn.locations) ? conn.locations : [];
+    const loc =
+      locations.find((l) => l?.name === conn.selected_location) ||
+      (locations.length === 1 ? locations[0] : null);
+    if (!loc?.name || !loc?.account) return null;
+
+    const accessToken = await gbpAccessToken(conn.refresh_token);
+    const res = await fetch(
+      `${V4_BASE}/${loc.account}/${loc.name}/reviews?pageSize=${limit}&orderBy=updateTime desc`,
+      { headers: { Authorization: `Bearer ${accessToken}` } }
+    );
+    if (!res.ok) return null;
+    const body = await res.json();
+
+    const value: GoogleReviewsResult = {
+      rating: typeof body.averageRating === "number" ? body.averageRating : null,
+      count: typeof body.totalReviewCount === "number" ? body.totalReviewCount : null,
+      reviews: (body.reviews || [])
+        .map((r: any) => ({
+          id: r.reviewId,
+          author: r.reviewer?.displayName || "Google user",
+          authorPhoto: r.reviewer?.profilePhotoUrl || null,
+          stars: STAR_VALUES[r.starRating] ?? 0,
+          text: typeof r.comment === "string" && r.comment.trim() ? r.comment.trim() : null,
+          createdAt: r.createTime || null,
+          reply: r.reviewReply?.comment
+            ? { text: r.reviewReply.comment.trim(), at: r.reviewReply.updateTime || null }
+            : null,
+        }))
+        // A star-only review with no words has nothing to show; the aggregate
+        // above already counts it.
+        .filter((r: GoogleReview) => !!r.text)
+        .slice(0, limit),
+      mapsUri: loc.mapsUri || null,
+    };
+
+    cache.set(key, { at: Date.now(), value });
+    return value;
+  } catch {
+    // A profile page must never fail because Google is slow or unhappy.
+    return null;
+  }
+}

--- a/lib/google-business.ts
+++ b/lib/google-business.ts
@@ -372,13 +372,30 @@ export async function gbpFetchLocations(accessToken: string): Promise<GbpLocatio
 
 const V4_BASE = "https://mybusiness.googleapis.com/v4";
 
+export interface GbpPhoto {
+  url: string;
+  /** COVER | PROFILE | LOGO | EXTERIOR | INTERIOR | … — Google's own labelling. */
+  category: string | null;
+  width: number | null;
+  height: number | null;
+}
+
 export interface GbpMediaResult {
-  photos: string[];
+  photos: GbpPhoto[];
   disabled: boolean;
   error?: string;
 }
 
-/** Public photo URLs for a location, newest first. */
+// Tiny images are usually icons or badges rather than usable storefront photos.
+const MIN_PHOTO_EDGE = 400;
+
+/**
+ * Photos for a location, with Google's own category on each.
+ *
+ * The category is the useful part: taking "the first N photos" left the profile
+ * with no hero image, because nothing said which one the owner had designated
+ * as their cover. COVER/PROFILE is exactly that designation.
+ */
 export async function gbpFetchPhotos(
   accessToken: string,
   locationName: string,
@@ -386,21 +403,73 @@ export async function gbpFetchPhotos(
   limit = 10
 ): Promise<GbpMediaResult> {
   try {
-    const res = await fetch(`${V4_BASE}/${accountName}/${locationName}/media?pageSize=${limit}`, {
+    const res = await fetch(`${V4_BASE}/${accountName}/${locationName}/media?pageSize=${Math.max(limit, 20)}`, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
     if (res.status === 403) return { photos: [], disabled: true, error: "Google My Business API is not enabled for this project." };
     if (!res.ok) return { photos: [], disabled: false, error: `media ${res.status}` };
     const body = await res.json();
-    const photos = (body.mediaItems || [])
+
+    const photos: GbpPhoto[] = (body.mediaItems || [])
       .filter((m: any) => m?.mediaFormat === "PHOTO")
-      .map((m: any) => m.googleUrl || m.sourceUrl || m.thumbnailUrl)
-      .filter(Boolean)
-      .slice(0, limit);
-    return { photos, disabled: false };
+      .map((m: any) => ({
+        url: m.googleUrl || m.sourceUrl || m.thumbnailUrl,
+        category: m.locationAssociation?.category || null,
+        width: m.dimensions?.widthPixels ?? null,
+        height: m.dimensions?.heightPixels ?? null,
+      }))
+      .filter((p: GbpPhoto) => !!p.url)
+      // Drop obvious non-photos; a missing dimension is kept rather than guessed at.
+      .filter((p: GbpPhoto) => !p.width || !p.height || Math.min(p.width, p.height) >= MIN_PHOTO_EDGE);
+
+    return { photos: photos.slice(0, limit), disabled: false };
   } catch (e: any) {
     return { photos: [], disabled: false, error: e?.message };
   }
+}
+
+/** The photo the owner designated as their cover, for the profile hero. */
+export function pickCoverPhoto(photos: GbpPhoto[]): string | null {
+  const byCategory = (c: string) => photos.find((p) => p.category === c)?.url;
+  return byCategory("COVER") || byCategory("PROFILE") || photos[0]?.url || null;
+}
+
+/**
+ * Copy Google-hosted photos into our own storage bucket and return the public
+ * URLs.
+ *
+ * Google's lh3.googleusercontent.com links are not durable — this codebase
+ * already caches scraped Maps photos into `entity-photos` for exactly that
+ * reason (scripts/cache_google_images.js). GBP photos are the merchant's own
+ * uploads, retrieved with the merchant's authorization, so they get the same
+ * treatment rather than leaving a profile pointed at links that can rot.
+ *
+ * Anything that fails to copy is dropped rather than stored as a Google URL, so
+ * the column never ends up a mix of durable and expiring links.
+ */
+export async function cacheGbpPhotos(
+  admin: any,
+  entityId: string,
+  urls: string[]
+): Promise<string[]> {
+  const cached: string[] = [];
+  for (const [i, url] of urls.entries()) {
+    try {
+      const res = await fetch(url);
+      if (!res.ok) continue;
+      const buffer = Buffer.from(await res.arrayBuffer());
+      if (!buffer.length) continue;
+      const path = `gbp/${entityId}_${i}.jpg`;
+      const { error } = await admin.storage
+        .from("entity-photos")
+        .upload(path, buffer, { contentType: "image/jpeg", upsert: true });
+      if (error) continue;
+      cached.push(admin.storage.from("entity-photos").getPublicUrl(path).data.publicUrl);
+    } catch {
+      /* skip this one, keep the rest */
+    }
+  }
+  return cached;
 }
 
 export interface GbpReviewsResult {
@@ -430,6 +499,94 @@ export async function gbpFetchReviews(
     };
   } catch (e: any) {
     return { rating: null, count: null, disabled: false, error: e?.message };
+  }
+}
+
+// ── Performance metrics ─────────────────────────────────────────────────────
+// A different API again (businessprofileperformance.googleapis.com) — verified
+// working with the same OAuth token. This is Google's own view of how the
+// listing performs: how many people saw it and how many acted. It's the
+// counterpart to our first-party pixel, and the thing an owner actually wants
+// to see next to "you're claimed".
+
+export interface GbpPerformance {
+  callClicks: number;
+  websiteClicks: number;
+  directionRequests: number;
+  impressions: number;
+  days: number;
+}
+
+const PERFORMANCE_METRICS = [
+  "CALL_CLICKS",
+  "WEBSITE_CLICKS",
+  "BUSINESS_DIRECTION_REQUESTS",
+  "BUSINESS_IMPRESSIONS_DESKTOP_SEARCH",
+  "BUSINESS_IMPRESSIONS_MOBILE_SEARCH",
+  "BUSINESS_IMPRESSIONS_DESKTOP_MAPS",
+  "BUSINESS_IMPRESSIONS_MOBILE_MAPS",
+];
+
+const ymd = (d: Date) => ({ year: d.getUTCFullYear(), month: d.getUTCMonth() + 1, day: d.getUTCDate() });
+
+/** Totals over the trailing `days`. Null when the API says no. */
+export async function gbpFetchPerformance(
+  accessToken: string,
+  locationName: string,
+  days = 30
+): Promise<GbpPerformance | null> {
+  try {
+    // Google's data lags by a couple of days; ending "today" just yields empty
+    // trailing entries, which is harmless but worth knowing when totals look low.
+    const end = new Date();
+    const start = new Date(end.getTime() - days * 86400000);
+    const params = new URLSearchParams();
+    for (const m of PERFORMANCE_METRICS) params.append("dailyMetrics", m);
+    const s = ymd(start);
+    const e = ymd(end);
+    params.set("dailyRange.start_date.year", String(s.year));
+    params.set("dailyRange.start_date.month", String(s.month));
+    params.set("dailyRange.start_date.day", String(s.day));
+    params.set("dailyRange.end_date.year", String(e.year));
+    params.set("dailyRange.end_date.month", String(e.month));
+    params.set("dailyRange.end_date.day", String(e.day));
+
+    const res = await fetch(
+      `https://businessprofileperformance.googleapis.com/v1/${locationName}:fetchMultiDailyMetricsTimeSeries?${params}`,
+      { headers: { Authorization: `Bearer ${accessToken}` } }
+    );
+    if (!res.ok) return null;
+    const body = await res.json();
+
+    // Days with no activity come back as a dated entry with no `value` at all,
+    // so a missing value means zero rather than missing data.
+    const totals: Record<string, number> = {};
+    for (const group of body.multiDailyMetricTimeSeries || []) {
+      for (const series of group.dailyMetricTimeSeries || []) {
+        const metric = series.dailyMetric;
+        const sum = (series.timeSeries?.datedValues || []).reduce(
+          (acc: number, dv: any) => acc + Number(dv.value || 0),
+          0
+        );
+        totals[metric] = (totals[metric] || 0) + sum;
+      }
+    }
+
+    const impressions =
+      (totals.BUSINESS_IMPRESSIONS_DESKTOP_SEARCH || 0) +
+      (totals.BUSINESS_IMPRESSIONS_MOBILE_SEARCH || 0) +
+      (totals.BUSINESS_IMPRESSIONS_DESKTOP_MAPS || 0) +
+      (totals.BUSINESS_IMPRESSIONS_MOBILE_MAPS || 0);
+
+    return {
+      callClicks: totals.CALL_CLICKS || 0,
+      websiteClicks: totals.WEBSITE_CLICKS || 0,
+      directionRequests: totals.BUSINESS_DIRECTION_REQUESTS || 0,
+      impressions,
+      days,
+    };
+  } catch {
+    return null;
   }
 }
 


### PR DESCRIPTION
…sts and performance

Four additions now that the My Business v4 API is enabled, all verified against the live listing.

Cover photo and durable copies. Photos came back but the profile still had no hero: shop_image_url was empty because we took "the first N photos" with nothing saying which one the owner designated. Each media item carries locationAssociation.category (COVER / PROFILE / LOGO / EXTERIOR / INTERIOR), so the cover now leads and fills the hero, and items smaller than 400px on a side are dropped as icons rather than storefronts.

Those photos were also being stored as raw lh3.googleusercontent.com links, which don't last — the reason this codebase already copies scraped Maps photos into the entity-photos bucket. GBP photos now take the same route. A listing already holding Google URLs counts as needing photos even though the column isn't empty, so rows synced before this heal themselves on the next sync; that's the one column allowed to overwrite, and only to replace an expiring link with our own copy. Everything else stays fill-only, because the owner's edits outrank Google.

Reviews are fetched live and NEVER stored. Google's terms restrict caching review content, so unlike every other enrichment field these don't touch the database — only a short in-process TTL to keep one page render from hammering the API. The component carries what the terms require: attribution to Google, a link to the listing, and a route to report a review, which has to be Google's own flow since they moderate it. Authorization is the OAuth grant itself: we only ever fetch for a location whose owner connected their own account.

Google Posts on the profile — the freshness half of connecting a profile, since posts are the one thing owners update regularly. Same live-fetch treatment.

Performance metrics from businessprofileperformance (a third API, same token) on the owner's card: views, calls, website clicks and direction requests for the trailing 30 days. Live rather than stored — it's a rolling window, and a persisted snapshot would just go stale. Real numbers for the test listing: 139 views, 7 website clicks, 57 direction requests. Days with no activity return a dated entry with no value at all, so a missing value is read as zero rather than missing data.


Claude-Session: https://claude.ai/code/session_01RTF3ibrf1oSQ8sHtx969wf