### PR TITLE
feat(nav,ai-solutions): drop Market Insights from the header, brand t…

### DIFF
--- a/app/ai-solutions/page.tsx
+++ b/app/ai-solutions/page.tsx
@@ -182,7 +182,8 @@ export default function AISolutionsPage() {
           </p>
           <h1 className="text-3xl sm:text-5xl lg:text-6xl font-bold tracking-tight text-foreground text-balance">
             Experience the Power of <br className="hidden sm:block" />
-            <span className="text-primary mt-2 inline-block">Aesthetic Intelligence</span>
+            {/* Same split as the navbar and hero lockups — one wordmark, one treatment. */}
+            <span className="mt-2 inline-block">Shear<span className="text-primary">Query</span></span>
           </h1>
           <p className="mx-auto mt-4 sm:mt-6 max-w-2xl text-base sm:text-lg text-muted-foreground leading-relaxed px-2 sm:px-0">
             Try out our tools for yourself. Click below to interact with our live dashboards, exam simulators, and job placement matchers designed specifically for barber and cosmetology schools.

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -12,7 +12,6 @@ import { LOGO_LOCKUP } from "@/lib/brand";
 import { ViewAsMenuItem, ViewAsPicker, useViewAs } from "@/components/layout/view-as";
 
 const navLinks = [
-  { label: "Market Insights", href: "/insights" },
   { label: "AI Lab", href: "/ai-solutions" },
   { label: "Membership", href: "/membership" },
   // Points at the free audit rather than the service page: a nav click is cold,


### PR DESCRIPTION
…he AI Lab hero

Removes the Market Insights link from navLinks, which feeds both the desktop bar and the mobile menu. The insights index stays reachable from the footer, so nothing is orphaned.

The /ai-solutions hero now reads "Experience the Power of ShearQuery" instead of "Aesthetic Intelligence", using the same Shear + text-primary Query split as the navbar, homepage hero and footer so the wordmark renders identically wherever it appears.