### PR TITLE
fix(chat): scope the assistant to all eight states, not just Texas

### DIFF
--- a/app/account/journey/journey-form.tsx
+++ b/app/account/journey/journey-form.tsx
@@ -34,6 +34,15 @@ const TRACKS_BY_STATE: Record<JourneyState, LicenseTrack[]> = {
   TX: ["barber", "cosmetology", "esthetician", "manicurist", "eyelash", "hair_weaving", "undecided"],
   CA: ["barber", "cosmetology", "esthetician", "manicurist", "hairstylist", "electrologist", "undecided"],
   MD: ["barber", "cosmetology", "esthetician", "manicurist", "eyelash", "hairstylist", "undecided"],
+  // The exam-only states. Tracks are listed where the state actually licenses
+  // them AND we hold a kit list, so nobody picks a licence we would then answer
+  // about from another state's document. Minnesota offers only "undecided"
+  // because its single page is the INSTRUCTOR practical, not an entry licence.
+  VA: ["barber", "cosmetology", "undecided"],
+  OH: ["barber", "cosmetology", "undecided"],
+  MS: ["barber", "cosmetology", "esthetician", "manicurist", "undecided"],
+  TN: ["barber", "undecided"],
+  MN: ["instructor", "undecided"],
 };
 
 const LABEL = "text-[10px] font-black uppercase tracking-widest text-slate-400 mb-1.5 block";

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -5,7 +5,7 @@ import { GoogleGenAI } from '@google/genai';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { computeShopEcosystemReport, getRentStatsByZip, findProfessionalEmployment, getTopVenuesByWorkerCount, getWorkersAtVenue, getConfirmationStats, listUnconfirmedMatches, getEmploymentMatchOverview, getSchoolExamStats, getStatewideExamStats, findStudentExamRecord, getSchoolRankingsByRegion, getTopSchoolsByPassRate, getSchoolTestTakers, getUpcomingEvents } from '@/lib/shop-ecosystem';
 import { currentMember, getJourney, appendToThread } from '@/lib/member-context';
-import { agentJourneyContext } from '@/lib/member-journey';
+import { agentJourneyContext, stateCoverageForChat } from '@/lib/member-journey';
 import { AUDIENCES } from '@/lib/audiences';
 import { slimContext, contextChars } from '@/lib/chat-context-slim';
 import { extractUsage, sumUsage, EMPTY_USAGE, type TokenUsage } from '@/lib/ai-usage';
