### PR TITLE
fix(pdf): render PDFs server-side, and give every page print styles

### DIFF
--- a/app/api/pdf/route.ts
+++ b/app/api/pdf/route.ts
@@ -1,0 +1,118 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isMarkdownEligible } from "@/lib/public-routes";
+
+/**
+ * Server-rendered PDF download.
+ *
+ * The print buttons on the kit lists and insights articles call window.print(),
+ * which hands the job to the visitor's own browser and OS print pipeline. That
+ * works until it doesn't — a wedged print backend or an extension hooking print
+ * leaves the dialog spinning on "Saving" forever, with nothing the site can do
+ * about it. This renders the PDF here instead and streams a real file, so the
+ * result is identical for every visitor regardless of their machine.
+ *
+ * GET /api/pdf?path=/texas-cosmetology-practical-exam-kit-list
+ */
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+// Rendering a page costs a browser launch, so this is not an open proxy: only
+// paths that are already public get rendered. isMarkdownEligible is the same
+// gate the .md layer uses — one definition of "public", so a page can never be
+// private for one exporter and public for the other.
+function resolvePath(raw: string | null): string | null {
+  if (!raw) return null;
+  let path = raw.trim();
+  if (!path.startsWith("/")) return null;
+  // Strip query/hash: they'd let one page be rendered under unlimited distinct
+  // cache keys, and nothing here needs them.
+  path = path.split(/[?#]/)[0];
+  if (path.length > 200) return null;
+  return isMarkdownEligible(path) ? path : null;
+}
+
+function originOf(request: NextRequest): string {
+  const host = request.headers.get("host") || "agency.innergcomplete.com";
+  return `${host.includes("localhost") ? "http" : "https"}://${host}`;
+}
+
+/** Same branch as app/api/events/extract — the Lambda-optimized binary only
+ *  resolves on Vercel, so local dev uses the full puppeteer package. */
+async function launchBrowser(): Promise<any> {
+  if (process.env.VERCEL) {
+    const chromium = (await import("@sparticuz/chromium")).default;
+    const puppeteerCore = await import("puppeteer-core");
+    return puppeteerCore.launch({
+      args: chromium.args,
+      executablePath: await chromium.executablePath(),
+      headless: true,
+    });
+  }
+  const puppeteer = await import("puppeteer");
+  return puppeteer.launch({ headless: true });
+}
+
+/** "/texas-cosmetology-practical-exam-kit-list" → a sane download filename. */
+function filenameFor(path: string): string {
+  const base = path.replace(/^\/+|\/+$/g, "").replace(/\//g, "-") || "page";
+  return `${base.slice(0, 80)}.pdf`;
+}
+
+export async function GET(request: NextRequest) {
+  const path = resolvePath(request.nextUrl.searchParams.get("path"));
+  if (!path) {
+    return NextResponse.json({ error: "Invalid or non-public path" }, { status: 400 });
+  }
+
+  const url = `${originOf(request)}${path}`;
+  let browser: any;
+  try {
+    browser = await launchBrowser();
+    const page = await browser.newPage();
+
+    // Marks the render in logs and lets a page suppress anything it shouldn't
+    // export. Not a security boundary — resolvePath is.
+    await page.setExtraHTTPHeaders({ "X-PDF-Render": "1" });
+    await page.goto(url, { waitUntil: "networkidle2", timeout: 45000 });
+
+    // Print styles are what strip the navbar and restore the checklist items;
+    // rendering in screen media would bake the whole app shell into the file.
+    await page.emulateMediaType("print");
+    // Fonts resolve after layout — printing early yields fallback glyphs.
+    await page.evaluate(() => (document as any).fonts?.ready);
+
+    const pdf = await page.pdf({
+      format: "letter",
+      printBackground: true,
+      margin: { top: "0.6in", bottom: "0.6in", left: "0.5in", right: "0.5in" },
+      displayHeaderFooter: true,
+      headerTemplate: "<div></div>",
+      footerTemplate: `
+        <div style="width:100%;font-size:8px;color:#666;padding:0 0.5in;display:flex;justify-content:space-between;">
+          <span>agency.innergcomplete.com</span>
+          <span>Page <span class="pageNumber"></span> of <span class="totalPages"></span></span>
+        </div>`,
+      timeout: 45000,
+    });
+
+    return new NextResponse(new Uint8Array(pdf), {
+      headers: {
+        "Content-Type": "application/pdf",
+        "Content-Disposition": `attachment; filename="${filenameFor(path)}"`,
+        // These pages change rarely; a CDN hit avoids a browser launch.
+        "Cache-Control": "public, max-age=3600, s-maxage=86400, stale-while-revalidate=604800",
+      },
+    });
+  } catch (err) {
+    console.error(`PDF render failed for ${path}:`, err);
+    return NextResponse.json({ error: "Could not generate the PDF" }, { status: 500 });
+  } finally {
+    // A leaked browser on a serverless instance is a memory leak that outlives
+    // the request, so this closes even when the render threw.
+    try {
+      await browser?.close();
+    } catch {
+      /* already gone */
+    }
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -241,3 +241,88 @@
     opacity: 1;
   }
 }
+/* ─── Print / Save-as-PDF ──────────────────────────────────────────────────
+ * Every page can be printed, but until now only the two exam kit pages
+ * carried any print rules — inline, and duplicated. Everything else printed
+ * with the fixed navbar burned into the output (and, being fixed, at risk of
+ * repeating on each page), plus buttons and nav chrome nobody wants on paper.
+ *
+ * `.no-print` is the opt-out any page can use. The rest of this block is the
+ * baseline: strip chrome, unpin fixed elements so they flow instead of
+ * overlaying, and stop headings/rows from splitting across a page break.
+ */
+@media print {
+  .no-print,
+  nav,
+  header,
+  footer {
+    display: none !important;
+  }
+
+  /* Pages offset their content for the fixed navbar; with the navbar hidden
+     that becomes a large blank gap at the top of page one. */
+  main {
+    padding-top: 0 !important;
+  }
+
+  /* A fixed element in print can be painted onto every page. Neutralize
+     rather than hide — some pages legitimately fix their main content. */
+  *,
+  *::before,
+  *::after {
+    position: static !important;
+    box-shadow: none !important;
+    text-shadow: none !important;
+  }
+
+  html,
+  body {
+    background: #fff !important;
+    color: #000 !important;
+    /* Let the printer decide the width instead of inheriting a viewport. */
+    width: auto !important;
+    margin: 0 !important;
+  }
+
+  /* Keep colored badges/pills legible when backgrounds are dropped. */
+  * {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4 {
+    break-after: avoid-page;
+    page-break-after: avoid;
+  }
+
+  li,
+  tr,
+  img,
+  blockquote,
+  pre {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  /* Interactive affordances mean nothing on paper. */
+  button,
+  [role="button"] {
+    display: none !important;
+  }
+
+  /* The kit checklists are the main thing people actually print — keep the
+     tick state visible rather than hiding the control that shows it. */
+  .print-keep,
+  .print-keep button,
+  .print-keep [role="button"] {
+    display: revert !important;
+  }
+
+  a {
+    text-decoration: none !important;
+    color: #000 !important;
+  }
+}

--- a/components/tools/download-pdf-button.tsx
+++ b/components/tools/download-pdf-button.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import { useState } from "react";
+import { Download, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+
+/**
+ * Downloads a server-rendered PDF of the current page.
+ *
+ * Deliberately not window.print(): that hands the job to the visitor's own
+ * print pipeline, which can sit on "Saving" indefinitely with no error and no
+ * way for the page to recover. Here the work happens server-side and every
+ * outcome is observable — it succeeds, or it says why.
+ */
+export function DownloadPdfButton({
+  path,
+  label = "Download PDF",
+  className,
+}: {
+  path: string;
+  label?: string;
+  className?: string;
+}) {
+  const [busy, setBusy] = useState(false);
+
+  const download = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      // Server rendering takes a few seconds; a request that never returns
+      // must fail loudly rather than leave the button spinning forever —
+      // that silent hang is the entire reason this component exists.
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 60000);
+
+      const res = await fetch(`/api/pdf?path=${encodeURIComponent(path)}`, {
+        signal: controller.signal,
+      });
+      clearTimeout(timer);
+      if (!res.ok) throw new Error(`Server returned ${res.status}`);
+
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = (path.replace(/^\/+/, "").replace(/\//g, "-") || "page") + ".pdf";
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      // Revoking immediately can cancel the download in some browsers.
+      setTimeout(() => URL.revokeObjectURL(url), 10000);
+    } catch (err) {
+      const aborted = err instanceof DOMException && err.name === "AbortError";
+      toast.error(
+        aborted
+          ? "The PDF took too long to build. Try again, or use your browser's Print → Save as PDF."
+          : "Couldn't build the PDF. Try again, or use your browser's Print → Save as PDF."
+      );
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <button
+      onClick={download}
+      disabled={busy}
+      aria-busy={busy}
+      className={
+        className ??
+        "inline-flex items-center gap-1.5 rounded-lg bg-indigo-600 px-3 py-1.5 text-xs font-bold text-white hover:bg-indigo-700 disabled:opacity-60 disabled:cursor-wait transition-colors"
+      }
+    >
+      {busy ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Download className="w-3.5 h-3.5" />}
+      {busy ? "Building PDF…" : label}
+    </button>
+  );
+}

--- a/components/tools/kit-checklist.tsx
+++ b/components/tools/kit-checklist.tsx
@@ -1,7 +1,9 @@
 "use client"
 
 import { useEffect, useState } from "react"
+import { usePathname } from "next/navigation"
 import { CheckCircle2, Circle, Printer, RotateCcw, Tag, TagIcon } from "lucide-react"
+import { DownloadPdfButton } from "@/components/tools/download-pdf-button"
 
 export interface KitItem {
   label: string
@@ -18,6 +20,8 @@ export interface KitGroup {
 const STORAGE_KEY = "tx-barber-kit-checklist-v2026"
 
 export function KitChecklist({ groups }: { groups: KitGroup[] }) {
+  // The checklist is mounted on several kit pages; render whichever one we're on.
+  const pathname = usePathname()
   const allItems = groups.flatMap((g) => g.items.map((i) => i.label))
   const total = allItems.length
 
@@ -61,12 +65,16 @@ export function KitChecklist({ groups }: { groups: KitGroup[] }) {
             <RotateCcw className="w-3.5 h-3.5" />
             Reset
           </button>
+          {/* Server-rendered download is the primary path — it can't hang on a
+              wedged local print pipeline. Print stays as a secondary option for
+              anyone who actually wants paper. */}
+          <DownloadPdfButton path={pathname} />
           <button
             onClick={() => window.print()}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-indigo-600 px-3 py-1.5 text-xs font-bold text-white hover:bg-indigo-700 transition-colors"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-bold text-slate-600 hover:bg-slate-50 transition-colors"
           >
             <Printer className="w-3.5 h-3.5" />
-            Print / Save as PDF
+            Print
           </button>
         </div>
       </div>
@@ -85,7 +93,10 @@ export function KitChecklist({ groups }: { groups: KitGroup[] }) {
         </div>
       </div>
 
-      <div className="space-y-6">
+      {/* print-keep: each item is a <button> holding its own tick state, and the
+          global print stylesheet hides buttons. Without this the checklist —
+          the whole reason anyone prints this page — comes out empty. */}
+      <div className="space-y-6 print-keep">
         {groups.map((group) => (
           <div key={group.title}>
             <div className="flex items-center gap-2 mb-2">


### PR DESCRIPTION
The "Print / Save as PDF" buttons called window.print(), which hands the job to the visitor's own print pipeline. When that pipeline is wedged — an extension hooking print, a stuck printer backend — the dialog sits on "Saving" forever and the site has no way to detect it, report it, or recover. Reproduced Chrome's exact PDF path headlessly against all three affected pages and each rendered in under a second with no pending requests, no unloaded fonts and no animations, which is what ruled the markup out and pointed at the client.

/api/pdf renders the page here instead and streams a real file, so the result is identical for every visitor regardless of their machine. It reuses the puppeteer-core + @sparticuz/chromium branch already used by /api/events/extract, since the Lambda binary only resolves on Vercel.

Path validation goes through isMarkdownEligible — the same gate the .md layer uses. One definition of "public" means a page can't be private for one exporter and public for the other, and it stops the route being an open proxy: absolute URLs, protocol-relative URLs, traversal, /admin and /dashboard are all rejected before a browser is ever launched.

The download button reports failure. A 60s abort and an explicit error toast exist specifically because a silent hang was the original bug — replacing it with a spinner that never resolves would fix nothing.

Print styles were previously inlined on the two exam kit pages and absent everywhere else, so /insights/* printed with the fixed navbar baked in (and, being fixed, at risk of repeating per page) — its PDF came out 2.1MB against 750KB for a kit page. globals.css now carries the baseline: strip chrome, unpin fixed elements so they flow rather than overlay, and keep headings with their content across page breaks.

That baseline hides buttons, which would have printed the kit checklist completely empty — every item is a <button> holding its own tick state. Hence .print-keep, and a verification that all 52 items still render in print media.


Claude-Session: https://claude.ai/code/session_01VtMRMpNeUXmMgHNt6nsfKg