### PR TITLE
feat(gbp-posts): schedule posts, queued here rather than at Google

### DIFF
--- a/app/api/account/gbp-posts/route.ts
+++ b/app/api/account/gbp-posts/route.ts
@@ -12,6 +12,7 @@ import {
 import {
   offerStarters, defaultWindow, validateOffer, toLocalPostOffer, type OfferDraft,
 } from "@/lib/gbp-post-offers";
+import { validateSchedule } from "@/lib/gbp-post-schedule";
 import { formatTime } from "@/lib/gbp-special-hours";
 
 /**
@@ -134,6 +135,13 @@ export async function GET() {
   });
   const lastPost = recent.ok ? (await recent.json())?.localPosts?.[0]?.createTime ?? null : null;
 
+  const { data: scheduled } = await (createAdminClient().from("gbp_scheduled_posts") as any)
+    .select("id, summary, scheduled_for, event, offer")
+    .eq("community_member_id", resolved.ctx.memberId)
+    .eq("location_name", locationName)
+    .eq("status", "pending")
+    .order("scheduled_for", { ascending: true });
+
   // Industry events near the shop, offered as candidates rather than built into
   // an angle: only the owner knows whether they're actually going, and we're
   // not going to assert attendance on someone's public listing.
@@ -166,6 +174,10 @@ export async function GET() {
     // a shop with no reviews and no services is exactly the one that needs an
     // offer most.
     callToAction: resolveCallToAction(context),
+    scheduled: (scheduled || []).map((r: any) => ({
+      id: r.id, summary: r.summary, scheduledFor: r.scheduled_for,
+      kind: r.offer ? "offer" : r.event ? "event" : "post",
+    })),
     events: nearby,
     offerStarters: starters,
     hasBookingLink: !!context.bookingUrl,
@@ -195,6 +207,7 @@ export async function POST(req: Request) {
   const photoUrl = body?.photoUrl ? String(body.photoUrl) : null;
   const eventId = body?.eventId ? String(body.eventId) : null;
   const offerInput = body?.offer ?? null;
+  const scheduledFor = body?.scheduledFor ? String(body.scheduledFor) : null;
 
   const check = validatePost(summary, { actionType: actionType as any, url });
   if (!check.ok) {
@@ -249,6 +262,31 @@ export async function POST(req: Request) {
     localPostEvent = built.event;
   }
 
+  // Queue rather than publish. The post is stored resolved — the event and
+  // offer objects, not an events.id — so a row edited between now and the send
+  // can't change what goes out under the owner's name.
+  if (scheduledFor) {
+    const when = validateSchedule(scheduledFor);
+    if (!when.ok) {
+      return NextResponse.json({ success: false, error: when.issues[0]?.message }, { status: 400 });
+    }
+    const { data: queued, error: queueErr } = await (admin.from("gbp_scheduled_posts") as any)
+      .insert({
+        community_member_id: ctx.memberId,
+        location_name: locationName,
+        summary, action_type: actionType, action_url: url ?? null,
+        photo_url: photoUrl, event: localPostEvent, offer: localPostOffer,
+        angle_id: angleId, scheduled_for: new Date(scheduledFor).toISOString(),
+      })
+      .select("id, scheduled_for")
+      .single();
+
+    if (queueErr) {
+      return NextResponse.json({ success: false, error: "Could not schedule that post." }, { status: 500 });
+    }
+    return NextResponse.json({ success: true, scheduled: true, id: queued.id, scheduledFor: queued.scheduled_for });
+  }
+
   const { data: request } = await (admin.from("gbp_change_requests") as any)
     .insert({
       community_member_id: ctx.memberId,
@@ -282,4 +320,36 @@ export async function POST(req: Request) {
 
   if (!write.ok) return NextResponse.json({ success: false, error: write.error }, { status: 502 });
   return NextResponse.json({ success: true, postName: write.postName });
+}
+
+/**
+ * Cancel a queued post.
+ *
+ * The reason the queue lives in our database rather than in Google's
+ * scheduledTime: a post already handed to Google can't be called back.
+ */
+export async function DELETE(req: Request) {
+  const resolved = await resolveConnection();
+  if ("error" in resolved) {
+    return NextResponse.json({ success: false, error: resolved.error }, { status: resolved.status });
+  }
+  const { ctx, locationName } = resolved;
+
+  const readOnly = assertNotImpersonating(ctx);
+  if (readOnly) return NextResponse.json({ success: false, error: readOnly.error }, { status: readOnly.status });
+
+  const id = new URL(req.url).searchParams.get("id");
+  if (!id) return NextResponse.json({ success: false, error: "Which post?" }, { status: 400 });
+
+  // Scoped to this member AND this location, so an id from elsewhere matches
+  // nothing rather than cancelling someone else's post.
+  const { error } = await (createAdminClient().from("gbp_scheduled_posts") as any)
+    .update({ status: "cancelled", updated_at: new Date().toISOString() })
+    .eq("id", id)
+    .eq("community_member_id", ctx.memberId)
+    .eq("location_name", locationName)
+    .eq("status", "pending");
+
+  if (error) return NextResponse.json({ success: false, error: "Could not cancel that." }, { status: 500 });
+  return NextResponse.json({ success: true });
 }

--- a/app/api/cron/gbp-publish-scheduled/route.ts
+++ b/app/api/cron/gbp-publish-scheduled/route.ts
@@ -1,0 +1,127 @@
+import { NextResponse } from "next/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { gbpAccessToken } from "@/lib/google-business";
+import { writeLocalPost } from "@/lib/gbp-write";
+import { isStillPublishable } from "@/lib/gbp-post-schedule";
+
+/**
+ * Publish posts that have come due.
+ *
+ * Runs often, because "scheduled for 9am" should mean roughly 9am. Everything
+ * it publishes was approved by an owner who saw the exact text — this job picks
+ * the moment, never the content.
+ *
+ * The check that earns this job its keep is the second validation. A post
+ * approved on the 1st and published on the 20th sat in a queue while the world
+ * moved: an offer can expire, an event can finish. Publishing those late is
+ * worse than not publishing, because it goes out under the shop's name to
+ * customers who will try to use it.
+ */
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 300;
+
+/** Vercel Cron sends `Authorization: Bearer $CRON_SECRET` when that var is set. */
+function authorized(req: Request): boolean {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) return false;
+  return req.headers.get("authorization") === `Bearer ${secret}`;
+}
+
+/** After this many failed attempts a post is left alone rather than retried forever. */
+const MAX_ATTEMPTS = 3;
+
+export async function GET(req: Request) {
+  if (!authorized(req)) {
+    return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
+  }
+
+  const admin = createAdminClient();
+  const now = new Date();
+
+  const { data: due, error } = await (admin.from("gbp_scheduled_posts") as any)
+    .select("*")
+    .eq("status", "pending")
+    .lte("scheduled_for", now.toISOString())
+    .order("scheduled_for", { ascending: true })
+    .limit(50);
+
+  if (error) {
+    return NextResponse.json({ success: false, error: error.message }, { status: 500 });
+  }
+
+  const summary = { due: due?.length ?? 0, published: 0, expired: 0, failed: 0, skipped: [] as string[] };
+
+  for (const row of due || []) {
+    const finish = (patch: Record<string, unknown>) =>
+      (admin.from("gbp_scheduled_posts") as any)
+        .update({ ...patch, updated_at: new Date().toISOString() })
+        .eq("id", row.id);
+
+    // Did the window close while this waited?
+    const still = isStillPublishable({ event: row.event, offer: row.offer }, now);
+    if (!still.publishable) {
+      await finish({ status: "cancelled", error: still.reason });
+      summary.expired++;
+      continue;
+    }
+
+    const { data: conn } = await (admin.from("gbp_connections") as any)
+      .select("refresh_token")
+      .eq("community_member_id", row.community_member_id)
+      .maybeSingle();
+
+    // Disconnected since scheduling. Not a failure to retry — there's nothing
+    // to retry with until they reconnect.
+    if (!conn?.refresh_token) {
+      await finish({ status: "cancelled", error: "the Google connection was removed" });
+      summary.skipped.push(`${row.id}: disconnected`);
+      continue;
+    }
+
+    try {
+      const token = await gbpAccessToken(conn.refresh_token);
+      const accountsRes = await fetch("https://mybusinessaccountmanagement.googleapis.com/v1/accounts", {
+        headers: { Authorization: `Bearer ${token}` }, cache: "no-store",
+      });
+      const accountName = accountsRes.ok ? (await accountsRes.json())?.accounts?.[0]?.name ?? null : null;
+      if (!accountName) throw new Error("could not resolve the Google account");
+
+      const write = await writeLocalPost({
+        token,
+        accountName,
+        locationName: row.location_name,
+        summary: row.summary,
+        callToAction: { actionType: row.action_type, url: row.action_url || undefined },
+        photoUrl: row.photo_url,
+        event: row.event,
+        offer: row.offer,
+        memberId: row.community_member_id,
+        note: `scheduled post${row.angle_id ? ` — ${row.angle_id}` : ""}`,
+      });
+
+      if (write.ok) {
+        await finish({ status: "published", published_at: new Date().toISOString(), post_name: write.postName ?? null, error: null });
+        summary.published++;
+      } else {
+        const attempts = (row.attempts ?? 0) + 1;
+        await finish({
+          status: attempts >= MAX_ATTEMPTS ? "failed" : "pending",
+          attempts,
+          error: write.error,
+        });
+        summary.failed++;
+      }
+    } catch (e: any) {
+      const attempts = (row.attempts ?? 0) + 1;
+      await finish({
+        status: attempts >= MAX_ATTEMPTS ? "failed" : "pending",
+        attempts,
+        error: e?.message || "publish threw",
+      });
+      summary.failed++;
+    }
+  }
+
+  return NextResponse.json({ success: true, ...summary });
+}