@@ -380,6 +380,11 @@ export async function POST(req: Request) {
       // the member is must never be the thing that falls off the end.
       ...(journeyContext ? { member_journey_context: journeyContext } : {}),
       ...(shopEcosystemContext ? { my_shop_ecosystem_report: shopEcosystemContext } : {}),
+      // Near the top for the same truncation reason as the two above. Someone
+      // arriving from a state page's suggested question has NO journey profile,
+      // so this is the only thing that lets the assistant answer for a state
+      // other than Texas instead of refusing.
+      state_licensing_coverage: stateCoverageForChat(),
       texas_2026_exam_school_leaderboard: withProfileUrl(testingLeaderboard, '/schools'),
       texas_2026_cosmetology_exam_school_leaderboard: withProfileUrl(cosmetologyTestingLeaderboard, '/schools'),
       school_district_barbershop_rankings: districtBarbershopRankings,
@@ -429,6 +434,13 @@ MEMBER_JOURNEY_CONTEXT RULE: member_journey_context is in the context data below
 - Do not recite their profile back at them, do not open with a greeting that lists what you know, and use their first name at most once in a conversation. Someone who told you their exam date wants a better answer, not a demonstration that you remembered.
 - NEVER invent a journey fact. If member_journey_context says school_name is null, you do not know where they study — the same rule as every other fact on this page.
 ` : ''}
+STATE COVERAGE RULE: state_licensing_coverage lists every state this site covers, whether that state has a practical exam at all, and the kit lists we publish for it. Use it whenever someone asks about a state — including states with no business listings, where it may be the only thing you hold on them. Three things it settles that you must not get wrong:
+- If has_practical_exam is false, that state licenses on the written examination alone. Say so plainly and do not mention kits, mannequins or what to pack.
+- MATCH THE LICENCE LOOSELY BEFORE CONCLUDING WE HAVE NOTHING. The labels are formal; people are not. "esthetics" and "skin care" are Esthetician. "nails", "manicure" and "nail tech" are Manicurist / Nail Technician. "teaching" and "instructor" are Instructor. "hair" is usually Cosmetology. If any entry in practical_exam_kit_lists plausibly covers the licence they named, link THAT entry.
+- Only say we do not publish a kit list when practical_exam_kit_lists for that state is EMPTY, or when nothing in it covers their licence at all. Then link the state hub. Never substitute another state's kit — the exam vendors differ (PSI, NIC, and several boards run their own), and so do the kits.
+- Every profile_url in this block is a real internal link. Hyperlink it per the LINKING RULE.
+Exam data (the 2026 leaderboards) is Texas-only. Never present a Texas pass rate as though it applied to another state.
+
 LINKING RULE: Whenever you mention a specific tool from software_tools, or a specific barbershop/barber/school/salon/cosmetologist/store that has a profile_url (or profileUrl) field in the context, you MUST format that mention as a markdown link using its EXACT value, e.g. [Barber & Cosmetology Placement](/barber-beauty-network). Every one of those internal links is a relative path starting with "/" — NEVER use a link starting with "http" or "https" for these (this includes Google Places URLs like places.googleapis.com, which sometimes appear elsewhere in this data as image sources, not link destinations). If an item you want to mention does NOT have a profile_url/profileUrl in the context, mention it by plain name with NO link at all — do not construct, guess, or reuse a URL from anywhere else in the data.
 The ONE exception is articles_and_videos: each entry's "url" field IS meant to be used as-is (it's a real external link to that article or video, not our own site) — link to it directly, but keep the link label short (the page's title or topic), never the raw_text field, which is scraped page content for your own reference only and must never appear in your response.
 Use each link only once per response.

--- a/app/minnesota-cosmetology-instructor-practical-exam-kit-list/page.tsx
+++ b/app/minnesota-cosmetology-instructor-practical-exam-kit-list/page.tsx
@@ -114,9 +114,9 @@ export default function Page() {
 
         <AgentInvite
           questions={[
-            "What does Minnesota require to become a cosmetology instructor?",
-            "Which cosmetology schools are near me?",
-            "What does booth rent cost around me once I'm licensed?",
+            "What does Minnesota require for the cosmetology instructor practical?",
+            "How long must my presentation be, and what fails it?",
+            "Which states publish an instructor exam kit list?",
           ]}
         />
 

--- a/app/ohio-barber-practical-exam-kit-list/page.tsx
+++ b/app/ohio-barber-practical-exam-kit-list/page.tsx
@@ -126,9 +126,9 @@ export default function Page() {
 
         <AgentInvite
           questions={[
-            "What does Ohio require to get a barber licence?",
-            "Which barber schools are near me?",
-            "What does booth rent cost around me once I'm licensed?",
+            "Does Ohio publish a supply list for the barber practical?",
+            "What's graded on the Ohio barber practical?",
+            "How does Ohio's kit differ from Texas or Virginia?",
           ]}
         />
 

--- a/app/ohio-cosmetology-practical-exam-kit-list/page.tsx
+++ b/app/ohio-cosmetology-practical-exam-kit-list/page.tsx
@@ -126,9 +126,9 @@ export default function Page() {
 
         <AgentInvite
           questions={[
-            "What does Ohio require to get a barber licence?",
-            "Which barber schools are near me?",
-            "What does booth rent cost around me once I'm licensed?",
+            "Does Ohio publish a supply list for the cosmetology practical?",
+            "What's graded on the Ohio cosmetology practical?",
+            "Which states publish a kit list and which don't?",
           ]}
         />
 

--- a/app/tennessee-barber-technician-practical-exam-kit-list/page.tsx
+++ b/app/tennessee-barber-technician-practical-exam-kit-list/page.tsx
@@ -119,9 +119,9 @@ export default function Page() {
 
         <AgentInvite
           questions={[
-            "What does Tennessee require to get a barber technician licence?",
-            "Which barber schools are near me?",
-            "What does booth rent cost around me once I'm licensed?",
+            "What does the Tennessee test centre supply, and what must I bring?",
+            "What's graded on the Tennessee barber technician practical?",
+            "Which Tennessee barber licences publish a kit list?",
           ]}
         />
 

--- a/app/virginia-cosmetology-practical-exam-kit-list/page.tsx
+++ b/app/virginia-cosmetology-practical-exam-kit-list/page.tsx
@@ -101,9 +101,9 @@ export default function Page() {
 
         <AgentInvite
           questions={[
-            "What does Virginia require to get a cosmetology licence?",
-            "Which cosmetology schools are near me?",
-            "What does booth rent cost around me once I'm licensed?",
+            "Does Virginia have a practical exam, and who writes it?",
+            "What's on the Virginia cosmetology practical?",
+            "Why is Virginia's cosmetology kit different from its barber kit?",
           ]}
         />
 

--- a/app/virginia-master-barber-practical-exam-kit-list/page.tsx
+++ b/app/virginia-master-barber-practical-exam-kit-list/page.tsx
@@ -108,9 +108,9 @@ export default function Page() {
 
         <AgentInvite
           questions={[
-            "What does Virginia require to get a master barber licence?",
-            "Which barber schools are near me?",
-            "What does booth rent cost around me once I'm licensed?",
+            "Does Virginia have a practical exam, and who writes it?",
+            "What's on the Virginia master barber practical?",
+            "How does Virginia's kit differ from Texas or Maryland?",
           ]}
         />
 

--- a/components/journey/agent-invite.tsx
+++ b/components/journey/agent-invite.tsx
@@ -28,7 +28,14 @@ import { ArrowUpRight, Sparkles } from "lucide-react";
 export function AgentInvite({
   questions,
   heading = "Ask about your own situation",
-  blurb = "Our AI is grounded in real TDLR exam results, school records and shop data — ask it something this page doesn't cover.",
+  /**
+   * The default no longer claims TDLR grounding, because TDLR is Texas and
+   * this component now sits on Virginia, Ohio, Mississippi, Tennessee and
+   * Minnesota pages too. Promising Texas exam data to a Minnesota reader and
+   * then not having it is how the assistant came to look broken. Texas pages
+   * can still pass the stronger claim explicitly.
+   */
+  blurb = "Our AI is grounded in real licensing documents, school records and shop data — ask it something this page doesn't cover.",
 }: {
   questions: string[];
   heading?: string;

--- a/components/tools/ms-kit-page.tsx
+++ b/components/tools/ms-kit-page.tsx
@@ -115,11 +115,15 @@ export function MsKitPage({
 
         <KitChecklist groups={groups} />
 
+        {/* Questions the assistant can actually answer for Mississippi. The
+            previous set asked about nearby schools and booth rent, which exist
+            only for Texas and California — so clicking one produced a refusal
+            and made the assistant look broken on a page it should own. */}
         <AgentInvite
           questions={[
-            `What does Mississippi require to get a ${licence.toLowerCase()} licence?`,
-            "Which schools are near me?",
-            "What does booth rent cost around me once I'm licensed?",
+            `What's graded on the Mississippi ${licence.toLowerCase()} practical?`,
+            "Which of my supplies need an exact label in Mississippi?",
+            "How does Mississippi's kit differ from Texas?",
           ]}
         />
 

