### PR TITLE
feat(schools): the three questions the panel promised

### DIFF
--- a/.claude/skills/geo-audit/SKILL.md
+++ b/.claude/skills/geo-audit/SKILL.md
@@ -28,7 +28,7 @@ The twin is automatic, so the failure mode is silent: a route that becomes
 markdown-ineligible loses its twin with no error anywhere.
 
 ```bash
-curl -s https://agency.innergcomplete.com/sitemap.xml | grep -o '<loc>[^<]*</loc>' \
+curl -s https://shearquery.com/sitemap.xml | grep -o '<loc>[^<]*</loc>' \
   | sed 's/<[^>]*>//g' | sort -R | head -25 | while read u; do
   b=$(curl -s --max-time 30 "$u.md" | wc -c | tr -d ' ')
   s=$(curl -s -o /dev/null -w '%{http_code}' --max-time 30 "$u.md")
@@ -58,7 +58,7 @@ Spot-check a figure that appears in both, especially after touching
 `lib/compare-content.ts` or a page that renders live data:
 
 ```bash
-curl -s https://agency.innergcomplete.com/compare-shops.md | head -40
+curl -s https://shearquery.com/compare-shops.md | head -40
 ```
 
 Numbers there must come from the same builder the HTML page uses. If someone
@@ -80,7 +80,7 @@ That is currently tolerated, not accidental — but re-check it whenever
 anything from an AI crawler.
 
 ```bash
