### PR TITLE
fix(texas): move the licensing index above the back link

### DIFF
--- a/app/texas/page.tsx
+++ b/app/texas/page.tsx
@@ -134,11 +134,11 @@ export default async function TexasHubPage() {
         backLabel="← Back to Search"
         heroStat={heroStat}
         resourcesNote={resourcesNote}
+        /* Below the directory on purpose — someone here for a barbershop should
+           not scroll past a licensing index to reach one — but above the back
+           link, which ends the page. */
+        beforeBackLink={<TexasResourceIndex />}
       />
-      {/* Below the directory on purpose. Someone here for a barbershop should
-          not scroll past a licensing index to reach one — this is for the other
-          audience, and it gives 13 previously orphaned pages an inbound link. */}
-      <TexasResourceIndex />
     </>
   );
 }

--- a/components/texas-hub/TexasHubDirectory.tsx
+++ b/components/texas-hub/TexasHubDirectory.tsx
@@ -53,6 +53,7 @@ export function TexasHubDirectory({
   backLabel,
   heroStat,
   resourcesNote,
+  beforeBackLink,
 }: {
   data: TexasHubData;
   title: string;
@@ -63,6 +64,13 @@ export function TexasHubDirectory({
   heroStat?: React.ReactNode;
   /** One line of context above the Statewide Resources grid. */
   resourcesNote?: React.ReactNode;
+  /**
+   * Rendered after Statewide Resources but BEFORE the back link, inside this
+   * component's light theme scope. The Texas licensing index used to render as
+   * a sibling of this component, which put it visually below "Back to Search" —
+   * the last thing on the page sat after the thing that ends the page.
+   */
+  beforeBackLink?: React.ReactNode;
 }) {
   const qualifyingCities = data.cities.filter((c) => c.qualifies);
   const otherCities = data.cities.filter((c) => !c.qualifies);
@@ -242,6 +250,8 @@ export function TexasHubDirectory({
             ))}
           </div>
         </div>
+
+        {beforeBackLink}
 
         <div className="text-center mt-10">
           <Link href={backHref} className="text-sm font-bold text-slate-500 hover:text-indigo-600 transition-colors">

--- a/components/texas-hub/TexasResourceIndex.tsx
+++ b/components/texas-hub/TexasResourceIndex.tsx
@@ -116,11 +116,11 @@ const GROUPS: ResourceGroup[] = [
 
 export function TexasResourceIndex() {
   return (
-    // `light` and the slate background are carried explicitly: this renders as a
-    // sibling of TexasHubDirectory rather than a child, so it does not inherit
-    // that component's theme scoping and would otherwise pick up the dark root.
-    <section className="light bg-slate-50 text-slate-900">
-      <div className="mx-auto max-w-7xl px-4 sm:px-6 pb-16">
+    // Rendered through TexasHubDirectory's beforeBackLink slot, so it sits
+    // inside that component's light theme scope and its container. No wrapper
+    // of its own is needed — an earlier version carried one because it used to
+    // render as a sibling and inherited the dark root theme.
+    <section className="mt-12">
       <div className="mb-6 border-t border-slate-200 pt-10">
         <h2 className="text-2xl font-black tracking-tight text-slate-900">
           Licensing, exams and opening a shop in Texas
@@ -156,7 +156,6 @@ export function TexasResourceIndex() {
             </ul>
           </div>
         ))}
-        </div>
       </div>
     </section>
   );


### PR DESCRIPTION
It rendered as a sibling of TexasHubDirectory, and the "Back to Search" link lives inside that component — so the index landed after the thing that ends the page. Content below the exit is content nobody reaches.

TexasHubDirectory gains an optional beforeBackLink slot rather than hardcoding the section, because CaliforniaHubDirectory shares this component and should be unaffected. The index passes through that slot from app/texas/page.tsx.

Being inside the parent now also makes its own theme wrapper redundant — it was carrying "light bg-slate-50 text-slate-900" only because rendering as a sibling meant inheriting the dark root instead. That comes back out, along with its duplicate max-width container, so it sits in the parent's grid like every other section.

Verified on the rendered page by document position:

  501138  Statewide Resources
  503058  Licensing index
  519847  Back to Search

42 entity links and 36 resource links intact, no stray theme wrapper.