--- a/lib/member-journey.ts
+++ b/lib/member-journey.ts
@@ -30,7 +30,13 @@
  * so the milestone logic is testable rather than dependent on the clock.
  */
 
-export type JourneyState = "TX" | "CA" | "MD";
+/**
+ * Every state the assistant can answer for. Adding one here is not cosmetic —
+ * it is the switch that lets the chat scope an answer to that state at all,
+ * and STATE_HUBS below must gain a matching entry or the type will not compile.
+ */
+export type JourneyState =
+  | "TX" | "CA" | "MD" | "VA" | "OH" | "MS" | "TN" | "MN";
 
 export type LicenseTrack =
   | "barber"
@@ -41,6 +47,14 @@ export type LicenseTrack =
   | "hair_weaving"
   | "hairstylist"
   | "electrologist"
+  /**
+   * Teaching, not practising. Added when Minnesota arrived: its only kit page
+   * is the cosmetology INSTRUCTOR practical, a taught lesson. Filing that under
+   * `cosmetology` would hand a student a lesson-plan checklist; leaving it
+   * unmapped hid a page we actually publish, and the assistant then told
+   * someone we had nothing. Its own track is the only answer that is true.
+   */
+  | "instructor"
   | "undecided";
 
 /** What the member told us. Every field optional but `audience`-implied ones. */