-curl -s https://agency.innergcomplete.com/robots.txt
+curl -s https://shearquery.com/robots.txt
 ```
 
 Also confirm the `*` group still carries `Disallow: /*.md$` — the twins are
@@ -96,7 +96,7 @@ entry covers both.
 
 ```bash
 for p in /account/add-business /accept-invite /admin/ad-campaigns /dashboard; do
-  printf "  %-26s %s\n" "$p" "$(curl -s -o /dev/null -w '%{http_code}' https://agency.innergcomplete.com$p.md)"
+  printf "  %-26s %s\n" "$p" "$(curl -s -o /dev/null -w '%{http_code}' https://shearquery.com$p.md)"
 done
 ```
 
@@ -106,7 +106,7 @@ deliberately, so the response does not reveal which private paths exist.
 ## 5. Is the MCP server answering?
 
 ```bash
-curl -s -X POST https://agency.innergcomplete.com/mcp \
+curl -s -X POST https://shearquery.com/mcp \
   -H 'Content-Type: application/json' \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | python3 -m json.tool | head -20
 ```

--- a/.claude/skills/publish-page/SKILL.md
+++ b/.claude/skills/publish-page/SKILL.md
@@ -78,7 +78,7 @@ not reintroduce a `.slice(0, 160)`.
 
 ## 4. Canonical
 
-`alternates: { canonical: "https://agency.innergcomplete.com/<route>" }` on
+`alternates: { canonical: "https://shearquery.com/<route>" }` on
 every public page. The pages currently without one are all private or
 noindex, which is correct — keep it that way.
 
@@ -141,7 +141,7 @@ Then `npm run build`. **A metadata mistake will not fail the build**, which
 is precisely why the render check comes first.
 
 Remember what a push does and does not do: it reaches
-`staging.innergcomplete.com`, not production. `agency.innergcomplete.com`
+`staging.innergcomplete.com`, not production. `shearquery.com`
 only moves on a manual PR into `main`.
 
 ## 8. Claims on the page

--- a/.claude/skills/verify-live/SKILL.md
+++ b/.claude/skills/verify-live/SKILL.md
@@ -21,16 +21,24 @@ mistake that was actually made, not a hypothetical.
 |---|---|---|
 | `localhost:<port>` | your working tree | `next dev` |
 | `staging.innergcomplete.com` | `barber-intel-diagnostic-v2` | pushing to the branch |
-| `agency.innergcomplete.com` | `main` — **production** | a **manual PR**, merged by a human |
+| `shearquery.com` | `main` — **production** | a **manual PR**, merged by a human |
+| `agency.innergcomplete.com` | nothing — **308s to shearquery.com** | — |
+
+**The production domain moved.** `agency.innergcomplete.com` now 308-redirects
+every path to `shearquery.com`, and `SITE_URL` in `lib/site.ts` is the one
+place that origin is written down. Checking the old host without `-L` returns
+a 15-byte "Redirecting..." body, whose `<title>` and canonical greps both come
+back empty — which reads exactly like a page with no metadata. Use `-L`, or
+check `shearquery.com` directly.
 
 **Pushing does not change production.** A fix committed and pushed reaches
-staging only. Checking `agency.innergcomplete.com` afterwards shows the old
+staging only. Checking `shearquery.com` afterwards shows the old
 behaviour, which reads exactly like the fix failing — and the natural
 response, "re-apply it harder", makes things worse.
 
 So:
 
-- **Diagnosing what is wrong in the wild** → `agency.innergcomplete.com`.
+- **Diagnosing what is wrong in the wild** → `shearquery.com`.
   That is what real users and Googlebot get.
 - **Confirming your fix works** → `localhost` or `staging`, never production
   until the PR is merged.
@@ -92,8 +100,8 @@ signal.
 Always establish the status before interpreting the body:
 
 ```bash
-curl -s --no-location -D - -o /dev/null https://agency.innergcomplete.com/some-page | head -3
-curl -sL -o /dev/null -w "final: %{url_effective} (%{num_redirects} hops, %{http_code})\n" https://agency.innergcomplete.com/some-page
+curl -s --no-location -D - -o /dev/null https://shearquery.com/some-page | head -3
+curl -sL -o /dev/null -w "final: %{url_effective} (%{num_redirects} hops, %{http_code})\n" https://shearquery.com/some-page
 ```
 
 If it redirects, `noindex` markup is the wrong tool — fix it in the sitemap
@@ -124,7 +132,7 @@ survives and every URL reads as changed. Use `sed -E`.
 ```bash
 norm() { grep -o '<loc>[^<]*</loc>' | sed 's/<[^>]*>//g' | sed -E 's|https?://[^/]+||' | sort -u; }
 curl -s -m 900 localhost:3399/sitemap.xml | norm > /tmp/new.txt
-curl -s https://agency.innergcomplete.com/sitemap.xml | norm > /tmp/old.txt
+curl -s https://shearquery.com/sitemap.xml | norm > /tmp/old.txt
 comm -23 /tmp/old.txt /tmp/new.txt   # removed — must be exactly what you intended
 comm -13 /tmp/old.txt /tmp/new.txt   # added
 ```
@@ -137,7 +145,7 @@ exclusion.
 ## The checks themselves
 
 ```bash
-P=https://agency.innergcomplete.com/some-page     # or localhost:3399/some-page
+P=https://shearquery.com/some-page     # or localhost:3399/some-page
 curl -s "$P" | grep -io '<title>[^<]*</title>'
 curl -s "$P" | grep -io '<meta name="description" content="[^"]*"'
 curl -s "$P" | grep -io '<meta name="robots"[^>]*>'
@@ -159,10 +167,10 @@ Loop over the sitemap rather than spot-checking, and let the data pick the
 priorities:
 
 ```bash
-curl -s https://agency.innergcomplete.com/sitemap.xml | grep -o '<loc>[^<]*</loc>' \
+curl -s https://shearquery.com/sitemap.xml | grep -o '<loc>[^<]*</loc>' \
   | sed 's/<[^>]*>//g' | sort -R | head -30 | while read u; do
   h=$(curl -s --max-time 30 "$u")
-  printf "%-64s %s | %s\n" "${u#https://agency.innergcomplete.com}" \
+  printf "%-64s %s | %s\n" "${u#https://shearquery.com}" \
     "$(echo "$h" | grep -io 'content="\(noindex[^"]*\|index, follow\)"' | head -1)" \
     "$(echo "$h" | grep -io '<title>[^<]*</title>' | head -1 | sed 's/<[^>]*>//g' | cut -c1-40)"
 done

--- a/app/api/internal/pass-rate-send/route.ts
+++ b/app/api/internal/pass-rate-send/route.ts
@@ -78,6 +78,10 @@ function emailHtml(opts: {
       <a href="${url}">${opts.schoolName} on ShearQuery</a> &middot;
       <a href="${SITE}/compare-schools">Compare all schools</a>
     </p>
+    <p>And the other half of what we promised you &mdash;
+      <a href="${SITE}/questions-to-ask-a-barber-cosmetology-school">the three questions worth asking on your tour</a>.
+      The first is about why the exam is written in language your textbook never uses.
+    </p>
     <p style="color:#666;font-size:12px">You're getting this because you asked for ${opts.schoolName}'s ${opts.period} results on ShearQuery. That was the only email we promised.</p>
   `;
 }

--- a/app/questions-to-ask-a-barber-cosmetology-school/page.tsx
+++ b/app/questions-to-ask-a-barber-cosmetology-school/page.tsx
@@ -1,0 +1,240 @@
+import Link from "next/link";
+import { AlertTriangle, ArrowRight, BookOpen, CalendarClock, Users } from "lucide-react";
+import { Navbar } from "@/components/layout/navbar";
+import { ResearchByline } from "@/components/research-byline";
+import { authorSchema } from "@/lib/author";
+import { SITE_URL } from "@/lib/site";
+
+/**
+ * The three questions the school pass-rate panel promises.
+ *
+ * WHY THESE THREE. Not "questions to ask a school" in the generic
+ * tour-checklist sense — that page exists a hundred times and helps nobody.
+ * Each of these is something an applicant cannot find out from the school's
+ * own website, and two of them come with a follow-up that only works because
+ * the visitor has already read our exam data.
+ *
+ * SOURCING. Every figure here is from lib/tdlr-sources.ts and nothing is
+ * carried between licences: barber and cosmetology operator are BOTH 1,000
+ * hours with written eligibility at 900 (apply-barber, apply-cosmetologist —
+ * separately verified entries, which is why both can be stated together), and
+ * PSI administering on TDLR's behalf is the `examinations` entry. The
+ * specialty licences have different hour totals and are deliberately not
+ * mentioned; see CLAUDE.md.
+ *
+ * The Milady/PSI wording gap is not a TDLR claim and is not presented as one.
+ * It is framed as a question to put to a school, because that is what it is.
+ */
+
+const TITLE = "3 Questions to Ask a Barber or Cosmetology School";
+const DESCRIPTION =
+  "Three things a school's website won't tell you: how they bridge Milady to PSI wording, what happens if you pause, and what they teach about getting clients.";
+const VERIFIED_ON = "2026-08-06";
+
+const QUESTIONS = [
+  {
+    icon: BookOpen,
+    q: "You teach from Milady. The exam is written by PSI. How do you close the gap?",
+    why:
+      "Milady explains things in plain, familiar language. PSI writes exam questions in a different register — double negatives, and terms that never appear in the textbook a student spent a year in. A candidate can know the material and still misread the question.",
+    good:
+      "They can describe how they drill PSI-style phrasing specifically: practice questions written the way the exam writes them, not just chapter reviews.",
+    bad:
+      "“We cover all the Milady content.” That answers a question about material, not about wording, and it usually means nobody there has looked at how the two differ.",
+    followUp:
+      "Your first-attempt pass rate is on our page for this school. Ask what happens to the students who don’t pass first time — and whether the school thinks the gap is the wording or something else.",
+  },
+  {
+    icon: CalendarClock,
+    q: "What happens if I have to stop for a while?",
+    why:
+      "Barber and cosmetology operator programmes are both 1,000 clock hours. Most students cannot hold a full-time job and finish on the school’s intended schedule, so pausing is common rather than exceptional — and how a school handles it is policy, not law.",
+    good:
+      "A written leave-of-absence policy, a clear answer on what re-enrolling costs, and a straight answer about financial aid.",
+    bad:
+      "Vagueness, or “that doesn’t really happen here.” It does. A school that hasn’t written the policy down has not thought about the students it loses.",
+    followUp:
+      "Worth knowing before you ask: TDLR lets you sit the written exam at 900 hours, before the full 1,000 are finished. Ask whether the school schedules students for it then, or makes everyone wait.",
+  },
+  {
+    icon: Users,
+    q: "What do you teach about getting clients?",
+    why:
+      "Technique gets you licensed. A book of clients is what pays the booth rent. Most programmes teach the first thoroughly and the second not at all, and graduates discover the difference in their first month paying for a chair.",
+    good:
+      "Something specific and current — how to build a following, how to keep a client coming back, how to price. Ideally taught by someone who is doing it now.",
+    bad:
+      "A one-off guest speaker, or a business module that hasn’t changed since before social media was how people find a barber.",
+    followUp:
+      "Our booth rent data shows what a chair costs in your city. Ask how many clients the programme expects you to have on the day you start paying that.",
+  },
+];
+
+export const metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  keywords: [
+    "questions to ask a cosmetology school",
+    "questions to ask a barber school",
+    "how to choose a barber school",
+    "how to choose a cosmetology school",
+    "psi exam vs milady",
+    "barber school tour questions",
+  ],
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: `${SITE_URL}/questions-to-ask-a-barber-cosmetology-school`,
+    type: "article",
+  },
+  alternates: { canonical: `${SITE_URL}/questions-to-ask-a-barber-cosmetology-school` },
+};
+
+export default function QuestionsToAskPage() {
+  return (
+    <div className="min-h-screen light bg-white text-slate-950">
+      <Navbar />
+      <main className="mx-auto max-w-3xl px-4 sm:px-6 pt-28 pb-16">
+        <p className="mb-3 text-xs font-black uppercase tracking-[0.25em] text-indigo-600">
+          Before you enrol
+        </p>
+        <h1 className="mb-4 text-3xl font-black leading-tight tracking-tight text-slate-950 sm:text-4xl">
+          Three questions to ask a barber or cosmetology school
+        </h1>
+
+        <ResearchByline verifiedOn={VERIFIED_ON} what="Hour requirements read from TDLR sources, compiled" />
+
+        <p className="mb-10 text-base leading-relaxed text-slate-600 sm:text-lg">
+          Every school will show you the floor, the tools and the graduation photos. None of that
+          separates a good programme from a bad one. These three do, and none of them can be
+          answered from a brochure.
+        </p>
+
+        <div className="space-y-8">
+          {QUESTIONS.map((item, i) => {
+            const Icon = item.icon;
+            return (
+              <section key={item.q} className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm sm:p-7">
+                <div className="mb-4 flex items-start gap-3">
+                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-indigo-600 text-sm font-black text-white">
+                    {i + 1}
+                  </span>
+                  <h2 className="text-lg font-black leading-snug text-slate-900 sm:text-xl">
+                    &ldquo;{item.q}&rdquo;
+                  </h2>
+                </div>
+
+                <p className="mb-5 flex gap-2 text-sm leading-relaxed text-slate-600">
+                  <Icon className="mt-0.5 h-4 w-4 shrink-0 text-slate-400" />
+                  <span>{item.why}</span>
+                </p>
+
+                <div className="mb-4 grid gap-3 sm:grid-cols-2">
+                  <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-3">
+                    <p className="mb-1 text-[10px] font-black uppercase tracking-widest text-emerald-700">
+                      A good answer
+                    </p>
+                    <p className="text-sm leading-relaxed text-emerald-900">{item.good}</p>
+                  </div>
+                  <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3">
+                    <p className="mb-1 text-[10px] font-black uppercase tracking-widest text-amber-700">
+                      A warning sign
+                    </p>
+                    <p className="text-sm leading-relaxed text-amber-900">{item.bad}</p>
+                  </div>
+                </div>
+
+                <p className="flex gap-2 rounded-xl bg-slate-50 px-4 py-3 text-sm leading-relaxed text-slate-700">
+                  <ArrowRight className="mt-0.5 h-4 w-4 shrink-0 text-indigo-600" />
+                  <span>
+                    <strong className="font-black text-slate-900">Then follow up:</strong>{" "}
+                    {item.followUp}
+                  </span>
+                </p>
+              </section>
+            );
+          })}
+        </div>
+
+        <section className="mt-10 rounded-2xl border border-slate-900 bg-slate-900 px-6 py-6 sm:px-7">
+          <h2 className="text-lg font-black text-white">Go in knowing the numbers</h2>
+          <p className="mt-2 text-sm leading-relaxed text-slate-300">
+            Two of these questions land harder when you already know how the school performs. We
+            publish state board pass rates by school, and what a chair actually costs once you
+            qualify.
+          </p>
+          <div className="mt-5 flex flex-wrap gap-3">
+            <Link
+              href="/compare-schools"
+              data-ig-click="questions_to_compare_schools"
+              className="inline-flex items-center gap-2 rounded-xl bg-white px-5 py-3 text-sm font-bold text-slate-900 transition-colors hover:bg-slate-100"
+            >
+              Compare schools by pass rate
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+            <Link
+              href="/compare-shops"
+              data-ig-click="questions_to_compare_shops"
+              className="inline-flex items-center gap-2 rounded-xl border border-slate-700 px-5 py-3 text-sm font-bold text-white transition-colors hover:bg-white/5"
+            >
+              See booth rent by city
+            </Link>
+          </div>
+        </section>
+
+        <div className="mt-8 rounded-2xl border border-slate-200 bg-slate-50 px-6 py-5 text-sm leading-relaxed text-slate-600">
+          <p className="mb-2 flex gap-2">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-slate-400" />
+            <span>
+              Hour requirements are TDLR&apos;s: Class A Barber and Cosmetology Operator are each
+              1,000 hours, with the written exam available at 900. The specialty licences
+              (esthetician, manicurist, eyelash extension, hair weaving) have different totals
+              entirely &mdash; check the one you are actually enrolling for. Exams are administered
+              by PSI on TDLR&apos;s behalf.
+            </span>
+          </p>
+          <p className="pl-6">
+            Already studying?{" "}
+            <Link href="/tools/texas-cosmetology-exam-practice-deck" className="font-bold text-indigo-600 hover:underline">
+              Our practice deck
+            </Link>{" "}
+            drills the question style PSI uses against Milady citations &mdash; which is the gap
+            question 1 is about.
+          </p>
+        </div>
+      </main>
+
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "FAQPage",
+            mainEntity: QUESTIONS.map((item) => ({
+              "@type": "Question",
+              name: item.q,
+              acceptedAnswer: {
+                "@type": "Answer",
+                text: `${item.why} A good answer: ${item.good} A warning sign: ${item.bad}`,
+              },
+            })),
+          }),
+        }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@type": "Article",
+            author: authorSchema(),
+            headline: TITLE,
+            description: DESCRIPTION,
+            dateModified: VERIFIED_ON,
+            mainEntityOfPage: `${SITE_URL}/questions-to-ask-a-barber-cosmetology-school`,
+          }),
+        }}
+      />
+    </div>
+  );
+}

