### PR TITLE
fix(seo-tracker): say WHY live GSC data is missing, not just that it is

### DIFF
--- a/app/tools/seo-keyword-tracker/page.tsx
+++ b/app/tools/seo-keyword-tracker/page.tsx
@@ -1,6 +1,13 @@
 import Link from "next/link"
 import { Search, TrendingUp, Hash, AlertTriangle, MousePointerClick, Eye } from "lucide-react"
-import { getCachedGscPerformance, type GscMetrics, type GscPerformance } from "@/lib/gsc-performance"
+import {
+  getCachedGscPerformance,
+  gscLastFailure,
+  gscMissingConfig,
+  type GscMetrics,
+  type GscPerformance,
+  type GscUnavailableReason,
+} from "@/lib/gsc-performance"
 import {
   resolveGscWindow,
   latestAvailableDay,
@@ -45,6 +52,17 @@ export default async function SeoKeywordTrackerPage({
   // Only the keys this page reads are fetched into cache — the raw response is
   // ~3MB and would exceed Next's data-cache limit.
   const perf = await getCachedGscPerformance({ start: win.start, end: win.end }, catalogGscKeys())
+
+  // Why it's missing, when it is. gscLastFailure() only reflects a run that
+  // actually happened — unstable_cache serves a cached null without re-entering
+  // the function, so on a cache hit there is no recorded reason. The config
+  // check needs no network and is always current, so it fills that gap: the
+  // common case (credentials absent on this deployment) still explains itself.
+  let gscFailure: GscUnavailableReason | null = null
+  if (!perf) {
+    const missing = gscMissingConfig()
+    gscFailure = missing.length ? { kind: "not-configured", missing } : gscLastFailure()
+  }
   const totals = catalogTotals()
   const shortLabel = windowShortLabel(win)
   const iso = (d: Date) => d.toISOString().slice(0, 10)
@@ -123,9 +141,37 @@ export default async function SeoKeywordTrackerPage({
             Live GSC · {perf.window.start} → {perf.window.end} ({win.days} days · {win.label}) · fetched {new Date(perf.fetchedAt).toLocaleString()}
           </div>
         ) : (
-          <div className="mt-4 flex items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-semibold text-amber-800">
-            <AlertTriangle className="h-4 w-4" />
-            Live GSC data unavailable — showing the keyword catalog without performance metrics.
+          <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-900">
+            <div className="flex items-center gap-2 font-semibold">
+              <AlertTriangle className="h-4 w-4" />
+              Live GSC data unavailable — showing the keyword catalog without performance metrics.
+            </div>
+            {/* The three causes need three different fixes, and the generic
+                message above sent people to check the token when the usual
+                culprit is a missing env var on the deployment. Say which. */}
+            {gscFailure?.kind === "not-configured" && (
+              <p className="mt-1.5 font-normal">
+                Search Console credentials are not set on this deployment. Missing:{" "}
+                <span className="font-mono font-semibold">{gscFailure.missing.join(", ")}</span>. Add them to the
+                hosting environment and redeploy — env vars are not picked up by an existing deployment.
+              </p>
+            )}
+            {gscFailure?.kind === "auth-failed" && (
+              <p className="mt-1.5 font-normal">
+                Google rejected the credentials (<span className="font-mono">{gscFailure.detail}</span>). A refresh
+                token only works with the OAuth client that minted it, so this is almost always{" "}
+                <span className="font-mono font-semibold">GOOGLE_INTERNAL_CLIENT_ID</span>/
+                <span className="font-mono font-semibold">_SECRET</span> missing here — the code then falls back to
+                the customer-facing app client, which never issued this token. Set both and redeploy, or re-mint the
+                token with <span className="font-mono">scripts/gsc_oauth_setup.js</span>.
+              </p>
+            )}
+            {gscFailure?.kind === "api-error" && (
+              <p className="mt-1.5 font-normal">
+                Search Console returned an error (<span className="font-mono">{gscFailure.detail}</span>). Credentials
+                look correct, so this is likely transient or a quota limit — the catalog below is unaffected.
+              </p>
+            )}
           </div>
         )}
 

--- a/lib/gsc-performance.ts
+++ b/lib/gsc-performance.ts
@@ -12,6 +12,20 @@ export interface GscMetrics {
   position: number
 }
 
+/**
+ * Why live data is missing, when it is.
+ *
+ * Collapsing every failure to `null` meant the page said "unavailable" whether
+ * the credentials were absent, the refresh token belonged to the wrong OAuth
+ * client, or Google was simply down — three problems with three different
+ * fixes, indistinguishable on screen. This is what tells them apart without
+ * anyone opening the function logs.
+ */
+export type GscUnavailableReason =
+  | { kind: "not-configured"; missing: string[] }
+  | { kind: "auth-failed"; detail: string }
+  | { kind: "api-error"; detail: string }
+
 export interface GscPerformance {
   byPath: Record<string, GscMetrics> // pathname -> aggregated metrics
   byQuery: Record<string, GscMetrics> // lowercased query -> metrics
@@ -20,6 +34,30 @@ export interface GscPerformance {
 }
 
 const { GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_GSC_REFRESH_TOKEN, GSC_SITE_URL } = internalEnv()
+
+/**
+ * Set on the failing path and read by the page after it gets null back.
+ *
+ * Module scope rather than a return value because getGscPerformance is wrapped
+ * in unstable_cache, which caches the resolved value — threading a reason
+ * through the return type would cache the reason too, and a stale "not
+ * configured" would outlive the fix by an hour.
+ */
+let lastFailure: GscUnavailableReason | null = null
+
+export function gscLastFailure(): GscUnavailableReason | null {
+  return lastFailure
+}
+
+/** Reported when credentials are absent, so the page can name them. */
+export function gscMissingConfig(): string[] {
+  return [
+    !GOOGLE_CLIENT_ID && "GOOGLE_INTERNAL_CLIENT_ID (or GOOGLE_CLIENT_ID)",
+    !GOOGLE_CLIENT_SECRET && "GOOGLE_INTERNAL_CLIENT_SECRET (or GOOGLE_CLIENT_SECRET)",
+    !GOOGLE_GSC_REFRESH_TOKEN && "GOOGLE_GSC_REFRESH_TOKEN",
+    !GSC_SITE_URL && "GSC_SITE_URL",
+  ].filter(Boolean) as string[]
+}
 
 /**
  * Fetch a window of Search Console performance.
@@ -37,18 +75,10 @@ export async function getGscPerformance(window: {
   start: string
   end: string
 }): Promise<GscPerformance | null> {
-  if (!GOOGLE_CLIENT_ID || !GOOGLE_CLIENT_SECRET || !GOOGLE_GSC_REFRESH_TOKEN || !GSC_SITE_URL) {
-    console.warn(
-      "[gsc-performance] not configured — missing:",
-      [
-        !GOOGLE_CLIENT_ID && "GOOGLE_CLIENT_ID",
-        !GOOGLE_CLIENT_SECRET && "GOOGLE_CLIENT_SECRET",
-        !GOOGLE_GSC_REFRESH_TOKEN && "GOOGLE_GSC_REFRESH_TOKEN",
-        !GSC_SITE_URL && "GSC_SITE_URL",
-      ]
-        .filter(Boolean)
-        .join(", ")
-    )
+  const missing = gscMissingConfig()
+  if (missing.length) {
+    lastFailure = { kind: "not-configured", missing }
+    console.warn("[gsc-performance] not configured — missing:", missing.join(", "))
     return null
   }
 
@@ -111,7 +141,15 @@ export async function getGscPerformance(window: {
 
     return { byPath, byQuery, window: { start: startDate, end: endDate }, fetchedAt: new Date().toISOString() }
   } catch (e) {
-    console.error("[gsc-performance] fetch failed:", (e as Error).message)
+    const detail = (e as Error).message || "unknown error"
+    // unauthorized_client / invalid_grant mean the refresh token was minted by
+    // a DIFFERENT OAuth client than the one in use — the exact failure when
+    // GOOGLE_INTERNAL_CLIENT_ID is absent and internalEnv() silently falls back
+    // to the customer-facing app client. Naming it is the whole point: the
+    // generic message sends people to look at the token, which is fine.
+    const isAuth = /unauthorized_client|invalid_grant|invalid_client/i.test(detail)
+    lastFailure = isAuth ? { kind: "auth-failed", detail } : { kind: "api-error", detail }
+    console.error(`[gsc-performance] fetch failed (${isAuth ? "auth" : "api"}):`, detail)
     return null
   }
 }


### PR DESCRIPTION
The tracker showed "Live GSC data unavailable" for three unrelated causes with three different fixes: credentials absent on the deployment, a refresh token that belongs to a different OAuth client, and Google returning an error. On screen they were indistinguishable, so the only way to tell them apart was reading Vercel function logs.

The live cause is the second one, reproduced locally: with all four variables set the query returns real rows, and simulating production without GOOGLE_INTERNAL_CLIENT_ID fails with `unauthorized_client`. internalEnv() deliberately falls back to the customer-facing app client when the internal one is absent — that fallback exists so old tokens survive a migration — but a refresh token only works with the client that minted it, so the fallback guarantees failure rather than avoiding it. The banner now names GOOGLE_INTERNAL_CLIENT_ID/_SECRET directly, because "check your token" sends people to the wrong place.

Two details worth keeping:

The reason lives in module state rather than the return value because getGscPerformance is wrapped in unstable_cache. Threading it through the return type would cache the reason too, and a stale "not configured" would outlive the fix by an hour.

That same caching means a cached null re-renders without re-entering the function, leaving no recorded reason — so the page falls back to the config check, which needs no network and is always current. The common case still explains itself on a cache hit.

Verified: the auth-vs-transient classifier is correct on all six real error strings, including that a quota error must NOT be blamed on credentials. The page itself sits behind the internal-tools lock, so the rendered banner could not be exercised over HTTP without a session — the branch logic is plain conditional markup, but that is untested rather than tested.


Claude-Session: https://claude.ai/code/session_01VtMRMpNeUXmMgHNt6nsfKg