@@ -74,6 +88,11 @@ export const STATE_LABELS: Record<JourneyState, string> = {
   TX: "Texas",
   CA: "California",
   MD: "Maryland",
+  VA: "Virginia",
+  OH: "Ohio",
+  MS: "Mississippi",
+  TN: "Tennessee",
+  MN: "Minnesota",
 };
 
 export const TRACK_LABELS: Record<LicenseTrack, string> = {
@@ -85,6 +104,7 @@ export const TRACK_LABELS: Record<LicenseTrack, string> = {
   hair_weaving: "Hair Weaving",
   hairstylist: "Hairstylist",
   electrologist: "Electrologist",
+  instructor: "Instructor",
   undecided: "Still deciding",
 };
 
@@ -95,12 +115,32 @@ export const TRACK_LABELS: Record<LicenseTrack, string> = {
  * mannequin prep, what to label) applies to a person at all.
  */
 export function hasPracticalExam(state: JourneyState): boolean {
-  return state !== "CA";
+  return !NO_PRACTICAL_EXAM.has(state);
 }
 
+/**
+ * States whose licensure is decided by the written examination alone.
+ *
+ * An explicit set rather than `state !== "CA"`, which was fine at three states
+ * and becomes a trap at eight — the next state added would have silently
+ * inherited "has a practical" whether or not it does. California is here
+ * because its bulletins contain the word "practical" zero times across 26
+ * pages. Every other state currently supported was confirmed to HAVE a
+ * practical while its kit pages were built.
+ */
+const NO_PRACTICAL_EXAM = new Set<JourneyState>(["CA"]);
+
 interface TrackRoutes {
-  /** How to get the licence in the first place. Always present. */
-  requirements: string;
+  /**
+   * How to get the licence in the first place.
+   *
+   * OPTIONAL since the exam-only states arrived. Virginia, Ohio, Mississippi
+   * and Tennessee have kit lists and no requirements guides yet, and callers
+   * already fall back to the state hub (`routes?.requirements ?? hub`), which
+   * is honest. Inventing a requirements URL to satisfy the type would send
+   * someone to a 404.
+   */
+  requirements?: string;
   /** The practical kit list, where the state has a practical exam AND we cover it. */
   kitList?: string;
   /** Written-exam preparation. */
@@ -199,6 +239,40 @@ const ROUTES: Record<JourneyState, Partial<Record<LicenseTrack, TrackRoutes>>> =
     eyelash: { requirements: "/maryland-cosmetology-license-requirements", kitList: "/maryland-eyelash-extension-practical-exam" },
     hairstylist: { requirements: "/maryland-cosmetology-license-requirements", kitList: "/maryland-hairstylist-practical-exam" },
   },
+  /**
+   * The five exam-only states. Kit lists exist; requirements, exam-prep and
+   * renewal pages do not yet, so those keys are absent and every caller falls
+   * back to the state hub.
+   */
+  VA: {
+    barber: { kitList: "/virginia-master-barber-practical-exam-kit-list" },
+    cosmetology: { kitList: "/virginia-cosmetology-practical-exam-kit-list" },
+  },
+  OH: {
+    barber: { kitList: "/ohio-barber-practical-exam-kit-list" },
+    cosmetology: { kitList: "/ohio-cosmetology-practical-exam-kit-list" },
+  },
+  MS: {
+    barber: { kitList: "/mississippi-barbering-practical-exam-kit-list" },
+    cosmetology: { kitList: "/mississippi-cosmetology-practical-exam-kit-list" },
+    manicurist: { kitList: "/mississippi-nail-technology-practical-exam-kit-list" },
+    esthetician: { kitList: "/mississippi-esthetics-practical-exam-kit-list" },
+  },
+  TN: {
+    // Tennessee's Barber Technician licence covers manicure and facial work,
+    // which is why the same kit serves both tracks. Master Barber and Barber
+    // Instructor publish no kit, so they are deliberately absent.
+    barber: { kitList: "/tennessee-barber-technician-practical-exam-kit-list" },
+  },
+  /**
+   * Minnesota's only kit page is the cosmetology INSTRUCTOR practical, so it
+   * sits under `instructor` rather than `cosmetology`. A student asking about
+   * the cosmetology track correctly gets no kit; someone asking about teaching
+   * gets the real page.
+   */
+  MN: {
+    instructor: { kitList: "/minnesota-cosmetology-instructor-practical-exam-kit-list" },
+  },
 };
 
 /** Where to send someone whose track we have no specific page for. */
@@ -206,7 +280,53 @@ export const STATE_HUBS: Record<JourneyState, string> = {
   TX: "/texas",
   CA: "/california",
   MD: "/maryland",
+  VA: "/virginia",
+  OH: "/ohio",
+  MS: "/mississippi",
+  TN: "/tennessee",
+  MN: "/minnesota",
 };
