### PR TITLE
fix(outreach): accept the CRON_SECRET fallback the signing library al…

### DIFF
--- a/scripts/send_school_outreach.js
+++ b/scripts/send_school_outreach.js
@@ -68,8 +68,16 @@ const CFG = {
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 function requireEnv() {
-  const missing = ["OUTREACH_POSTAL_ADDRESS", "OUTREACH_TOKEN_SECRET", "GHL_API_KEY", "GHL_LOCATION_ID"]
+  const missing = ["OUTREACH_POSTAL_ADDRESS", "GHL_API_KEY", "GHL_LOCATION_ID"]
     .filter((k) => !process.env[k]);
+  // Matches what lib/outreach-suppression.ts actually does: it signs with
+  // OUTREACH_TOKEN_SECRET and falls back to CRON_SECRET. Demanding the former
+  // here while the library accepts either invited the worse mistake — setting
+  // OUTREACH_TOKEN_SECRET locally to a value production does not share, which
+  // would sign every unsubscribe link with a key production cannot verify.
+  if (!process.env.OUTREACH_TOKEN_SECRET && !process.env.CRON_SECRET) {
+    missing.push("OUTREACH_TOKEN_SECRET (or CRON_SECRET)");
+  }
   if (missing.length) {
     console.error(`Refusing to run. Missing: ${missing.join(", ")}`);
     console.error("Without these the message is either non-compliant or its unsubscribe link is dead.");


### PR DESCRIPTION
…ready uses

requireEnv demanded OUTREACH_TOKEN_SECRET, but lib/outreach-suppression.ts signs with OUTREACH_TOKEN_SECRET *or* CRON_SECRET. Demanding the stricter of the two invited the worse mistake: setting OUTREACH_TOKEN_SECRET locally to a value production does not share, which would sign every unsubscribe link with a key production cannot verify — and the failure would only surface when a school clicked one and got "this link has been altered".

Verified end to end against production before changing anything: a token signed locally resolves on shearquery.com/unsubscribe, and POSTing it to /api/outreach/unsubscribe records the suppression row. Tested with a canary address, which was deleted afterwards.


Claude-Session: https://claude.ai/code/session_01NNFZQVnoLh5eb2KyonNnSU