### PR TITLE
feat(gbp): extend the Google connect flow to schools and supply stores

### DIFF
--- a/app/api/google-business/sync/route.ts
+++ b/app/api/google-business/sync/route.ts
@@ -30,14 +30,17 @@ import {
 // parts, a summary and an amenities column.
 const SYNC_FIELDS: Record<
   string,
-  { addressParts?: boolean; summary?: string; amenities?: string; hours?: string }
+  { addressParts?: boolean; summary?: string; amenities?: string; hours?: string; reviewCount?: string }
 > = {
-  agent_barbershop_leads: { addressParts: true, summary: "ai_culture_summary", amenities: "custom_amenities", hours: "google_hours" },
-  agent_salon_leads: { addressParts: true, summary: "ai_culture_summary", amenities: "custom_amenities", hours: "google_hours" },
-  agent_barber_school_leads: { hours: "google_hours" },
-  agent_cosmetology_school_leads: { hours: "google_hours" },
-  agent_barber_supply_store_leads: { hours: "google_hours" },
-  agent_beauty_supply_store_leads: { hours: "google_hours" },
+  agent_barbershop_leads: { addressParts: true, summary: "ai_culture_summary", amenities: "custom_amenities", hours: "google_hours", reviewCount: "total_reviews" },
+  agent_salon_leads: { addressParts: true, summary: "ai_culture_summary", amenities: "custom_amenities", hours: "google_hours", reviewCount: "total_reviews" },
+  // Schools count reviews in google_review_count, not total_reviews — writing
+  // the wrong name doesn't error, it's just silently skipped as "no such
+  // column", so a school would never have shown a review count at all.
+  agent_barber_school_leads: { hours: "google_hours", reviewCount: "google_review_count" },
+  agent_cosmetology_school_leads: { hours: "google_hours", reviewCount: "google_review_count" },
+  agent_barber_supply_store_leads: { hours: "google_hours", reviewCount: "total_reviews" },
+  agent_beauty_supply_store_leads: { hours: "google_hours", reviewCount: "total_reviews" },
 };
 
 const isBlank = (v: any) =>
@@ -169,13 +172,14 @@ export async function POST() {
       }
     }
   }
-  if (isBlank(entity.rating) || isBlank(entity.total_reviews)) {
+  const reviewCountField = fields.reviewCount;
+  if (isBlank(entity.rating) || (reviewCountField && isBlank(entity[reviewCountField]))) {
     const reviews = await gbpFetchReviews(accessToken, loc.name, loc.account);
     if (reviews.disabled) {
       if (!notes.length) notes.push("Ratings need the Google My Business API enabled on the Cloud project.");
     } else {
       if (reviews.rating != null) candidates.rating = reviews.rating;
-      if (reviews.count != null) candidates.total_reviews = reviews.count;
+      if (reviews.count != null && reviewCountField) candidates[reviewCountField] = reviews.count;
     }
   }
 

--- a/app/schools/[slug]/page.tsx
+++ b/app/schools/[slug]/page.tsx
@@ -32,6 +32,8 @@ import { SearchVisibilityCard } from "@/components/shared/search-visibility-card
 import { ClaimShopButton } from "@/components/shared/claim-shop-button";
 import { isEntityClaimed } from "@/lib/entity-claim";
 import { ReviewsSection } from "@/components/shared/reviews-section";
+import { GoogleReviews } from "@/components/shared/google-reviews";
+import { GooglePosts } from "@/components/shared/google-posts";
 import { WriteReviewButton } from "@/components/shared/write-review-button";
 import { getApprovedReviews, computeReviewStats } from "@/lib/reviews";
 
@@ -613,6 +615,12 @@ export default async function SchoolProfilePage(props: { params: Promise<{ slug:
               containerClassName="bg-white border border-slate-200 rounded-2xl shadow-sm px-6 py-5"
               action={<WriteReviewButton entityType="school" entityId={school.id} entityName={school.school_name} />}
             />
+
+            {/* Live Google content for a school whose owner connected their
+                Business Profile. claimEntityType distinguishes the two school
+                tables, which share this route. */}
+            <GooglePosts entityType={claimEntityType} entityId={school.id} />
+            <GoogleReviews entityType={claimEntityType} entityId={school.id} />
           </div>
 
           {/* Sidebar */}

--- a/app/stores/[slug]/page.tsx
+++ b/app/stores/[slug]/page.tsx
@@ -29,6 +29,8 @@ import {
 } from "lucide-react";
 import { ClaimShopButton } from "@/components/shared/claim-shop-button";
 import { isEntityClaimed } from "@/lib/entity-claim";
+import { GoogleReviews } from "@/components/shared/google-reviews";
+import { GooglePosts } from "@/components/shared/google-posts";
 
 export const revalidate = 3600;
 
@@ -355,6 +357,11 @@ export default async function SupplyStoreProfilePage(props: { params: Promise<{ 
                 Find Shops Near This Store
               </Link>
             </div>
+
+            {/* Live Google content for a store whose owner connected their
+                Business Profile; renders nothing otherwise. */}
+            <GooglePosts entityType={claimEntityType} entityId={store.id} />
+            <GoogleReviews entityType={claimEntityType} entityId={store.id} />
 
             <NearbyEntitiesSection title="Nearby Shops" icon={Scissors} entities={nearbyShops} />
             <NearbyEntitiesSection title="Nearby Salons" icon={Sparkles} entities={nearbySalons} />


### PR DESCRIPTION
Schools and supply stores already matched, staged, published and claimed through the Google flow — what they lacked was the live content and one column mapping.

Google Posts and Google Reviews now render on both routes. The type is resolved per page rather than assumed, since /schools serves barber and cosmetology schools from separate tables and /stores does the same for barber and beauty supply — the existing claimEntityType already distinguishes them, so it drives these too.

Fixed a silent bug in the sync: review counts were written to total_reviews for every type, but schools count them in google_review_count. Writing a column a table doesn't have isn't an error, it's skipped — so schools would have kept a rating with no review count next to it, permanently and quietly. The column is now named per table alongside the other enrichment fields.

Claim badges needed no work here: unlike shop and salon, these four have no claimed_at column and their pages already read the link table through isEntityClaimed, so a Google claim has always shown correctly on them.

Barbers and cosmetologists are deliberately NOT included. Those tables are person profiles built around Booksy — no place_id, no city, no formatted_address, no google_* columns of any kind — so there is nothing for a GBP location to match against or write into. Supporting them is a schema question, not a wiring one.


Claude-Session: https://claude.ai/code/session_01RTF3ibrf1oSQ8sHtx969wf