+
+/**
+ * Every state this site can answer for, as context for the AI assistant.
+ *
+ * WHY IT IS DERIVED RATHER THAN WRITTEN OUT. The chat's system prompt tells it
+ * to answer ONLY from the context it is given, so a state absent from that
+ * context is a state the assistant will refuse to discuss — which is exactly
+ * what happened when someone clicked a Minnesota question on a Minnesota page
+ * and got "I don't know". Hand-listing the states here would put that failure
+ * one forgotten edit away every time a state is added. Building it from
+ * STATE_HUBS and ROUTES means adding a state to the type is enough.
+ *
+ * `profile_url` is the field name on purpose: the chat's LINKING RULE only
+ * hyperlinks context items carrying `profile_url`, and its deterministic link
+ * filter strips any URL that was not in the context. Naming the key anything
+ * else would give the model a real page it is then forbidden to link.
+ */
+export function stateCoverageForChat() {
+  return (Object.keys(STATE_HUBS) as JourneyState[]).map((code) => {
+    const tracks = ROUTES[code];
+    const kits = (Object.keys(tracks) as LicenseTrack[])
+      .map((track) => ({ track, routes: tracks[track] as TrackRoutes | undefined }))
+      .filter((t) => t.routes?.kitList)
+      .map((t) => ({
+        licence: TRACK_LABELS[t.track],
+        profile_url: t.routes!.kitList as string,
+      }));
+    return {
+      state: STATE_LABELS[code],
+      state_code: code,
+      profile_url: STATE_HUBS[code],
+      has_practical_exam: hasPracticalExam(code),
+      practical_exam_kit_lists: kits,
+      coverage_note: kits.length
+        ? `We publish ${kits.length} practical exam kit list${kits.length > 1 ? "s" : ""} for ${STATE_LABELS[code]}.`
+        : hasPracticalExam(code)
+          ? `${STATE_LABELS[code]} has a practical exam but we do not publish a kit list for it yet — send them to the hub.`
+          : `${STATE_LABELS[code]} licenses on the written examination alone. There is no practical exam and no kit.`,
+    };
+  });
+}
 
 /** Every route this module can emit — the test walks this to check they exist. */
 export function allJourneyRoutes(): string[] {


### PR DESCRIPTION
Clicking a suggested question on the Minnesota page opened a chat that could not answer it. Three separate causes, all fixed here.

1. THE ASSISTANT ONLY KNEW THREE STATES. JourneyState was "TX" | "CA" | "MD", so VA, OH, MS, TN and MN did not exist to any code path that scopes an answer. Extended to eight, with STATE_HUBS, STATE_LABELS, ROUTES and the per-state track list filled in. The type caught every place that needed updating, which is why it is a union rather than a string.

2. NOTHING PUT STATE COVERAGE IN THE CONTEXT. The system prompt tells the model to answer ONLY from context, so a state absent from it is a state the model refuses to discuss. stateCoverageForChat() now emits every state, whether it has a practical exam, and the kit lists we publish — DERIVED from STATE_HUBS and ROUTES rather than hand-listed, so adding a state to the type is enough and this failure cannot recur one forgotten edit later. Keys are named profile_url because the chat's link filter strips any URL not present in context under that name.

3. THE SUGGESTED QUESTIONS WERE UNANSWERABLE BY CONSTRUCTION. Minnesota's asked about nearby schools and booth rent — data that exists for Texas and California only. Every new state page now asks what its own page and the coverage block can actually answer.

Two things found while verifying, both of which were my own errors:

- MN was mapped to {} to stop a cosmetology student being handed an instructor checklist. That also hid the page, and the assistant duly said we publish nothing for Minnesota. Added an `instructor` LicenseTrack — teaching is not practising, and its own track is the only mapping that is true.
- The coverage rule was written per-state but questions arrive per-licence, so "Mississippi esthetics" matched nothing against the label "Esthetician" and the model said we had no kit list. Reproduced 3/3 before the fix, correct after. The rule now names the loose matches explicitly.

hasPracticalExam is now an explicit set rather than `state !== "CA"`, which was fine at three states and would have silently granted a practical to the next state added whether or not it has one.

The AgentInvite default blurb no longer claims TDLR grounding. TDLR is Texas; promising Texas exam data to a Minnesota reader is what made this look broken.

Verified against a running server: Minnesota, Ohio, Mississippi esthetics, Mississippi nails and California all answer correctly and link the right page. Build clean, 634 tests pass.


Claude-Session: https://claude.ai/code/session_014TtUD4cwUnyyj278qMjFAA