--- a/components/account/gbp-post-form.tsx
+++ b/components/account/gbp-post-form.tsx
@@ -5,6 +5,18 @@ import Link from "next/link";
 import { AlertTriangle, ArrowRight, CalendarDays, Check, Clock, Loader2, MessageSquareQuote, Sparkles, Tag } from "lucide-react";
 import { validatePost, POST_MAX, type PostAngle, type PostCallToAction } from "@/lib/gbp-posts";
 import { validateOffer, type OfferDraft } from "@/lib/gbp-post-offers";
+import { validateSchedule, describeSchedule, suggestedSlots } from "@/lib/gbp-post-schedule";
+
+interface ScheduledPost {
+  id: string;
+  summary: string;
+  scheduledFor: string;
+  kind: "post" | "event" | "offer";
+}
+
+/** datetime-local wants "YYYY-MM-DDTHH:mm" in local time, not an ISO string. */
+const toLocalInput = (d: Date) =>
+  new Date(d.getTime() - d.getTimezoneOffset() * 60_000).toISOString().slice(0, 16);
 
 interface OfferStarterUI {
   id: string; label: string; title: string; summary: string;
@@ -47,6 +59,9 @@ export function GbpPostForm() {
   // The button to use when no angle is selected — an offer or event post
   // doesn't depend on there being a review or a service to draw on.
   const [fallbackCta, setFallbackCta] = useState<PostCallToAction>({ actionType: "CALL" });
+  const [queue, setQueue] = useState<ScheduledPost[]>([]);
+  // "" = publish now. Anything else queues it.
+  const [when, setWhen] = useState("");
   // null = not writing an offer. The amount is always the owner's to fill in.
   const [offer, setOffer] = useState<OfferDraft | null>(null);
   const [loading, setLoading] = useState(true);
@@ -67,6 +82,7 @@ export function GbpPostForm() {
         setEvents(json.events || []);
         setStarters(json.offerStarters || []);
         if (json.callToAction) setFallbackCta(json.callToAction);
+        setQueue(json.scheduled || []);
         if (json.angles?.[0]) { setChosen(json.angles[0].id); setText(json.angles[0].summary); }
       } catch { setError("Could not load post ideas."); }
       finally { setLoading(false); }
@@ -82,10 +98,17 @@ export function GbpPostForm() {
   // An offer or an event is enough on its own; an angle is one way in, not the
   // only one.
   const composing = Boolean(angle || eventId || offer);
+  const scheduleCheck = when ? validateSchedule(when) : null;
   const check = composing ? validatePost(text, activeCta) : null;
+
+  const cancelScheduled = async (id: string) => {
+    setQueue((q) => q.filter((p) => p.id !== id));
+    await fetch(`/api/account/gbp-posts?id=${encodeURIComponent(id)}`, { method: "DELETE" }).catch(() => {});
+  };
 
   const publish = async () => {
     if (!composing) return;
+    if (when && !validateSchedule(when).ok) return;
     setPosting(true); setError(null);
     try {
       const res = await fetch("/api/account/gbp-posts", {
@@ -93,10 +116,20 @@ export function GbpPostForm() {
         body: JSON.stringify({
           summary: text, angleId: angle?.id ?? null, photoUrl: activePhoto, eventId, offer,
           actionType: activeCta.actionType, url: activeCta.url,
+          scheduledFor: when ? new Date(when).toISOString() : null,
         }),
       });
       const json = await res.json();
       if (!json.success) { setError(json.error || "Could not publish."); return; }
+      if (json.scheduled) {
+        // Stay on the page — the point of a queue is lining several up.
+        setQueue((q) => [...q, {
+          id: json.id, summary: text, scheduledFor: json.scheduledFor,
+          kind: (offer ? "offer" : eventId ? "event" : "post") as ScheduledPost["kind"],
+        }].sort((a, b) => a.scheduledFor.localeCompare(b.scheduledFor)));
+        setChosen(null); setEventId(null); setOffer(null); setText(""); setWhen(""); setPhoto(undefined);
+        return;
+      }
       setPublished(true);
     } catch { setError("Could not publish."); }
     finally { setPosting(false); }
@@ -130,6 +163,35 @@ export function GbpPostForm() {
           </p>
         )}
       </div>
+
+      {queue.length > 0 && (
+        <section className="mt-6 rounded-2xl border border-slate-200 bg-white p-4">
+          <p className="text-sm font-bold text-slate-900">
+            {queue.length} post{queue.length === 1 ? "" : "s"} queued
+          </p>
+          <ul className="mt-3 space-y-2">
+            {queue.map((q) => (
+              <li key={q.id} className="flex items-start justify-between gap-3 rounded-xl border border-slate-100 bg-slate-50 px-3 py-2">
+                <span className="min-w-0">
+                  <span className="block truncate text-xs font-semibold text-slate-700">
+                    {q.summary.split("\n")[0]}
+                  </span>
+                  <span className="block text-[11px] text-slate-500">
+                    {q.kind === "offer" ? "Offer · " : q.kind === "event" ? "Event · " : ""}
+                    {describeSchedule(q.scheduledFor)}
+                  </span>
+                </span>
+                <button
+                  onClick={() => cancelScheduled(q.id)}
+                  className="shrink-0 text-[11px] font-bold text-slate-500 underline hover:text-rose-700"
+                >
+                  Cancel
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
 
       {published ? (
         <p className="mt-6 flex items-center gap-2 rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm font-semibold text-emerald-800">
@@ -402,12 +464,50 @@ export function GbpPostForm() {
                 </ul>
               )}
 
+              <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-3">
+                <div className="flex flex-wrap items-center gap-2">
+                  <button
+                    onClick={() => setWhen("")}
+                    aria-pressed={!when}
+                    className={`rounded-lg border px-3 py-1.5 text-xs font-bold transition-colors ${
+                      !when ? "border-primary bg-primary text-primary-foreground" : "border-slate-200 bg-white text-slate-600 hover:bg-slate-100"
+                    }`}
+                  >
+                    Publish now
+                  </button>
+                  {suggestedSlots(new Date(), 3).map((d, i) => (
+                    <button
+                      key={i}
+                      onClick={() => setWhen(toLocalInput(d))}
+                      className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-bold text-slate-600 transition-colors hover:bg-slate-100"
+                    >
+                      In {i + 1} week{i ? "s" : ""}
+                    </button>
+                  ))}
+                  <input
+                    type="datetime-local"
+                    value={when}
+                    onChange={(e) => setWhen(e.target.value)}
+                    className="rounded-lg border border-slate-200 bg-white px-2 py-1.5 text-xs text-slate-700 outline-none focus:border-slate-400"
+                  />
+                </div>
+                <p className="mt-2 text-[11px] leading-relaxed text-slate-500">
+                  {when
+                    ? "Queued here, not with Google — you can cancel it any time before it goes out. An offer or event that expires first is dropped rather than published late."
+                    : "Posts drop out of the feed after about a week. Lining up a few now is the difference between posting once and staying visible."}
+                </p>
+                {scheduleCheck && !scheduleCheck.ok && (
+                  <p className="mt-2 text-xs font-semibold text-rose-700">{scheduleCheck.issues[0]?.message}</p>
+                )}
+              </div>
+
               <button
                 onClick={publish}
-                disabled={posting || !check?.ok || (!!offer && !offerCheck?.ok)}
+                disabled={posting || !check?.ok || (!!offer && !offerCheck?.ok) || (!!when && !scheduleCheck?.ok)}
                 className="mt-4 inline-flex items-center gap-2 rounded-xl bg-primary px-5 py-2.5 text-sm font-black uppercase tracking-wide text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
               >
-                {posting && <Loader2 className="h-4 w-4 animate-spin" />} Publish post
+                {posting && <Loader2 className="h-4 w-4 animate-spin" />}
+                {when ? "Schedule post" : "Publish post"}
               </button>
             </article>
           )}

--- a/lib/gbp-post-schedule.test.ts
+++ b/lib/gbp-post-schedule.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateSchedule, isStillPublishable, describeSchedule, suggestedSlots,
+  SCHEDULE_MAX_DAYS, SCHEDULE_MIN_MINUTES,
+} from "./gbp-post-schedule";
+
+const NOW = new Date("2026-08-01T12:00:00Z");
+const at = (iso: string) => new Date(iso);
+
+describe("validateSchedule", () => {
+  it("accepts a time later today", () => {
+    expect(validateSchedule(at("2026-08-01T18:00:00Z"), NOW).ok).toBe(true);
+  });
+
+  it("rejects a time that has passed", () => {
+    const r = validateSchedule(at("2026-08-01T09:00:00Z"), NOW);
+    expect(r.ok).toBe(false);
+    expect(r.issues[0].message).toMatch(/already passed/i);
+  });
+
+  it("rejects something so close it may as well be published now", () => {
+    const r = validateSchedule(at("2026-08-01T12:05:00Z"), NOW);
+    expect(r.ok).toBe(false);
+    expect(r.issues[0].message).toContain(String(SCHEDULE_MIN_MINUTES));
+  });
+
+  it("rejects a date beyond the horizon", () => {
+    // What's true about a shop today may not be in six months, and a queue
+    // nobody remembers filling is how a stale post goes out.
+    const r = validateSchedule(at("2027-06-01T12:00:00Z"), NOW);
+    expect(r.ok).toBe(false);
+    expect(r.issues[0].message).toContain(String(SCHEDULE_MAX_DAYS));
+  });
+
+  it("rejects a nonsense value rather than queueing it", () => {
+    expect(validateSchedule("tomorrow-ish", NOW).ok).toBe(false);
+  });
+});
+
+describe("isStillPublishable", () => {
+  const offerEnding = (iso: string) => {
+    const [y, m, d] = iso.split("-").map(Number);
+    return { event: { schedule: { endDate: { year: y, month: m, day: d } } }, offer: {} };
+  };
+
+  it("lets a plain post through — nothing about it expires", () => {
+    expect(isStillPublishable({}, NOW).publishable).toBe(true);
+    expect(isStillPublishable({ event: null, offer: null }, NOW).publishable).toBe(true);
+  });
+
+  it("drops an offer whose window closed while it waited", () => {
+    // This is the check the whole feature turns on: an expired offer published
+    // late reaches customers under the shop's name and they try to use it.
+    const r = isStillPublishable(offerEnding("2026-07-20"), NOW);
+    expect(r.publishable).toBe(false);
+    expect(r.reason).toMatch(/offer expired/i);
+  });
+
+  it("publishes on the final day, not up to midnight UTC", () => {
+    // An offer valid "until the 31st" is valid all of the 31st. Cutting at
+    // 00:00 UTC would lose a day in every US timezone.
+    const lateOnLastDay = new Date("2026-08-01T23:30:00Z");
+    expect(isStillPublishable(offerEnding("2026-08-01"), lateOnLastDay).publishable).toBe(true);
+  });
+
+  it("names an event rather than an offer when there's no offer", () => {
+    const r = isStillPublishable(
+      { event: { schedule: { endDate: { year: 2026, month: 7, day: 1 } } } },
+      NOW
+    );
+    expect(r.publishable).toBe(false);
+    expect(r.reason).toMatch(/event finished/i);
+  });
+});
+
+describe("describeSchedule", () => {
+  it("reads as a human would say it", () => {
+    expect(describeSchedule("2026-08-01T12:30:00Z", NOW)).toBe("in 30 minutes");
+    expect(describeSchedule("2026-08-01T18:00:00Z", NOW)).toBe("in 6 hours");
+    expect(describeSchedule("2026-08-08T12:00:00Z", NOW)).toBe("in 7 days");
+  });
+
+  it("says a due post is due", () => {
+    expect(describeSchedule("2026-08-01T11:00:00Z", NOW)).toBe("due now");
+  });
+});
+
+describe("suggestedSlots", () => {
+  it("spaces them a week apart, because that's how long a post survives", () => {
+    const slots = suggestedSlots(NOW, 4);
+    expect(slots).toHaveLength(4);
+    expect(slots[0].toISOString()).toBe("2026-08-08T12:00:00.000Z");
+    expect(slots[3].toISOString()).toBe("2026-08-29T12:00:00.000Z");
+  });
+
+  it("keeps the time of day, so nothing lands at 3am", () => {
+    for (const s of suggestedSlots(NOW, 3)) {
+      expect(s.getUTCHours()).toBe(NOW.getUTCHours());
+    }
+  });
+
+  it("every suggested slot passes validation", () => {
+    for (const s of suggestedSlots(NOW, 4)) {
+      expect(validateSchedule(s, NOW).ok).toBe(true);
+    }
+  });
+});

--- a/lib/gbp-post-schedule.ts
+++ b/lib/gbp-post-schedule.ts
@@ -1,0 +1,121 @@
+/**
+ * Scheduling posts.
+ *
+ * The judgement here is about time passing between approval and publication.
+ * Everything else in this feature validates a post at the moment an owner
+ * presses publish, when what they see is what goes out. A scheduled post is
+ * approved once and published days later, and in that gap an offer can expire,
+ * an event can finish, and a listing can be disconnected.
+ *
+ * So a scheduled post is checked twice: once when it's queued, and again by the
+ * publisher immediately before it goes out. The second check is the one that
+ * matters — publishing an offer that ran out last Tuesday is worse than not
+ * publishing at all, because it reaches customers with the shop's name on it.
+ *
+ * Pure — no network.
+ */
+
+export const SCHEDULE_MAX_DAYS = 90;
+/** Below this, "schedule" is just a slow publish and the owner should press the button. */
+export const SCHEDULE_MIN_MINUTES = 10;
+
+export interface ScheduleIssue {
+  level: "error" | "warning";
+  message: string;
+}
+
+/** Can this be queued for that moment? */
+export function validateSchedule(scheduledFor: Date | string, now: Date = new Date()): {
+  ok: boolean;
+  issues: ScheduleIssue[];
+} {
+  const issues: ScheduleIssue[] = [];
+  const when = scheduledFor instanceof Date ? scheduledFor : new Date(scheduledFor);
+
+  if (Number.isNaN(when.getTime())) {
+    return { ok: false, issues: [{ level: "error", message: "That isn't a valid date and time." }] };
+  }
+
+  const minutes = (when.getTime() - now.getTime()) / 60_000;
+
+  if (minutes < SCHEDULE_MIN_MINUTES) {
+    issues.push({
+      level: "error",
+      message:
+        minutes < 0
+          ? "That time has already passed."
+          : `Pick a time at least ${SCHEDULE_MIN_MINUTES} minutes out, or just publish it now.`,
+    });
+  }
+
+  if (minutes / 1440 > SCHEDULE_MAX_DAYS) {
+    issues.push({
+      level: "error",
+      message: `That's more than ${SCHEDULE_MAX_DAYS} days away. Queue it nearer the time — what's true about your shop today may not be by then.`,
+    });
+  }
+
+  return { ok: !issues.some((i) => i.level === "error"), issues };
+}
+
+export interface ScheduledPostPayload {
+  event?: { schedule?: { endDate?: { year: number; month: number; day: number } } } | null;
+  offer?: unknown | null;
+}
+
+/**
+ * Is this still worth publishing, at the moment it comes due?
+ *
+ * Called by the publisher, not the scheduler. An EVENT or OFFER post carries a
+ * window, and a window that closed while the post sat in the queue makes the
+ * post actively misleading — an offer customers can't use, an event already
+ * over. Those are dropped rather than published late.
+ *
+ * A plain post has no window and is always still fine: "we do fades" doesn't
+ * expire.
+ */
+export function isStillPublishable(
+  payload: ScheduledPostPayload,
+  now: Date = new Date()
+): { publishable: boolean; reason?: string } {
+  const end = payload.event?.schedule?.endDate;
+  if (!end) return { publishable: true };
+
+  // Compared on the whole day: an offer valid "until the 31st" is valid all of
+  // the 31st, and expiring it at midnight UTC would cut a day off in every US
+  // timezone.
+  const endOfDay = Date.UTC(end.year, end.month - 1, end.day, 23, 59, 59);
+  if (now.getTime() > endOfDay) {
+    return {
+      publishable: false,
+      reason: payload.offer
+        ? "the offer expired before this was due to publish"
+        : "the event finished before this was due to publish",
+    };
+  }
+  return { publishable: true };
+}
+
+/** How a pending post reads in the queue list. */
+export function describeSchedule(scheduledFor: string, now: Date = new Date()): string {
+  const when = new Date(scheduledFor);
+  if (Number.isNaN(when.getTime())) return "";
+  const mins = Math.round((when.getTime() - now.getTime()) / 60_000);
+  if (mins < 0) return "due now";
+  if (mins < 60) return `in ${mins} minute${mins === 1 ? "" : "s"}`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return `in ${hours} hour${hours === 1 ? "" : "s"}`;
+  const days = Math.round(hours / 24);
+  return `in ${days} day${days === 1 ? "" : "s"}`;
+}
+
+/**
+ * Suggested slots for a drip.
+ *
+ * Weekly, because posts age out of the feed in about a week — the gap is set by
+ * how long a post survives, not by a marketing calendar. Offered at the same
+ * time of day the owner is scheduling, so nothing arrives at 3am.
+ */
+export function suggestedSlots(now: Date = new Date(), count = 4): Date[] {
+  return Array.from({ length: count }, (_, i) => new Date(now.getTime() + (i + 1) * 7 * 86_400_000));
+}

--- a/supabase/migrations/20260801060000_create_gbp_scheduled_posts.sql
+++ b/supabase/migrations/20260801060000_create_gbp_scheduled_posts.sql
@@ -1,0 +1,65 @@
+-- Posts approved now, published later.
+--
+-- Google's LocalPost has a scheduledTime field, and this deliberately does NOT
+-- use it. Two reasons: we have not verified what Google actually does with it
+-- on create — whether it defers publication or merely stamps a date — and a
+-- post already handed to Google cannot be cancelled by us. Holding the queue
+-- here means an owner can change their mind, and the publish path is the same
+-- create call that already works.
+--
+-- The point of the queue is the treadmill. Google posts age out of the feed in
+-- about a week, so staying visible means posting again and again, and nobody
+-- remembers. Approving four in one sitting and letting them out weekly turns
+-- that into ten minutes a month.
+
+CREATE TABLE IF NOT EXISTS public.gbp_scheduled_posts (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    community_member_id uuid NOT NULL,
+    location_name text NOT NULL,
+
+    -- The post itself, in the shape writeLocalPost takes.
+    summary text NOT NULL,
+    action_type text NOT NULL DEFAULT 'CALL',
+    action_url text,
+    photo_url text,
+    -- EVENT/OFFER payloads. Stored resolved rather than as an events.id, so a
+    -- row edited or deleted between scheduling and publishing can't silently
+    -- change what goes out under the owner's name.
+    event jsonb,
+    offer jsonb,
+    angle_id text,
+
+    scheduled_for timestamptz NOT NULL,
+    status text NOT NULL DEFAULT 'pending',
+
+    published_at timestamptz,
+    post_name text,
+    error text,
+    attempts integer NOT NULL DEFAULT 0,
+
+    created_at timestamptz NOT NULL DEFAULT now(),
+    updated_at timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT gbp_scheduled_posts_status_check
+        CHECK (status IN ('pending', 'published', 'failed', 'cancelled'))
+);
+
+-- The cron's only query: what is due and still waiting.
+CREATE INDEX IF NOT EXISTS gbp_scheduled_posts_due_idx
+    ON public.gbp_scheduled_posts (scheduled_for)
+    WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS gbp_scheduled_posts_member_idx
+    ON public.gbp_scheduled_posts (community_member_id, scheduled_for DESC);
+
+-- Service-role only, like every other table holding customer listing data:
+-- RLS on with no policies means no anon or authenticated client can read it,
+-- and the routes reach it through the admin client after checking the session.
+ALTER TABLE public.gbp_scheduled_posts ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE public.gbp_scheduled_posts IS
+    'Owner-approved Google Posts waiting to publish. Published by /api/cron/gbp-publish-scheduled.';
+COMMENT ON COLUMN public.gbp_scheduled_posts.event IS
+    'Resolved LocalPostEvent, stored rather than referenced so the published post is what was approved.';
+COMMENT ON COLUMN public.gbp_scheduled_posts.attempts IS
+    'Publish attempts. A row that keeps failing is left failed rather than retried forever.';

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,10 @@
     {
       "path": "/api/cron/gbp-monitor",
       "schedule": "0 14 * * 1"
+    },
+    {
+      "path": "/api/cron/gbp-publish-scheduled",
+      "schedule": "*/15 * * * *"
     }
   ]
 }


### PR DESCRIPTION
Google posts age out of the feed in about a week, so staying visible means posting again and again and nobody remembers. Approving four in one sitting and letting them out weekly turns the treadmill into ten minutes a month — that is what this is for.

NOT Google's scheduledTime. Two reasons: we have not verified what Google does with that field on create — whether it defers publication or merely stamps a date — and a post already handed to Google cannot be called back. Holding the queue in our own table means an owner can cancel, and the publish path is the same create call that is now known to work.

THE CHECK THAT EARNS THIS ITS KEEP is the second validation. Everything else in this feature validates at the moment the owner presses publish, when what they see is what goes out. A scheduled post is approved once and published days later, and in that gap an offer expires, an event finishes, a listing gets disconnected. So the publisher re-checks immediately before sending: an expired offer is cancelled rather than published late, because late is worse than never — it reaches customers under the shop's name and they try to use it.

Expiry is compared on the whole day. An offer valid "until the 31st" is valid all of the 31st; cutting at midnight UTC would lose a day in every US timezone.

The queue stores the resolved event and offer objects rather than an events.id, so a row edited between approval and publication cannot change what goes out under someone's name. Failures retry twice then stop; a disconnected listing cancels rather than retrying forever against nothing.

Runs every 15 minutes, because "scheduled for 9am" should mean roughly 9am.