### PR TITLE
feat(seo): 308 the old domain to shearquery.com

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -180,6 +180,44 @@ const nextConfig = {
     });
 
     return [
+      // ---------------------------------------------------------------------
+      // THE DOMAIN MOVE: agency.innergcomplete.com -> shearquery.com
+      // ---------------------------------------------------------------------
+      // Permanent (308) and path-preserving. Google treats 301 and 308 alike
+      // as permanent, so 308 is chosen for the other half of its meaning: 301
+      // historically lets a client turn a POST into a GET, 308 requires the
+      // method be preserved. This domain still receives POSTs (/mcp, form
+      // handlers), and a silently downgraded POST fails in a way nothing logs.
+      //
+      // Page-by-page, never a catch-all to "/". Google: "Don't redirect many
+      // old URLs to one irrelevant single URL destination, such as the home
+      // page." The equity here is 9,785 long-tail entity URLs, so a homepage
+      // catch-all would discard essentially all of it.
+      //
+      // WHAT IS EXCLUDED, AND WHY IT COSTS NOTHING. /api/* and the OAuth
+      // */callback routes keep answering on the old host. They are machine
+      // endpoints registered with third parties — /api/security/risc is where
+      // Google POSTs Cross-Account Protection tokens, and seven providers hold
+      // redirect URIs on this domain. A browser follows a 308; a server-to-
+      // server caller may not, and would fail silently. Every one of these is
+      // robots-disallowed or unindexed, so keeping them is free in SEO terms.
+      // Remove these exclusions once each integration has been repointed.
+      {
+        source: "/",
+        has: [{ type: "host", value: "agency.innergcomplete.com" }],
+        destination: "https://shearquery.com/",
+        permanent: true,
+      },
+      {
+        // The exclusions live in this pattern rather than in earlier "skip"
+        // rules, because Next.js redirects have no skip — a rule that sends a
+        // path back to itself is a loop, not an exemption.
+        source: "/:path((?!api/|_next/|_vercel/)(?!.*callback).*)",
+        has: [{ type: "host", value: "agency.innergcomplete.com" }],
+        destination: "https://shearquery.com/:path",
+        permanent: true,
+      },
+
       // Consolidate the texasbarbering.innergcomplete.com subdomain onto the
       // primary agency.innergcomplete.com domain. That subdomain served a
       // near-complete duplicate of the entire site (only its homepage was


### PR DESCRIPTION
The move itself. Path-preserving and permanent, matched on the inbound host so shearquery.com is untouched and cannot loop.

308 rather than 301. Google treats both as permanent, so this is about the other half of the meaning: 301 historically permits a client to turn a POST into a GET, 308 requires the method be preserved. This host still takes POSTs — /mcp, the form handlers — and a POST silently downgraded to a GET fails in a way that appears in no log.

Page-by-page, never a catch-all to "/". Google: "Don't redirect many old URLs to one irrelevant single URL destination, such as the home page." The equity is 9,785 long-tail entity URLs; a homepage catch-all discards essentially all of it.

/api/* and the OAuth */callback routes are deliberately NOT redirected. They are machine endpoints held by third parties — /api/security/risc is where Google POSTs Cross-Account Protection tokens, and seven providers hold redirect URIs on this host. A browser follows a 308; a server-to- server caller may not, and would fail silently. All of them are robots-disallowed or unindexed, so the exclusion costs nothing in SEO. Drop it once each integration is repointed.

Done in next.config rather than as a Vercel domain redirect precisely because of those exclusions: a dashboard redirect is whole-domain and cannot express them.

The exclusions sit inside the catch-all's own pattern because Next.js redirects have no skip — a rule pointing a path at itself is a loop, not an exemption. First attempt did exactly that.

Verified against a dev server with spoofed Host headers: root, nested paths, query strings and .md twins all 308 with the path intact; /api/security/risc and /linkedin/callback pass through untouched; shearquery.com answers 200 everywhere with no loop.


Claude-Session: https://claude.ai/code/session_01RTF3ibrf1oSQ8sHtx969wf