--- a/components/schools/pass-rate-alert.tsx
+++ b/components/schools/pass-rate-alert.tsx
@@ -187,8 +187,17 @@ export function PassRateAlert({
                   We publish {examState === "CA" ? "California" : "Texas"} state board results by
                   school. The {CURRENT_PERIOD} figures on this page{" "}
                   {COVERAGE[examState === "CA" ? "CA" : "TX"]}; leave your email and we&apos;ll send
-                  you this school&apos;s {NEXT_PERIOD} results when they land — plus the three
-                  questions worth asking on your tour.
+                  you this school&apos;s {NEXT_PERIOD} results when they land — plus the{" "}
+                  <a
+                    href="/questions-to-ask-a-barber-cosmetology-school"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    data-ig-click="panel_three_questions"
+                    className="font-semibold text-indigo-300 underline underline-offset-2 hover:text-indigo-200"
+                  >
+                    three questions worth asking on your tour
+                  </a>
+                  .
                 </p>
               </div>
             </div>


### PR DESCRIPTION
The pass-rate panel told students they'd get "the three questions worth asking on your tour" and there was nothing behind it. This is that page, and the promise is now a link rather than a claim.

The three come from what actually trips students up, not a generic tour checklist:

1. Milady vs PSI wording. The textbook teaches in plain terms; the exam is written in another register — double negatives, words that never appear in Milady. A candidate can know the material and misread the question. This one is checkable: a school that has thought about it describes how it drills PSI phrasing; one that hasn't says "we cover the Milady content". The cosmetology practice deck already pairs "Milady citations and question style PSI uses", so the page can point at proof we did the work.

2. Pausing. Both programmes are 1,000 hours and most students cannot hold a full-time job and finish on schedule, so stopping is normal rather than exceptional — and it is school policy, not law. Deliberately framed that way: there is no TDLR rule here to cite, so none is implied.

3. Getting clients. Technique gets you licensed; a book pays the booth rent.

Two carry a follow-up that only works because the reader has our data — the school's first-attempt rate, and what a chair costs in their city. That is what makes this ours rather than advice anyone could write.

Figures are from lib/tdlr-sources.ts and nothing is carried between licences: apply-barber and apply-cosmetologist are separately verified at 1,000 hours with written eligibility at 900, which is why both are stated together. The specialty licences differ and are pointedly excluded. PSI administering on TDLR's behalf is the `examinations` entry. The 900-hour detail turns out to be the most useful thing on the page for question 2.

Also updates all three skills for the domain move. shearquery.com is production now and agency.innergcomplete.com 308s to it — which matters more than a find-and-replace suggests: curling the old host without -L returns a 15-byte "Redirecting..." body whose title and canonical greps come back empty, reading exactly like a page with no metadata. That cost a real detour today.