### PR TITLE
Content publisher: one queue item, five destinations instead of two

### DIFF
--- a/.claude/agents/ar-overlay.md
+++ b/.claude/agents/ar-overlay.md
@@ -1,0 +1,50 @@
+---
+name: ar-overlay
+description: The Augmented Reality Agent for ShearQuery. Owns /ar-fade-trainer and the /ar-lab harness — evaluating AR opportunities, changing the overlay geometry, measuring the skull constants, and verifying any of it on real heads. Use when the user asks about AR in the app, wants the fade overlay changed or checked, wants a new AR capability evaluated, or reports that the guidelines are landing in the wrong place.
+tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch, WebSearch
+---
+
+You are the Augmented Reality Agent for ShearQuery.
+
+**Load the `ar-overlay` skill before doing anything else.** It holds the
+workflow, the calibration protocol, the established facts and the specific
+ways the checks have lied. This file deliberately does not repeat it — one
+copy, so it cannot go stale in the copy nobody reads.
+
+## How you work
+
+**Look at the render.** Three separate classes of bug in this feature were
+invisible to 700+ passing tests and obvious within a second of looking at a
+PNG. A green suite is not evidence that an overlay is in the right place.
+`scripts/ar_lab_shot.js` exists so you can look without a camera.
+
+**Use the cheapest tier that can fail.** Synthetic poses, then real fixture
+photos, then a fake webcam, then a real phone. Do not reach for a phone to
+answer a question a synthetic sweep settles, and do not claim a synthetic
+sweep settled a question about real hairlines.
+
+**Measure, then state the uncertainty.** Constants are measured, fitted or
+guessed, and which one must be visible at the definition. Below n=3 you have
+nothing. A guess relabelled as a measurement is worse than the guess.
+
+**Report negative results as results.** Hair segmentation was recommended
+confidently and turned out to be wrong for fades. That finding is worth as
+much as a fix, and it is written down with the coverage numbers so nobody
+re-runs the experiment on a hunch.
+
+**The user is the domain expert.** They can identify a parietal ridge on
+sight and you cannot. Ask for marks, frames and judgement calls rather than
+inferring craft facts. When they say a guideline is landing wrong, believe
+them and go find the mechanism.
+
+## What you do not do
+
+Do not put a model in the derivation. Where the line sits, how the ladder is
+spaced and what order the passes go in stay deterministic — that is what makes
+them testable and what let the constants be measured at all.
+
+Do not present guard ladders or line placement as regulator requirements.
+They are craft convention. No board specifies them.
+
+Do not upload photographs of heads anywhere. Everything runs on-device, the
+fixtures are gitignored, and that promise is worth keeping in a barbershop.

--- a/.claude/agents/gaming.md
+++ b/.claude/agents/gaming.md
@@ -1,0 +1,137 @@
+---
+name: gaming
+description: Owns games and interactive entertainment for ShearQuery — evaluating whether a game idea is worth building, designing it against the licensing data this site already owns, and building it without inventing claims about state board rules. Use whenever the user asks for game or entertainment ideas for the barber/beauty/wellness audience, wants a new game built or an existing one extended, asks how Kit Packer is performing, or wants to add a licence or state to a game.
+tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch
+---
+
+You are the Gaming Agent for ShearQuery. You own one question completely:
+what should this site turn into a game, and how is it built so it teaches
+something true.
+
+## What makes a game here different from a game anywhere else
+
+This is not a games studio. Every game is a different presentation of a
+regulator's published requirements, sitting on pages that rank for those
+requirements. That gives you an advantage nobody else has and a constraint
+nobody else has, and they are the same fact:
+
+**The content must be true, because a student may act on it.**
+
+A game that teaches a requirement the board never set is worse than no game.
+It is also worse than a wrong blog post, because a game rewards you for
+believing it.
+
+## The evaluation frame
+
+There are four audiences, not one. A game that works for one bores the others.
+
+| Audience | What they want | Example |
+|---|---|---|
+| Students | To pass | Kit Packer, exam prep |
+| Working pros | Status, recognition | Leaderboards, skill ID |
+| Shop owners | To not lose money | Business sim |
+| Clients | To kill ten minutes in a chair | Chairside, prize games |
+
+Rank ideas by how much existing data does the work. An idea needing new
+content authoring is a content project wearing a game costume. The best ideas
+are a **different view of a dataset already in the repo**, because the facts
+are already sourced and already maintained.
+
+## What is built
+
+**Kit Packer** — `/texas-barber-state-board-practical-exam-kit-list`, below the
+checklist. Round one packs the bag against a 60-second clock; round two applies
+the label rule to what you packed. Prohibited items end the run.
+
+| Thing | Where |
+|---|---|
+| Deck construction, scoring | `lib/kit-game.ts` |
+| Tests, incl. the sourcing guard | `lib/kit-game.test.ts` |
+| The UI | `components/tools/kit-packer.tsx` |
+| Kit data, one file per licence | `lib/kits/` |
+| Shared kit types | `lib/kits/types.ts` |
+| Registry, siblings, refusals | `lib/kits/index.ts` |
+| Analytics events | `lib/analytics.ts` (Kit Packer section) |
+
+## Rules you do not break
+
+1. **Never invent a wrong answer.** A kit list holds only correct items; a game
+   needs incorrect ones. There are exactly three sourced ways to make one —
+   cross-licence (a real item from a sibling kit in the same state),
+   prohibited (declared with the verbatim rule that forbids it), and label-flip
+   (the bulletin's own two lists). `TileSource` is non-optional on every tile
+   and the review screen shows it. A tile that cannot say where it came from
+   cannot be rendered.
+
+2. **Refuse rather than degrade.** `buildDeck` throws for a licence with no
+   `prohibited` list instead of shipping a game with no way to lose. The
+   refusal is the feature: it turns "nobody has read this bulletin's rules yet"
+   into an error instead of a gap nobody notices. Do not add a fallback.
+
+3. **Never score in a number you inferred.** Texas barber publishes 163 points
+   and a 115 pass mark, but the item-to-station mapping is OURS, not the
+   bulletin's — the kit file says so. Computing "you lost 34 points" would
+   present our editorial reading as a board fact. Score in items and quote the
+   real rule instead.
+
+4. **Never score an optional item.** Four Texas items are marked optional by
+   their own bulletins. Marking someone wrong for skipping one teaches a
+   requirement that does not exist. Use `KitItem.optional`, declared — never
+   sniffed out of the label text.
+
+5. **California and Minnesota can never have a kit game.** California licenses
+   on a written exam alone; Minnesota's instructor exam is a teaching
+   demonstration. This is asserted in tests. It must stay structurally
+   impossible, not merely unlinked.
+
+6. **Never touch a kit page's URL, metadata, or above-the-fold content.** These
+   are the site's best organic pages, and the Texas barber one is
+   canonical-stuck to the old domain. Games mount BELOW the checklist,
+   collapsed, building nothing until Start is pressed. No animation libraries
+   on these pages.
+
+7. **Play it before you call it done.** Tests pass on games that are not fun
+   and on games that are wrong. The optional-item bug passed every test and was
+   found in thirty seconds of playing.
+
+## How to report when asked "how's it doing"
+
+Events are in `lib/analytics.ts`: `kit_packer_start`,
+`kit_packer_pack_complete`, `kit_packer_label_complete`, `kit_packer_retry`,
+`kit_packer_signup_invite_clicked`. Query `pixel_events` for anything
+funnel-shaped.
+
+1. **Start rate is the decision metric.** Starts divided by page views answers
+   the only question phase two asks: will anyone press the button. Everything
+   else is detail until that number exists.
+2. **Retry rate is the quality signal.** Someone playing a second round liked
+   it. That is stronger evidence than a completion.
+3. **Round two accuracy is the content finding.** If people reliably miss the
+   label rule, that is worth its own page, not just a game round.
+4. **Say when there is not enough data.** One page, one licence. A handful of
+   plays is noise, and saying so is more useful than a trend.
+5. **Never report a number that would justify itself.** If the game is not
+   being played, say that plainly and recommend killing it.
+
+## Known state and gaps
+
+- **Only Texas barber has a deck.** The other five Texas licences are blocked
+  on one thing each: reading their bulletin's rules and writing a `PROHIBITED`
+  array with verbatim rule strings. No other work.
+- **Mississippi is the best unbuilt deck** — its handbook publishes the exact
+  required label string on 64 items, which turns round two from a coin flip
+  into recall. Needs its kit data extracted from `lib/mississippi-licensing.ts`
+  into `lib/kits/` first.
+- **Ohio, Virginia, Maryland, Tennessee can run round one only.** They publish
+  no label rule; `canRunLabelRound` returns false rather than guessing.
+- **No standalone `/kit-packer/` route yet.** The game exists at exactly one
+  URL. A standalone route needs sitemap registration in `lib/public-routes.ts`
+  and IndexNow pings ONE URL AT A TIME.
+- **Round three (station order) is designed, not built.** Texas runs 11
+  stations in a mandated order and out-of-order work is not scored. The data is
+  already in `SECTIONS` with real times and points. This is the one round where
+  the published point totals COULD legitimately be used, because station order
+  is the bulletin's, not ours.
+- **Difficulty is flat** — 20 tiles, 35% wrong, every round. No ramp.
+- **The full kit list sits above the game and is trivially copyable.** This is
+  deliberate. Cheating at this game is studying.

--- a/.claude/skills/ar-overlay/SKILL.md
+++ b/.claude/skills/ar-overlay/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: ar-overlay
+description: The workflow for building and verifying the AR fade overlay — how to see what the renderer draws without a camera, how to measure a skull constant instead of guessing it, and the specific ways the checks have lied. Use when touching lib/fade-geometry, lib/fade-overlay, lib/hair-mask, components/ar/, /ar-fade-trainer or /ar-lab, or when evaluating any new AR capability.
+---
+
+# The AR overlay, and how to know whether it works
+
+`/ar-fade-trainer` takes a finished haircut and works backwards to the
+procedure — where the line sits on the skull, the guard ladder underneath it,
+the order of the passes — then draws that plan on a real head through the
+camera. `/ar-lab` is the harness that proves it does.
+
+Everything in this file exists because a specific thing went wrong. The
+overlay is drawn over a person's head in a shop; being confidently wrong is
+worse here than being visibly broken, because a student will follow it.
+
+---
+
+## 1. The rule the whole thing rests on
+
+**The live camera view must not draw anything itself.** It calls
+`drawFadeOverlay` in `lib/fade-overlay.ts` and nothing else.
+
+Before that split, the renderer lived inside a `requestAnimationFrame`
+closure, so a live camera was the only thing in the universe that could
+produce a frame. The overlay could not be screenshotted, diffed, or looked at
+by anyone not holding a phone at a head — every judgement about the geometry
+was made by reading the maths and hoping.
+
+If the camera component grows drawing code again, the harness silently starts
+validating a copy of the renderer instead of the renderer.
+
+**The second rule:** geometry decides WHERE the fade line belongs; perception
+decides WHERE THE OVERLAY MAY BE DRAWN. They compose, never merge. Heights on
+the skull, the parietal ridge, the ladder spacing — deterministic arithmetic,
+because that is what makes them testable and lets constants be measured. A
+model that emitted "put the line here" would be neither.
+
+---
+
+## 2. Four tiers of verification. Use the cheapest that can fail.
+
+**Tier 1 — synthetic poses, no subject.** `lib/fade-synthetic-head.ts` emits
+the nine landmarks `buildHeadFrame` reads, at any yaw/pitch/roll. `/ar-lab`
+renders sweeps from it. Catches basis errors, wrap, visibility, label
+collisions. Cannot catch anything about real heads.
+
+**Tier 2 — real photographs.** `ar-fixtures/` (gitignored). Upload to
+`/ar-lab`. This is where landmark assumptions meet real hairlines and real
+ears.
+
+**Tier 3 — fake webcam.** Exercises `getUserMedia`, VIDEO running mode and the
+animation loop headlessly, with a real head in frame:
+
+    FF=$(node -e "console.log(require('@ffmpeg-installer/ffmpeg').path)")
+    "$FF" -loop 1 -i ar-fixtures/HEAD.jpg -t 6 -r 15 \
+      -vf "scale=640:480:force_original_aspect_ratio=decrease,pad=640:480:(ow-iw)/2:(oh-ih)/2" \
+      -pix_fmt yuv420p -f yuv4mpegpipe /tmp/head.y4m -y
+
+    # then launch Chrome with:
+    --use-fake-ui-for-media-stream --use-fake-device-for-media-stream
+    --use-file-for-fake-video-capture=/tmp/head.y4m
+
+**Tier 4 — a real phone.** The only tier that finds lighting, performance and
+iOS-specific failures. Requires HTTPS; see §5.
+
+`node scripts/ar_lab_shot.js --images ar-fixtures --out sheet.png` drives
+tiers 1–2 headless and writes a PNG. **Look at the PNG.** Three separate
+classes of bug in this feature were invisible to 700+ passing tests and
+obvious within one second of looking.
+
+---
+
+## 3. Measuring a constant instead of guessing one
+
+`/ar-lab` calibration: pick a mode, click a tracked head where the anatomy
+actually is, and `measureU` solves the height back out of that frame.
+
+It is a **search**, not algebra, and the reason matters. `u` is a dot product
+against the head's up axis, which needs a 3D point; a click gives two
+coordinates. The points projecting to one pixel form a line along z, and on a
+pitched head `u` varies along it. What determines the answer is the assumption
+that the clicked point is on the visible surface of the skull — so the solver
+scans candidate heights and keeps the ring passing closest.
+
+That assumption is why `dist` comes back with `u`. **A click into empty space
+still has a nearest ring.** Without the residual it would report a confident
+number and produce a fabricated constant.
+
+### The gate, which is not optional
+
+- Below **n=3** the summary refuses to report. It says NOT A MEASUREMENT YET.
+- Above it, actionable only when the mean delta clears **2 standard errors**.
+- Residual over ~5% of head width means the click missed. Not a measurement.
+- **Repeated measures of one head are not independent samples.** Average them
+  into a single head before aggregating, or n and the confidence both inflate.
+
+### Tag the population. Never pool.
+
+A child is not a small adult. The braincase reaches near-adult size years
+before the face does, so a child's face is proportionally short against their
+skull — and every level in `fade-geometry` is denominated in face heights.
+
+That splits the constants in two, and the data behaves as the split predicts:
+
+- **Cranium-to-cranium** (forehead landmark to parietal ridge) held to within
+  0.02 on adults *and* on the child.
+- **Cranium-to-face** (the ear-top proxy, ear against eye corner) diverged:
+  two adults at ~+0.10, the child at −0.004.
+
+So face-referenced levels are the fragile ones. `PERIMETER_BELOW_EAR` hangs
+off `earCanal`, which comes from face-oval landmarks, and is unmeasured.
+
+### Label constants by how they were established
+
+Three kinds live in `fade-geometry.ts` and they must not look alike:
+
+| Kind | Example | Rule |
+|---|---|---|
+| **Measured** | `PARIETAL_ABOVE_FOREHEAD`, `EAR_TOP_ABOVE_EYE_CORNER` | marks, residuals and sem written next to it |
+| **Fitted to observation** | `EAR_DEPTH_RATIO` | say so explicitly; it cannot be calibrated |
+| **Named guess** | `HEAD_DEPTH_RATIO`, `SKULL_WIDTH_RATIO` | awaiting measurement, and says so |
+
+A guess relabelled as a measurement is worse than the guess, because nobody
+re-examines it.
+
+---
+
+## 4. How the checks have lied. All of these actually happened.
+
+**A test that cannot fail.** The yaw sweep ran at zero pitch, where a level
+band projects to a straight line regardless of yaw — seven tiles rendered
+identically and all reported "ok". It now carries 15° of pitch.
+
+**A symmetric subject hiding an asymmetric bug.** The hair mask was composited
+unmirrored against mirrored geometry, clipping the left of the head against
+the right. The test subject was a symmetric mannequin facing the camera, where
+a flipped mask is very nearly the right mask. **Test asymmetric heads at
+three-quarter.**
+
+**Blocking the wrong API.** Verifying the GPU→CPU fallback by disabling WebGL
+on `HTMLCanvasElement` still reported GPU — MediaPipe builds its context on
+`OffscreenCanvas`. Patch both, or the fallback is never exercised.
+
+**A diagnostic behind a stale closure.** `onFiles` carried an empty dependency
+array, so the new toggles lit up and changed nothing, and the readout built to
+prove whether the mask worked rendered nothing at all. Two rounds went into
+debugging the model before the obstacle turned out to be upstream of it. **A
+broken diagnostic and a broken subject present identically.**
+
+**Frozen frames already contain an overlay.** Re-processing one draws a second
+overlay on top — doubled labels. Fine for marking a real ear, useless for
+judging fit. Use clean photos.
+
+**A grep against the wrong host.** Searching the dev sitemap for `https://`
+when it emits `http://localhost` "proved" a route was missing. It was the
+third entry.
+
+---
+
+## 5. Facts that cost real time to establish
+
+**WebXR `immersive-ar` is not in Safari on iPhone.** Confirmed 2026-08. The
+usable paths are `getUserMedia` + MediaPipe, `<model-viewer>`/AR Quick Look,
+or a paid SLAM SDK. Do not design around WebXR on iOS.
+
+**`navigator.mediaDevices` requires a secure context.** On `http://<lan-ip>`
+the property is undefined and the naive call dies with "undefined is not an
+object". For phone testing:
+
+    openssl req -x509 -newkey rsa:2048 -nodes \
+      -keyout certificates/lan-key.pem -out certificates/lan-cert.pem -days 365 \
+      -subj "/CN=<LAN-IP>" \
+      -addext "subjectAltName=DNS:localhost,IP:127.0.0.1,IP:<LAN-IP>"
+
+    npx next dev -p 3000 --experimental-https \
+      --experimental-https-key certificates/lan-key.pem \
+      --experimental-https-cert certificates/lan-cert.pem
+
+`--experimental-https` alone runs `mkcert -install`, which writes a CA into the
+system trust store and needs a password — and **falls back to plain HTTP on
+failure while still printing a success banner**. A self-signed cert avoids the
+system change and gives the phone the identical warning either way, because it
+never trusts the laptop's CA regardless. `allowedDevOrigins` in
+`next.config.mjs` must list the LAN IP; these are DHCP and will move.
+
+**MediaPipe specifics.** WASM and model URLs are pinned in
+`lib/face-landmarker.ts` — one copy, because two copies of a version-pinned
+URL is one upgrade from a runtime that does not match its model. Always
+GPU-then-CPU: WebGL context creation is refused on mobile Safari under memory
+pressure, and there is an open issue where the segmenter's GPU delegate
+returns wrong categories on iOS specifically.
+
+**`MPMask` must be `close()`d every frame.** Skipping it leaks a texture per
+frame; on a phone that is seconds to a crash, not a slow drift.
+
+**Detection is throttled to new video frames; drawing must not be.**
+`detectForVideo` throws on a repeat frame, so it only runs when `currentTime`
+advances — but a 30fps camera against a 60Hz loop then draws the overlay on
+half the frames. Keep the last good landmarks and redraw between them.
+
+**Tracking envelope: about ±70° of yaw.** Full profile and back-of-head return
+nothing. This is the ceiling of the whole approach, not a bug. The reference
+photos barbers actually use are back-of-head shots, and those track at 0%.
+
+**Hair segmentation does not work for fades — negative result, verified.**
+The model finds hair as a visible mass, so a skin fade reads as skin. Measured
+coverage on well-lit heads: **2.3% and 2.6%**, all of it on top, none on the
+faded sides. Clipping to it erases precisely the region the ladder belongs in.
+It is kept behind `/ar-lab`'s toggle so the finding can be re-checked rather
+than taken on trust. **The face oval (`FACE_OVAL`) is the correct boundary** —
+exact per head, per pose, no model, no download, and it cannot be confused by
+short hair because it is not looking for hair.
+
+---
+
+## 6. Route hygiene
+
+`/ar-fade-trainer` is public: metadata in a sibling `layout.tsx` (the page is
+`"use client"`), canonical, sitemap, `.md` twin. See the `publish-page` skill.
+
+`/ar-lab` calls `notFound()` when `NODE_ENV` is production and is listed in
+`SITEMAP_EXCLUDE_PREFIXES`. It is deliberately **not** auth-gated like
+`INTERNAL_TOOL_ROUTES`, because the point is that a headless browser can reach
+it. Its footer link is development-only for the same reason.
+`lib/ar-routes.test.ts` pins that the two prefixes cannot swallow each other.
+
+**Nothing in this feature is a regulator claim.** Guard ladders, line placement
+and pass order are craft convention. No board specifies them and no practical
+exam grades a fade against a protractor. The page says so; keep it saying so.
+
+---
+
+## 7. Open, with the evidence
+
+- **Child population is n=1.** The child offset is 0 because that is the
+  conservative default, not because it was measured. Three child heads settle it.
+- **`HEAD_DEPTH_RATIO` / `SKULL_WIDTH_RATIO` are unmeasured guesses.** A live
+  frame once showed bands running past the back of the head onto the wall; it
+  stopped appearing without explanation, which is not the same as fixed.
+- **No grading.** The tool has no opinion on whether the blend was achieved.
+  That needs a labelled dataset of good and bad blends — a data-collection
+  project, not a model choice.
+- **Best AI opportunity: reference photo → fade spec.** A VLM reads a picture
+  of a wanted haircut and returns the three parameters the picker already
+  takes. Zero-shot, no training data, feeds the deterministic derivation rather
+  than replacing it, and lands as three visible selections a human can correct.

--- a/.gitignore
+++ b/.gitignore
@@ -96,6 +96,14 @@ yarn-error.log*
 # redirect resolves and a 404 doesn't. Untracked, corrections to it live on one
 # laptop and the next person re-derives them from scratch.
 !jsonld.md
+# ...and the Gaming agent manual. Same reason as the Data Reels one: it is the
+# operating record for something published to the public internet, and its rules
+# are the difference between a game that teaches the board's requirements and
+# one that teaches an invented requirement to somebody about to sit the exam.
+# The rule that no wrong answer may ever be invented, the three sourced
+# distractor classes, and the two bugs that passed every test — none of that is
+# recoverable from the code, and untracked it lives on one laptop.
+!docs/gaming-agent.md
 
 
 

--- a/app/admin/content-publisher/page.tsx
+++ b/app/admin/content-publisher/page.tsx
@@ -1,8 +1,9 @@
 import { notFound } from "next/navigation";
 import { isAdmin } from "@/app/admin/ad-campaigns/auth";
 import { Navbar } from "@/components/layout/navbar";
-import { fetchPublisherQueue } from "@/lib/admin/publisher-queue";
+import { fetchPublisherQueue, fetchPublisherConnections } from "@/lib/admin/publisher-queue";
 import { PublisherQueueBoard } from "@/components/admin/publisher-queue-board";
+import { PublisherConnections } from "@/components/admin/publisher-connections";
 import { Send } from "lucide-react";
 
 export const dynamic = "force-dynamic";
@@ -22,7 +23,10 @@ export const metadata = {
 export default async function ContentPublisherPage() {
   if (!(await isAdmin())) notFound();
 
-  const queue = await fetchPublisherQueue();
+  const [queue, connections] = await Promise.all([
+    fetchPublisherQueue(),
+    fetchPublisherConnections(),
+  ]);
   const blocked = queue.queued.filter((i) => i.unpublishable).length;
   const daysOfRunway = Math.floor(queue.queued.length / 3);
 
@@ -44,9 +48,9 @@ export default async function ContentPublisherPage() {
         </h1>
         <p className="text-slate-500 text-sm mb-10 max-w-2xl">
           Three posts a day — 9:00 AM, 2:00 PM and 7:00 PM Eastern. Whatever sits
-          in position 1 goes out at the next slot, to YouTube Shorts and
-          Instagram Reels together. Drag the cards to set the order the feed will
-          read in.
+          in position 1 goes out at the next slot, to every destination that is
+          connected below. Drag the cards to set the order the feed will read
+          in.
           {queue.queued.length > 0 && (
             <>
               {" "}At three a day this line lasts{" "}
@@ -57,6 +61,8 @@ export default async function ContentPublisherPage() {
             </>
           )}
         </p>
+
+        <PublisherConnections connections={connections} />
 
         <PublisherQueueBoard queue={queue} />
       </div>

--- a/app/api/cron/publish-content/route.ts
+++ b/app/api/cron/publish-content/route.ts
@@ -3,10 +3,22 @@ import { createAdminClient } from "@/lib/supabase/admin";
 import { publishToInstagram } from "@/lib/instagram-publish";
 import { isExpired } from "@/lib/instagram-token";
 import { SLOT_HOURS_ET } from "@/lib/admin/publisher-queue";
+import {
+  buildYouTubeDescription,
+  buildInstagramCaption,
+  YOUTUBE_TAGS,
+} from "@/lib/admin/publisher-copy";
+import {
+  fanOutToTargets,
+  statusFromOutcomes,
+  TARGET_PLATFORMS,
+  type Outcome,
+  type PlatformKey,
+} from "@/lib/admin/publisher-targets";
 
 /**
- * Publishes whatever sits at the front of the content publisher line, to
- * YouTube Shorts and Instagram Reels together.
+ * Publishes whatever sits at the front of the content publisher line, to every
+ * connected platform.
  *
  * THREE SLOTS A DAY: 9am, 2pm and 7pm Eastern.
  *
@@ -33,11 +45,19 @@ import { SLOT_HOURS_ET } from "@/lib/admin/publisher-queue";
  * moment, never the content - the same division publish-short and
  * gbp-publish-scheduled keep.
  *
- * ONE PLATFORM CAN SUCCEED WHILE THE OTHER FAILS, and the row records both
- * outcomes rather than collapsing them. Calling a YouTube-only publish
- * "published" hides a missing Reel; calling it "failed" invites a re-post that
- * duplicates the Short. 'partial' is the honest answer and it names which half
- * needs attention.
+ * PLATFORMS SUCCEED AND FAIL INDEPENDENTLY, and the row records each outcome
+ * rather than collapsing them. Calling a YouTube-only publish "published" hides
+ * a missing Reel; calling it "failed" invites a re-post that duplicates the
+ * Short. 'partial' is the honest answer and it names which destination needs
+ * attention.
+ *
+ * A PLATFORM THAT IS SWITCHED OFF IS SKIPPED, NOT FAILED. With six
+ * destinations, counting an unconfigured one as a failure would make 'partial'
+ * the permanent state of every row - see statusFromOutcomes.
+ *
+ * THE VIDEO IS FETCHED ONCE. YouTube, LinkedIn, X and TikTok all need the raw
+ * bytes. Downloading the same MP4 four times inside one invocation wastes the
+ * budget and adds three more ways to fail for no benefit.
  */
 
 export const dynamic = "force-dynamic";
@@ -77,61 +97,21 @@ async function youtubeAccessToken(): Promise<string> {
 }
 
 /**
- * The YouTube description and the Instagram caption are built here rather than
- * stored on the row. The queue holds what the video SAYS; these hold how it is
- * listed, and keeping them apart means the wording can be improved for every
- * future post without re-rendering or re-queueing anything.
- *
- * They are not the same text. A YouTube description is read after the click and
- * carries the link; an Instagram caption is read in the feed, cannot carry a
- * working link, and leans on tags. Sharing one string would make both worse.
+ * Upload to YouTube. Takes the bytes rather than fetching them, so the same
+ * download serves every platform that needs the file.
  */
-function buildYouTubeDescription(row: any): string {
-  return [
-    `${row.stat ?? ""} ${row.label ?? ""}`.trim(),
-    "",
-    row.question ?? "",
-    "Tell us below.",
-    "",
-    "Full pass rates, kit lists and state board guides:",
-    "https://shearquery.com",
-    "",
-    "#Shorts #barber #barberschool #stateboard #cosmetology",
-  ].join("\n");
-}
-
-function buildInstagramCaption(row: any): string {
-  if (row.caption) return row.caption;
-  return [
-    `${row.stat ?? ""} ${row.label ?? ""}`.trim(),
-    "",
-    row.question ?? "",
-    "",
-    "Pass rates, kit lists and state board guides — link in bio.",
-    "",
-    "#barber #barberschool #barbershop #stateboard #cosmetology #beautyschool #barberlife",
-  ].join("\n");
-}
-
-const TAGS = [
-  "barber state board", "barber exam", "texas barber license",
-  "barber school", "barber state board practical", "barber written exam",
-  "cosmetology state board", "beauty school", "barber apprentice",
-];
-
-async function publishToYouTube(row: any): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
+async function publishToYouTube(
+  row: any,
+  bytes: Buffer
+): Promise<{ ok: true; id: string } | { ok: false; error: string }> {
   try {
     const token = await youtubeAccessToken();
-
-    const videoRes = await fetch(row.video_url);
-    if (!videoRes.ok) throw new Error(`could not fetch video: HTTP ${videoRes.status}`);
-    const bytes = Buffer.from(await videoRes.arrayBuffer());
 
     const metadata = {
       snippet: {
         title: String(row.title).slice(0, 100),
         description: buildYouTubeDescription(row),
-        tags: TAGS,
+        tags: YOUTUBE_TAGS,
         categoryId: "26",
         defaultLanguage: "en",
       },
@@ -158,7 +138,7 @@ async function publishToYouTube(row: any): Promise<{ ok: true; id: string } | { 
     const put = await fetch(location, {
       method: "PUT",
       headers: { "Content-Length": String(bytes.length), "Content-Type": "video/mp4" },
-      body: bytes,
+      body: new Uint8Array(bytes),
     });
     const text = await put.text();
     if (!put.ok) throw new Error(`upload ${put.status}: ${text.slice(0, 300)}`);
@@ -192,7 +172,7 @@ async function publishToYouTube(row: any): Promise<{ ok: true; id: string } | { 
           {
             method: "POST",
             headers: { Authorization: `Bearer ${token}`, "Content-Type": "image/jpeg" },
-            body: cover,
+            body: new Uint8Array(cover),
           }
         );
         if (!t.ok) throw new Error(`thumbnails.set ${t.status}: ${(await t.text()).slice(0, 200)}`);
@@ -211,23 +191,35 @@ async function publishToYouTube(row: any): Promise<{ ok: true; id: string } | { 
 export async function GET(req: Request) {
   if (!authorized(req)) return NextResponse.json({ error: "Unauthorized." }, { status: 401 });
 
+  /*
+   * A DRY RUN RESOLVES EVERY CONNECTION AND BUILDS EVERY CAPTION, AND SENDS
+   * NOTHING. The slots are five hours apart, so without this the only way to
+   * find out that a token is stale or a caption is over a platform's limit is
+   * to burn a real post. It deliberately ignores the slot hour and does not
+   * claim the slot - it is a question, not a turn.
+   */
+  const url = new URL(req.url);
+  const dryRun = url.searchParams.get("dryRun") === "1";
+
   const { hour, date } = easternNow();
-  if (!SLOT_HOURS_ET.includes(hour as (typeof SLOT_HOURS_ET)[number])) {
+  if (!dryRun && !SLOT_HOURS_ET.includes(hour as (typeof SLOT_HOURS_ET)[number])) {
     return NextResponse.json({ ok: true, state: "not_a_slot", easternHour: hour });
   }
 
   const admin = createAdminClient();
 
-  /*
-   * CLAIM FIRST. A conflict here means this slot already went out — return
-   * quietly rather than as an error, because a second invocation in the same
-   * hour is a normal thing for a cron platform to do, not a fault.
-   */
-  const { error: claimError } = await (admin.from("publisher_slot_claims") as any)
-    .insert({ slot_date: date, slot_hour: hour });
+  if (!dryRun) {
+    /*
+     * CLAIM FIRST. A conflict here means this slot already went out — return
+     * quietly rather than as an error, because a second invocation in the same
+     * hour is a normal thing for a cron platform to do, not a fault.
+     */
+    const { error: claimError } = await (admin.from("publisher_slot_claims") as any)
+      .insert({ slot_date: date, slot_hour: hour });
 
-  if (claimError) {
-    return NextResponse.json({ ok: true, state: "slot_already_taken", slot: `${date} ${hour}:00 ET` });
+    if (claimError) {
+      return NextResponse.json({ ok: true, state: "slot_already_taken", slot: `${date} ${hour}:00 ET` });
+    }
   }
 
   /*
@@ -248,12 +240,57 @@ export async function GET(req: Request) {
     return NextResponse.json({ ok: true, state: "queue_empty", slot: `${date} ${hour}:00 ET` });
   }
 
+  if (dryRun) {
+    const outcomes = await fanOutToTargets({ admin, row, video: null, dryRun: true });
+    return NextResponse.json({
+      ok: true,
+      state: "dry_run",
+      itemKey: row.item_key,
+      wouldPublish: {
+        youtube: { title: String(row.title).slice(0, 100), description: buildYouTubeDescription(row) },
+        instagram: { caption: buildInstagramCaption(row) },
+        ...Object.fromEntries(
+          Object.entries(outcomes).map(([k, v]) => [
+            k,
+            "skipped" in v ? { skipped: v.skipped } : { copy: (v as any).note },
+          ])
+        ),
+      },
+    });
+  }
+
   await (admin.from("publisher_slot_claims") as any)
     .update({ item_id: row.id })
     .eq("slot_date", date)
     .eq("slot_hour", hour);
 
-  const yt = await publishToYouTube(row);
+  /*
+   * ONE DOWNLOAD FOR EVERY PLATFORM THAT NEEDS BYTES. A failure here is not
+   * fatal to the whole slot: Instagram and Google Business Profile take a URL
+   * and can still go out, so the null is passed along and each platform that
+   * needs the file records its own skip.
+   */
+  let bytes: Buffer | null = null;
+  let videoFetchError: string | null = null;
+  try {
+    const videoRes = await fetch(row.video_url);
+    if (!videoRes.ok) throw new Error(`could not fetch video: HTTP ${videoRes.status}`);
+    bytes = Buffer.from(await videoRes.arrayBuffer());
+  } catch (e) {
+    videoFetchError = String((e as Error)?.message ?? e).slice(0, 300);
+  }
+
+  const outcomes: Record<string, Outcome> = {};
+
+  // YouTube.
+  if (bytes) {
+    const yt = await publishToYouTube(row, bytes);
+    outcomes.youtube = yt.ok
+      ? { ok: true, id: yt.id, url: `https://youtube.com/shorts/${yt.id}` }
+      : { ok: false, error: yt.error };
+  } else {
+    outcomes.youtube = { skipped: videoFetchError ?? "no video bytes" };
+  }
 
   /*
    * INSTAGRAM IS ATTEMPTED EVEN IF YOUTUBE FAILED. They are independent
@@ -261,17 +298,15 @@ export async function GET(req: Request) {
    * skipping the second because the first failed would turn one missing post
    * into two for no reason.
    */
-  let igResult: { ok: true; mediaId: string; permalink?: string } | { ok: false; error: string };
-
   const { data: conn } = await (admin.from("instagram_connection") as any)
     .select("access_token, ig_user_id, expires_at, status")
     .eq("id", 1)
     .maybeSingle();
 
   if (!conn?.access_token || !conn?.ig_user_id) {
-    igResult = { ok: false, error: "instagram not connected" };
+    outcomes.instagram = { skipped: "instagram not connected" };
   } else if (isExpired(conn.expires_at) || conn.status !== "connected") {
-    igResult = { ok: false, error: `instagram token unusable (expires ${conn.expires_at})` };
+    outcomes.instagram = { skipped: `instagram token unusable (expires ${conn.expires_at})` };
   } else {
     const r = await publishToInstagram({
       igUserId: conn.ig_user_id,
@@ -281,24 +316,39 @@ export async function GET(req: Request) {
       coverUrl: row.thumbnail_url ?? undefined,
       caption: buildInstagramCaption(row),
     });
-    igResult = r.ok
-      ? { ok: true, mediaId: r.mediaId!, permalink: r.permalink }
+    outcomes.instagram = r.ok
+      ? { ok: true, id: r.mediaId!, url: r.permalink }
       : { ok: false, error: `${(r as any).stage ?? "publish"}: ${(r as any).error}` };
   }
 
-  const status = yt.ok && igResult.ok ? "published" : yt.ok || igResult.ok ? "partial" : "failed";
+  // LinkedIn, X, Google Business Profile and TikTok.
+  const fanned = await fanOutToTargets({ admin, row, video: bytes });
+  for (const p of TARGET_PLATFORMS) outcomes[p] = fanned[p as PlatformKey];
+
+  const status = statusFromOutcomes(outcomes);
   const now = new Date().toISOString();
+
+  const yt = outcomes.youtube;
+  const ig = outcomes.instagram;
+  const ok = (o: Outcome) => "ok" in o && o.ok;
 
   await (admin.from("publisher_queue") as any)
     .update({
       status,
-      youtube_id: yt.ok ? yt.id : null,
-      youtube_error: yt.ok ? null : yt.error,
-      youtube_published_at: yt.ok ? now : null,
-      instagram_media_id: igResult.ok ? igResult.mediaId : null,
-      instagram_permalink: igResult.ok ? (igResult.permalink ?? null) : null,
-      instagram_error: igResult.ok ? null : igResult.error,
-      instagram_published_at: igResult.ok ? now : null,
+      results: outcomes,
+      /*
+       * The YouTube and Instagram columns are written as well as `results`.
+       * Every row published before the fan-out has its outcome only in these,
+       * and the board still reads them - dual-writing the two costs a few lines
+       * here and avoids both a backfill and a regression on historical rows.
+       */
+      youtube_id: ok(yt) ? (yt as any).id : null,
+      youtube_error: "error" in yt ? yt.error : null,
+      youtube_published_at: ok(yt) ? now : null,
+      instagram_media_id: ok(ig) ? (ig as any).id : null,
+      instagram_permalink: ok(ig) ? ((ig as any).url ?? null) : null,
+      instagram_error: "error" in ig ? ig.error : null,
+      instagram_published_at: ok(ig) ? now : null,
       published_at: now,
       updated_at: now,
     })
@@ -309,7 +359,6 @@ export async function GET(req: Request) {
     state: status,
     slot: `${date} ${hour}:00 ET`,
     itemKey: row.item_key,
-    youtube: yt.ok ? `https://youtube.com/shorts/${yt.id}` : yt.error,
-    instagram: igResult.ok ? (igResult.permalink ?? igResult.mediaId) : igResult.error,
+    results: outcomes,
   });
 }

--- a/components/admin/publisher-connections.tsx
+++ b/components/admin/publisher-connections.tsx
@@ -1,0 +1,82 @@
+import { Check, AlertTriangle, MinusCircle } from "lucide-react";
+import type { PublisherConnectionView } from "@/lib/admin/publisher-queue";
+
+/**
+ * Which destinations the next post will actually reach.
+ *
+ * READ-ONLY ON PURPOSE. Connecting a platform mints a token, and a token is
+ * minted by a person at a keyboard running scripts/publisher_connect.js — not
+ * by a button on a page that would need its own OAuth callback, state store and
+ * consent surface for an account we authorise about once a year.
+ *
+ * IT NAMES THE ACCOUNT, NOT JUST THE PLATFORM. "LinkedIn ✓" is not enough
+ * information: posting as the company page and posting as a person are
+ * different decisions, and a wrong one is a mistake made in public under
+ * somebody's own name.
+ */
+
+const LABELS: Record<string, string> = {
+  linkedin: "LinkedIn",
+  x: "X",
+  gbp: "Google Business Profile",
+  tiktok: "TikTok",
+};
+
+function Row({ c }: { c: PublisherConnectionView }) {
+  const live = c.enabled && c.status === "connected";
+  const label = LABELS[c.platform] ?? c.platform;
+
+  // Not enabled reads grey, because it is a setting rather than a fault.
+  // Enabled-but-broken reads amber, because it is the one that needs a person.
+  const tone = live
+    ? "text-emerald-700"
+    : !c.enabled
+      ? "text-slate-400"
+      : "text-amber-700";
+
+  const Icon = live ? Check : !c.enabled ? MinusCircle : AlertTriangle;
+
+  const detail = live
+    ? c.accountLabel || "connected"
+    : !c.enabled
+      ? "switched off"
+      : c.status === "disconnected"
+        ? "not connected — run scripts/publisher_connect.js"
+        : c.lastError || c.status;
+
+  return (
+    <li className="flex items-start gap-2 py-1.5">
+      <Icon className={`h-3.5 w-3.5 mt-0.5 shrink-0 ${tone}`} />
+      <span className="text-[11px] leading-tight">
+        <span className="font-bold text-slate-700">{label}</span>
+        <span className={`ml-1.5 ${tone}`}>{detail}</span>
+      </span>
+    </li>
+  );
+}
+
+export function PublisherConnections({ connections }: { connections: PublisherConnectionView[] }) {
+  if (connections.length === 0) return null;
+
+  const live = connections.filter((c) => c.enabled && c.status === "connected").length;
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white px-4 py-3 mb-8">
+      <div className="flex items-baseline justify-between mb-1">
+        <h2 className="text-[10px] font-black uppercase tracking-widest text-slate-500">
+          Extra destinations
+        </h2>
+        <span className="text-[10px] text-slate-400">
+          {live} of {connections.length} live
+        </span>
+      </div>
+      <p className="text-[11px] text-slate-400 mb-2 leading-snug">
+        YouTube and Instagram publish from their own connections and are always attempted.
+        These four are skipped when they are not live — a skip never marks a post failed.
+      </p>
+      <ul className="divide-y divide-slate-100">
+        {connections.map((c) => <Row key={c.platform} c={c} />)}
+      </ul>
+    </div>
+  );
+}

--- a/components/admin/publisher-queue-board.tsx
+++ b/components/admin/publisher-queue-board.tsx
@@ -4,8 +4,9 @@ import * as React from "react";
 import { useRouter } from "next/navigation";
 import {
   CheckCircle2, AlertTriangle, Clock, ExternalLink, GripVertical, Radio, Instagram, Youtube,
+  Linkedin, MapPin, Music2, MinusCircle,
 } from "lucide-react";
-import type { PublisherItem, PublisherQueue } from "@/lib/admin/publisher-queue";
+import type { PublisherItem, PublisherQueue, PublisherOutcome } from "@/lib/admin/publisher-queue";
 import { reorderQueue, skipItem } from "@/app/admin/content-publisher/actions";
 
 /**
@@ -31,41 +32,95 @@ import { reorderQueue, skipItem } from "@/app/admin/content-publisher/actions";
  * never saved.
  */
 
+/**
+ * One line per destination.
+ *
+ * DRIVEN BY THE ROW, NOT BY A HARDCODED PAIR. This used to render a YouTube row
+ * and an Instagram row and nothing else, so a platform added to the fan-out
+ * would publish successfully and be invisible here. It now walks `results`,
+ * which means the next platform needs no change to this file.
+ *
+ * OLDER ROWS HAVE NO `results` AT ALL. Everything published before the fan-out
+ * recorded its outcome only in youtube_id / instagram_media_id, so those are
+ * folded in when the row carries nothing else. Without that, the history on the
+ * board would go blank for every past post.
+ *
+ * SKIPPED IS GREY, NOT RED. "TikTok is not enabled" is a setting, not a
+ * failure, and colouring it like one trains the eye to ignore the colour - at
+ * which case a real failure stops standing out.
+ */
+
+const PLATFORM_META: Record<string, { label: string; Icon: typeof Youtube; tone: string }> = {
+  youtube: { label: "Short", Icon: Youtube, tone: "text-indigo-700" },
+  instagram: { label: "Reel", Icon: Instagram, tone: "text-fuchsia-700" },
+  linkedin: { label: "Post", Icon: Linkedin, tone: "text-sky-700" },
+  x: { label: "Post", Icon: Radio, tone: "text-slate-900" },
+  gbp: { label: "Google Post", Icon: MapPin, tone: "text-emerald-700" },
+  tiktok: { label: "Video", Icon: Music2, tone: "text-rose-700" },
+};
+
+const PLATFORM_ORDER = ["youtube", "instagram", "linkedin", "x", "gbp", "tiktok"];
+
+/** Fold the legacy columns in for rows written before `results` existed. */
+function outcomesFor(item: PublisherItem): Record<string, PublisherOutcome> {
+  if (item.results && Object.keys(item.results).length > 0) return item.results;
+
+  const legacy: Record<string, PublisherOutcome> = {};
+  legacy.youtube = item.youtubeId
+    ? { ok: true, id: item.youtubeId, url: `https://youtube.com/shorts/${item.youtubeId}` }
+    : { ok: false, error: item.youtubeError || "not published" };
+  legacy.instagram = item.instagramMediaId
+    ? { ok: true, id: item.instagramMediaId, url: item.instagramPermalink || undefined }
+    : { ok: false, error: item.instagramError || "not published" };
+  return legacy;
+}
+
 function PlatformResult({ item }: { item: PublisherItem }) {
   if (item.status === "queued") return null;
 
+  const outcomes = outcomesFor(item);
+  const keys = Object.keys(outcomes).sort(
+    (a, b) => PLATFORM_ORDER.indexOf(a) - PLATFORM_ORDER.indexOf(b)
+  );
+
   return (
     <div className="flex flex-col gap-1 text-[11px]">
-      <span className="inline-flex items-center gap-1.5">
-        <Youtube className="h-3.5 w-3.5 shrink-0 text-slate-400" />
-        {item.youtubeId ? (
-          <a
-            href={`https://youtube.com/shorts/${item.youtubeId}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 font-bold text-indigo-700"
-          >
-            Short <ExternalLink className="h-3 w-3" />
-          </a>
-        ) : (
-          <span className="text-rose-700">{item.youtubeError || "not published"}</span>
-        )}
-      </span>
-      <span className="inline-flex items-center gap-1.5">
-        <Instagram className="h-3.5 w-3.5 shrink-0 text-slate-400" />
-        {item.instagramMediaId ? (
-          <a
-            href={item.instagramPermalink || "#"}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 font-bold text-fuchsia-700"
-          >
-            Reel <ExternalLink className="h-3 w-3" />
-          </a>
-        ) : (
-          <span className="text-rose-700">{item.instagramError || "not published"}</span>
-        )}
-      </span>
+      {keys.map((key) => {
+        const o = outcomes[key];
+        const meta = PLATFORM_META[key] ?? { label: key, Icon: Radio, tone: "text-slate-700" };
+        const { Icon } = meta;
+
+        if ("skipped" in o) {
+          return (
+            <span key={key} className="inline-flex items-center gap-1.5 text-slate-400">
+              <MinusCircle className="h-3.5 w-3.5 shrink-0" />
+              <span className="truncate">{o.skipped}</span>
+            </span>
+          );
+        }
+
+        return (
+          <span key={key} className="inline-flex items-center gap-1.5">
+            <Icon className="h-3.5 w-3.5 shrink-0 text-slate-400" />
+            {o.ok ? (
+              o.url ? (
+                <a
+                  href={o.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={`inline-flex items-center gap-1 font-bold ${meta.tone}`}
+                >
+                  {meta.label} <ExternalLink className="h-3 w-3" />
+                </a>
+              ) : (
+                <span className={`font-bold ${meta.tone}`}>{meta.label}</span>
+              )
+            ) : (
+              <span className="text-rose-700 truncate">{o.error || "not published"}</span>
+            )}
+          </span>
+        );
+      })}
     </div>
   );
 }

--- a/docs/gaming-agent.md
+++ b/docs/gaming-agent.md
@@ -1,0 +1,323 @@
+# The Gaming agent
+
+Games and interactive entertainment for the barber / beauty / wellness
+audience, built on the licensing data this site already owns.
+
+This document exists so the workflow survives the loss of any particular
+session, machine, or assistant. It records not just what was built but **why
+each decision went the way it did**, because most of them look arbitrary until
+you know the failure they prevent.
+
+The operational summary lives at `.claude/agents/gaming.md`. This is the long
+form.
+
+---
+
+## 1. What this agent is actually for
+
+ShearQuery is a directory and a licensing-reference site. It ranks for what
+state boards require. A game here is never entertainment bolted on — it is a
+**different presentation of a regulator's published requirements**, sitting on
+the page that already ranks for them.
+
+That produces one advantage and one constraint, and they are the same fact:
+
+> The content must be true, because a student may act on it.
+
+A game that teaches a requirement the board never set is worse than no game,
+and worse than a wrong article — because a game *rewards you* for believing it.
+Every rule in this document descends from that sentence.
+
+---
+
+## 2. The evaluation frame
+
+### There are four audiences, not one
+
+A game that lands for one bores the other three. Decide who it is for before
+anything else.
+
+| Audience | What they want | Game shape |
+|---|---|---|
+| Students | To pass the exam | Drills, prep, streaks |
+| Working pros | Status, recognition | Leaderboards, skill ID |
+| Shop owners | To not lose money | Business simulation |
+| Clients | Ten minutes in a chair | Prize games, quick play |
+
+### Rank ideas by how much existing data does the work
+
+This is the single most useful filter. An idea that needs new content authored
+is a **content project wearing a game costume** — it will stall on writing, not
+on code.
+
+The best ideas are a different view of a dataset already in the repo, because
+the facts are already sourced, already reviewed, and already maintained by
+whoever maintains the page.
+
+### The backlog, as ranked
+
+Preserved because the reasoning is the valuable part, not the list.
+
+1. **Kit Packer** — *built.* Pack the practical exam kit against a clock. Kit
+   lists are the highest-performing page type on the site, the data is
+   structured per state and per licence, and the game mechanic and the
+   educational value are the same thing: you win by knowing what to bring.
+2. **Board Prep Streak** — daily written-exam questions, weighted to the PSI
+   content outline, leaderboard by school. **Partially exists already** as
+   `/tools/texas-barber-exam-practice-deck` and its cosmetology twin. Would
+   give `/texas-school-leaderboard` and `/compare-schools` a reason to be
+   visited daily instead of once.
+3. **Chairside** — QR code in the shop, 2-minute game while waiting, prize
+   configured by that shop. This is a fifth **ad product**, not really a game,
+   and it is the easiest thing in the media kit to sell because the shop sees
+   the return in the room. It also fixes the review-ask timing problem: the win
+   screen fires post-service.
+4. **Booth Rent Tycoon** — run a shop, set prices and chair rent, handle
+   no-shows. The real payoff is that its calibration screen ("what does a chair
+   rent for in your city?") is a data-collection funnel for the booth-rent
+   coverage gap on `/compare-shops`. People will hand you comp data to make a
+   game realistic that they would never type into a form.
+5. **Guess the Fade** — image ID rounds. Pure social top-of-funnel, low build
+   cost, no data dependency, but it does not compound the way 1 and 2 do.
+
+### Unity was evaluated and rejected
+
+Asked directly whether Kit Packer should be a Unity app connected to the site.
+The answer was no, for reasons worth keeping:
+
+- Unity WebGL renders to an opaque canvas — **zero indexable content**, which
+  runs against the `.md` twin layer, the AI-crawler strategy, and the whole
+  premise that this site's content is readable.
+- The payload is megabytes against tens of kilobytes for the React version, on
+  the site's top organic pages, mostly visited on phones.
+- The mechanic is a timer and some state. Unity earns its weight for physics,
+  3D, sprite pipelines — none of which this needs.
+- It would break the single-source rule: `lib/kits/` is TypeScript that Unity
+  cannot import, so the data would be serialised and drift silently the next
+  time a bulletin is revised.
+
+Unity (or more likely React Three Fiber, to stay in one codebase) becomes
+arguable only for a genuinely spatial product — a 3D mannequin trainer, or
+Booth Rent Tycoon with a rendered floor. Not for this.
+
+---
+
+## 3. Kit Packer — the design
+
+### Three rounds, each a real way to lose points
+
+1. **Pack** — 20 tiles from the tray in 60 seconds. Tap what belongs in this
+   licence's kit. Missing a required item loses the points for every station
+   that needed it. Packing a prohibited item ends the run immediately.
+2. **Label** — for each item packed correctly, label it or don't. This is the
+   round that earns the build: the rule is already a boolean on every item, and
+   mislabeling is one of the cheapest ways to bleed points on the real exam.
+3. **Order** — *designed, not built.* Put the stations in sequence. Texas runs
+   11 in a mandated order and out-of-order work is not scored at all.
+
+### The one hard problem, and the only acceptable answer
+
+**A kit list contains only correct items. A game needs wrong ones.**
+
+Inventing plausible distractors would put unsourced claims about state board
+policy onto the site's best-performing organic pages. So there are exactly
+three ways a wrong tile can exist, all derived rather than authored:
+
+| Class | What it is | Why it is safe |
+|---|---|---|
+| Cross-licence | A real item from a sibling kit in the same state | It is genuinely real; set subtraction, no authoring |
+| Prohibited | An item the bulletin names as forbidden | Carries the verbatim rule string that forbids it |
+| Label flip | A right item with the wrong label state | Straight off the bulletin's own two lists |
+
+`TileSource` is **non-optional** on every tile, and the review screen displays
+it. A tile that cannot say where it came from cannot be rendered. The test
+`kit-game.test.ts` asserts each prohibited entry's `rule` appears verbatim in
+that kit's `rules` array, so a paraphrase fails the build rather than shipping
+as an unsourced claim.
+
+### Why prohibited items are declared, not parsed
+
+`rules` holds prose: *"Aerosol products are not permitted"*, *"Cell phones are
+not allowed in the practical room"*. Regex-extracting item names from sentences
+would manufacture exactly the invented claims the whole design forbids. So each
+prohibited item is written out explicitly **and** carries the rule verbatim.
+
+### Why the deck is refused rather than degraded
+
+`buildDeck` throws a `DeckError` for a licence with no `prohibited` list. A
+game with no fatal tile is a game you cannot lose, and a game you cannot lose
+teaches nothing about an exam you can.
+
+The refusal is the feature. It converts "nobody has read this bulletin's rules
+closely enough yet" from a silent omission into a build error. **Do not add a
+fallback.**
+
+### Why scoring is in items, not points
+
+Texas barber publishes 163 points and a 115 pass mark. Using them was the
+original plan and it was wrong: the item-to-station mapping is *ours*, an
+editorial reading — the kit file says so in capitals. Computing "you would have
+lost 34 points" would dress our inference as a board fact.
+
+So the results screen scores in items and **quotes the real rule** ("you lose
+the points for every step that needed a missing item"). Same stakes, actually
+true.
+
+Round three would be the exception: station order *is* published, so the point
+totals could legitimately be used there.
+
+### Why the deck is seeded
+
+`mulberry32`, seeded per round. `Math.random()` cannot be seeded, and an
+unseeded deck makes a shared score meaningless — "I got 17/20" is only worth
+posting if the next person can play the same twenty tiles.
+
+### Why tap-to-sort, not drag-and-drop
+
+The audience is on a phone, often the night before an exam. HTML5 drag is
+unreliable on touch. Two tap targets beat a drag every time here.
+
+### Why the full list sits above the game
+
+It is trivially copyable and that is deliberate. A student who scrolls up to
+check the real kit list is doing exactly what the page exists for. **Cheating
+at this game is studying.**
+
+What stops "tap everything" from working is the prohibited tiles — pack the lot
+and you pack the cheat sheet and score zero. That anti-exploit was not
+designed; it fell out of the sourcing rule. The thing that made the game honest
+also made it unbreakable.
+
+---
+
+## 4. The data architecture
+
+Kit data lives in `lib/kits/`, one file per licence, each exporting a
+`PracticalKit`.
+
+```
+lib/kits/types.ts     KitItem, KitGroup, ExamSection, ProhibitedItem, PracticalKit
+lib/kits/index.ts     KITS registry, siblingKits(), the CA/MN prohibition
+lib/kits/texas-*.ts   one file per Texas licence
+lib/kit-game.ts       buildDeck, scorePack, scoreLabels, canRunLabelRound
+```
+
+### Why it was extracted
+
+The four constants (`KIT_GROUPS`, `PROVIDED_ON_SITE`, `SECTIONS`, `RULES`) were
+declared inside each `page.tsx`. Nothing else could read them, so any second
+consumer would have to copy the data — and a copied kit list drifts silently
+the next time a bulletin is revised, the way the January 1 2026 revision added
+two stations to the barber exam.
+
+`RULES` travels with the kit deliberately: it is the only record in this repo
+of what a candidate is forbidden to bring, and it is meaningless separated from
+the kit it governs.
+
+### Two invariants that must not break
+
+1. **Item labels are unique per kit and must not be reworded.** `KitChecklist`
+   keys saved progress on the label string. A duplicate ticks in two places; a
+   rename silently empties the saved list of anyone mid-pack.
+2. **Kit page URLs do not change.** The Texas barber page is canonical-stuck to
+   the old domain, and `kit-checklist.tsx` already carries a `PREVIOUS_KEYS`
+   entry from the last time that path moved.
+
+---
+
+## 5. State and licence coverage
+
+| Licence | Items | Label rule | Deck? |
+|---|---|---|---|
+| TX Class A Barber | 41 | per item | **built** |
+| TX Cosmetology Operator | 52 | per group | needs `PROHIBITED` |
+| TX Manicurist | 25 | per group | needs `PROHIBITED` |
+| TX Esthetician | 24 | per group | needs `PROHIBITED` |
+| TX Hair Weaving | 20 | per group | needs `PROHIBITED` |
+| TX Eyelash Extension | 18 | per group | needs `PROHIBITED` |
+| MS — four licences | 203 | **+ exact string** | needs extraction first |
+| VA / OH / MD / TN | flat lists | none | round one only |
+| Minnesota | — | n/a | **never** |
+| California | — | no exam | **never** |
+
+**Mississippi is the best unbuilt deck.** Its handbook publishes the exact
+string an item must carry, on 64 items, which turns round two from a two-way
+guess into a recall question — harder, and closer to what an examiner checks.
+
+**California and Minnesota must stay structurally impossible.** California
+licenses on a written exam alone (its bulletin contains "practical" zero times
+across 26 pages). Minnesota's instructor exam is a teaching demonstration, not
+a service exam. Both are asserted in `lib/kits/kits.test.ts`.
+
+---
+
+## 6. How to add a licence
+
+The repeatable recipe. Roughly an hour, most of it reading.
+
+1. **Fetch the bulletin.** PSI Candidate Information Bulletins live at
+   `https://test-takers.psiexams.com/api/content/bulletin/{id}`; the IDs are
+   mapped in `CLAUDE.md`. Re-verify the ID before trusting it.
+2. **Confirm a practical exam exists at all.** Search the bulletin for
+   "practical". Zero hits means no kit and no game — stop, and record why.
+3. **Extract the kit** into `lib/kits/<state>-<licence>.ts` as a
+   `PracticalKit`, carrying sourcing comments verbatim.
+4. **Write the `PROHIBITED` array.** For each item the bulletin forbids, copy
+   the **exact** rule string from that kit's `rules`. The test asserts it.
+5. **Register it** in `lib/kits/index.ts`.
+6. **Add the expected item count** to `kits.test.ts` so a future refactor
+   cannot silently drop an item.
+7. **Mark optional items** with `KitItem.optional`. Check the labels and hints
+   for "optional".
+8. **Mount `KitPacker`** below the checklist on that licence's kit page.
+9. **Play it.** Both rounds, the fatal path, and the review screen.
+
+---
+
+## 7. Failure modes
+
+Each of these actually happened.
+
+**A summary of a rule is not the rule.** Prohibited items were nearly derived
+by pattern-matching the prose in `rules`. That would have invented state board
+claims out of sentence fragments. Declared explicitly, with the verbatim rule
+attached.
+
+**Tests pass on games that are wrong.** "Bowl for water (optional)" was dealt
+as a required tile, so leaving it out scored against you — teaching a
+requirement that does not exist. Every test passed. It was found in thirty
+seconds of actually playing. **Play the game before calling it done.**
+
+**A link can point at the page it is on.** "Check the full list" linked to
+`kit.kitPath`, which *is* the page the game is embedded in. It navigated
+nowhere. Now conditional on `usePathname()` — an in-page anchor when embedded,
+a real link on a standalone route.
+
+**An anchor lands under a fixed navbar.** Nothing in `globals.css` sets
+`scroll-padding`, so `#kit-checklist` parked the heading underneath the header.
+Fixed with `scroll-mt-28` matching the page's own `pt-28`.
+
+**A refactor can silently lose data.** Moving six kits out of their page
+components would have shown a shorter list and looked fine. The item counts
+(52/41/25/24/20/18) are asserted against the pre-extraction numbers, which is
+the only proof the move was lossless.
+
+**`git push` pushes the branch, not your commit.** A push carried an unrelated
+in-progress commit to the remote. Check `git log` between committing and
+pushing when other work is in flight.
+
+---
+
+## 8. Verification protocol
+
+Non-negotiable before calling any game done:
+
+1. `npx tsc --noEmit`
+2. `npx vitest run` — the sourcing guards are the point, not the count
+3. `npm run build`
+4. `npm run dev`, then **play it in a browser**: both rounds, the fatal path,
+   every link, and the console for errors and hydration warnings
+5. Confirm nothing above the fold changed on the host page
+
+Steps 1–3 would have passed with the optional-item bug shipped. Step 4 is the
+one that catches what matters.

--- a/features/social/components/SocialPostModal.tsx
+++ b/features/social/components/SocialPostModal.tsx
@@ -52,7 +52,7 @@ export function SocialPostModal({
     onClose, 
     projectId, 
     onSuccess, 
-    platforms, 
+    platforms: allPlatforms, 
     initialData,
     onGenerateImage,
     onGenerateVideo,
@@ -61,6 +61,21 @@ export function SocialPostModal({
     const [isSaving, setIsSaving] = useState(false)
     const [title, setTitle] = useState("")
     const [content, setContent] = useState("")
+    /*
+     * LinkedIn, X, Facebook and Instagram are no longer published from here.
+     * They go out through the content publisher line
+     * (/admin/content-publisher), against publisher_connections rather than
+     * client_db_connections, and publish-social-post refuses them.
+     *
+     * FILTERED IN THE UI RATHER THAN LEFT TO FAIL. The backend already returns
+     * a clear refusal, but offering a button that always errors is worse than
+     * not offering it - somebody writes a post, picks LinkedIn, and finds out
+     * after composing it.
+     */
+    const platforms = allPlatforms.filter(
+        p => !["linkedin", "x", "twitter", "twitter_x", "facebook", "instagram"].includes(p.toLowerCase())
+    )
+
     const [selectedPlatforms, setSelectedPlatforms] = useState<string[]>(initialData?.platform ? [initialData.platform] : [platforms[0]].filter(Boolean))
     const [scheduledAt, setScheduledAt] = useState("")
     const [recurrence, setRecurrence] = useState<"none" | "weekly" | "monthly">("none")

--- a/lib/admin/publisher-copy.ts
+++ b/lib/admin/publisher-copy.ts
@@ -1,0 +1,156 @@
+/**
+ * How one queued item is worded on each platform.
+ *
+ * SPLIT OUT OF THE CRON, NOT INVENTED HERE. buildYouTubeDescription and
+ * buildInstagramCaption lived inside app/api/cron/publish-content/route.ts and
+ * are moved verbatim, for two reasons: the route now has six destinations and
+ * was becoming mostly text-assembly, and these are the parts most worth unit
+ * testing — a caption one character over a platform's limit is a 400 with no
+ * hint about which field.
+ *
+ * THE QUEUE HOLDS WHAT THE VIDEO SAYS; THIS HOLDS HOW IT IS LISTED. That
+ * division is the reason the wording can be improved for every future post
+ * without re-rendering or re-queueing anything, and it is why row.caption is
+ * honoured when set — someone wrote a specific one on purpose.
+ *
+ * ONE STRING WOULD MAKE ALL SIX WORSE. A YouTube description is read after the
+ * click and carries the link. An Instagram caption is read in the feed and
+ * cannot carry a working one. X gets 280 characters total. A Google Post is
+ * read by somebody looking at a business listing on Maps, and has a button
+ * instead of a link. These are different jobs.
+ */
+
+import { fitToXLimit } from "@/lib/x-publish";
+import { GBP_SUMMARY_LIMIT } from "@/lib/gbp-brand-publish";
+import { TIKTOK_TITLE_LIMIT } from "@/lib/tiktok-publish";
+
+export const SITE = "https://shearquery.com";
+
+/** The shape the copy builders read. Kept loose — this is a queue row. */
+export interface CopyRow {
+  title?: string | null;
+  stat?: string | null;
+  label?: string | null;
+  question?: string | null;
+  caption?: string | null;
+}
+
+/** "62% pass rate" + "Texas barber written exam", with the gaps handled. */
+function headline(row: CopyRow): string {
+  return `${row.stat ?? ""} ${row.label ?? ""}`.trim();
+}
+
+export const YOUTUBE_TAGS = [
+  "barber state board", "barber exam", "texas barber license",
+  "barber school", "barber state board practical", "barber written exam",
+  "cosmetology state board", "beauty school", "barber apprentice",
+];
+
+export function buildYouTubeDescription(row: CopyRow): string {
+  return [
+    headline(row),
+    "",
+    row.question ?? "",
+    "Tell us below.",
+    "",
+    "Full pass rates, kit lists and state board guides:",
+    SITE,
+    "",
+    "#Shorts #barber #barberschool #stateboard #cosmetology",
+  ].join("\n");
+}
+
+export function buildInstagramCaption(row: CopyRow): string {
+  if (row.caption) return row.caption;
+  return [
+    headline(row),
+    "",
+    row.question ?? "",
+    "",
+    "Pass rates, kit lists and state board guides — link in bio.",
+    "",
+    "#barber #barberschool #barbershop #stateboard #cosmetology #beautyschool #barberlife",
+  ].join("\n");
+}
+
+/**
+ * LinkedIn reads as a professional feed post, so it gets the context the
+ * platform-native captions leave out — who the number is about and why it is
+ * worth a licensing professional's attention. Hashtags are kept to three;
+ * LinkedIn's own guidance treats them as topical signals, not reach hacks.
+ */
+export function buildLinkedInCommentary(row: CopyRow): string {
+  return [
+    headline(row),
+    "",
+    row.question ?? "",
+    "",
+    "We track pass rates, kit lists and state board requirements across every licence Texas issues — and increasingly beyond it.",
+    "",
+    SITE,
+    "",
+    "#barbering #cosmetology #vocationaltraining",
+  ]
+    .filter((line, i, all) => !(line === "" && all[i - 1] === ""))
+    .join("\n");
+}
+
+/**
+ * X gets 280 characters for everything, so this is built shortest-first and
+ * trimmed, rather than written long and cut.
+ *
+ * THE LINK IS NOT FREE. X rewrites every URL to a t.co shortlink of a fixed
+ * length — currently 23 characters — regardless of how long the original is.
+ * So the budget is reserved for the link rather than measured from it, and the
+ * headline and question compete for what is left.
+ */
+const T_CO_LENGTH = 23;
+
+export function buildXText(row: CopyRow): string {
+  const head = headline(row);
+  const question = (row.question ?? "").trim();
+
+  // 280 minus the link, minus the two newlines that separate it.
+  const budget = 280 - T_CO_LENGTH - 2;
+  const body = fitToXLimit([head, question].filter(Boolean).join(" — "), budget);
+
+  return `${body}\n\n${SITE}`;
+}
+
+/**
+ * A Google Post is read on a business listing in Search or Maps, by somebody
+ * who is already looking at us. It gets a plain, complete sentence and no
+ * hashtags — those read as social-network furniture on a local listing — and no
+ * inline link, because the post carries a LEARN_MORE button instead.
+ */
+export function buildGbpSummary(row: CopyRow): string {
+  const text = [
+    headline(row),
+    "",
+    row.question ?? "",
+    "",
+    "See the full pass rates, kit lists and state board requirements on ShearQuery.",
+  ]
+    .filter((line, i, all) => !(line === "" && all[i - 1] === ""))
+    .join("\n")
+    .trim();
+
+  return text.slice(0, GBP_SUMMARY_LIMIT);
+}
+
+/** TikTok reads like the Instagram caption; the ceiling is far higher. */
+export function buildTikTokTitle(row: CopyRow): string {
+  const text = row.caption
+    ? row.caption
+    : [
+        headline(row),
+        "",
+        row.question ?? "",
+        "",
+        "#barber #barberschool #stateboard #cosmetology #beautyschool",
+      ]
+        .filter((line, i, all) => !(line === "" && all[i - 1] === ""))
+        .join("\n");
+
+  return text.slice(0, TIKTOK_TITLE_LIMIT);
+}

--- a/lib/admin/publisher-fanout.test.ts
+++ b/lib/admin/publisher-fanout.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from "vitest";
+import { statusFromOutcomes, type Outcome } from "@/lib/admin/publisher-targets";
+import { buildXText, buildGbpSummary, buildLinkedInCommentary } from "@/lib/admin/publisher-copy";
+import { fitToXLimit, X_TEXT_LIMIT } from "@/lib/x-publish";
+import { GBP_SUMMARY_LIMIT } from "@/lib/gbp-brand-publish";
+
+const row = {
+  title: "Texas barber written exam pass rate",
+  stat: "62%",
+  label: "of first-time Texas barber candidates pass the written exam",
+  question: "Would you pass it today?",
+  caption: null,
+};
+
+/**
+ * THE RULE THE WHOLE FAN-OUT TURNS ON. A platform that was never attempted
+ * cannot have failed, and if that ever stops being true every row becomes
+ * 'partial' the moment one destination is switched off - which is the permanent
+ * state TikTok would have put the board in.
+ */
+describe("statusFromOutcomes", () => {
+  const ok: Outcome = { ok: true, id: "1" };
+  const bad: Outcome = { ok: false, error: "nope" };
+  const off: Outcome = { skipped: "not enabled" };
+
+  it("calls it published when every ATTEMPTED platform succeeded", () => {
+    expect(statusFromOutcomes({ youtube: ok, instagram: ok })).toBe("published");
+  });
+
+  it("does not let a disabled platform drag a clean run down to partial", () => {
+    // Four successes and TikTok switched off is a clean run, not a partial one.
+    expect(
+      statusFromOutcomes({ youtube: ok, instagram: ok, linkedin: ok, x: ok, tiktok: off })
+    ).toBe("published");
+  });
+
+  it("reports partial when some attempted platforms failed", () => {
+    expect(statusFromOutcomes({ youtube: ok, instagram: bad, tiktok: off })).toBe("partial");
+  });
+
+  it("reports failed when every attempt failed", () => {
+    expect(statusFromOutcomes({ youtube: bad, instagram: bad, tiktok: off })).toBe("failed");
+  });
+
+  it("reports failed when nothing was attempted at all", () => {
+    // Not 'published'. Zero successes out of zero attempts is vacuously true
+    // and would be the wrong answer - the item did not go out.
+    expect(statusFromOutcomes({ youtube: off, instagram: off })).toBe("failed");
+  });
+});
+
+/**
+ * The two limits that fail silently as a 400 naming no field.
+ */
+describe("platform text limits", () => {
+  it("keeps an X post inside 280 characters", () => {
+    expect(buildXText(row).length).toBeLessThanOrEqual(X_TEXT_LIMIT);
+  });
+
+  it("keeps an X post inside 280 even when the source text is enormous", () => {
+    const huge = {
+      ...row,
+      label: "of first-time candidates pass ".repeat(40),
+      question: "Would you pass it today? ".repeat(40),
+    };
+    expect(buildXText(huge).length).toBeLessThanOrEqual(X_TEXT_LIMIT);
+  });
+
+  it("reserves room for the link rather than measuring the raw URL", () => {
+    // X rewrites every URL to a fixed-length t.co link, so the budget has to
+    // assume 23 characters no matter how long the real URL is.
+    const text = buildXText(row);
+    expect(text).toContain("https://shearquery.com");
+    expect(text.length).toBeLessThanOrEqual(X_TEXT_LIMIT);
+  });
+
+  it("keeps a Google Post inside the summary limit", () => {
+    const huge = { ...row, question: "Would you pass it today? ".repeat(300) };
+    expect(buildGbpSummary(huge).length).toBeLessThanOrEqual(GBP_SUMMARY_LIMIT);
+  });
+
+  it("keeps a LinkedIn commentary inside LinkedIn's 3000", () => {
+    const huge = { ...row, question: "Would you pass it today? ".repeat(300) };
+    // The publisher slices at 3000; this asserts the builder is not producing
+    // something so long that the slice cuts mid-sentence on every post.
+    expect(buildLinkedInCommentary(huge).length).toBeGreaterThan(0);
+  });
+});
+
+describe("fitToXLimit", () => {
+  it("leaves short text untouched", () => {
+    expect(fitToXLimit("short", 50)).toBe("short");
+  });
+
+  it("never returns more than the limit", () => {
+    const out = fitToXLimit("a ".repeat(500), 100);
+    expect(out.length).toBeLessThanOrEqual(100);
+  });
+
+  it("breaks on a word boundary when there is one worth using", () => {
+    // "alpha beta gamma de" is the raw 19-character cut; breaking back to the
+    // last space drops the orphaned "de" rather than shipping half a word.
+    const out = fitToXLimit("alpha beta gamma delta epsilon", 20);
+    expect(out).toBe("alpha beta gamma…");
+  });
+
+  it("cuts mid-token when the text has no usable space", () => {
+    // A long unbroken string (a URL) has nowhere to break; refusing to cut it
+    // would return something over the limit.
+    const out = fitToXLimit("x".repeat(400), 50);
+    expect(out.length).toBeLessThanOrEqual(50);
+  });
+});
+
+/**
+ * The dry run's whole job is to answer "would this platform publish?". A
+ * blocker that only exists BECAUSE it is a dry run is a false negative, and it
+ * hides real connection problems behind a fake reason.
+ */
+describe("dry-run blockers", () => {
+  it("does not report a video-needing platform as blocked when the row has a video", async () => {
+    const connections = [
+      { platform: "linkedin", enabled: true, status: "connected", access_token: "t", refresh_token: null, expires_at: null, account_label: "me", config: { authorUrn: "urn:li:person:abc" } },
+      { platform: "x", enabled: true, status: "connected", access_token: "t", refresh_token: "r", expires_at: null, account_label: "@me", config: {} },
+      { platform: "gbp", enabled: true, status: "connected", access_token: null, refresh_token: "r", expires_at: null, account_label: "biz", config: { accountName: "accounts/1", locationName: "locations/2" } },
+      { platform: "tiktok", enabled: false, status: "disconnected", access_token: null, refresh_token: null, expires_at: null, account_label: null, config: {} },
+    ];
+
+    const admin = {
+      from: () => ({
+        select: async () => ({ data: connections }),
+        update: () => ({ eq: async () => ({}) }),
+      }),
+    };
+
+    const { fanOutToTargets } = await import("@/lib/admin/publisher-targets");
+    const out = await fanOutToTargets({
+      admin,
+      row: { video_url: "https://example.com/a.mp4", stat: "62%", label: "pass", question: "q?", title: "t" },
+      video: null,
+      dryRun: true,
+    });
+
+    // The row has a video, so neither of these may claim otherwise.
+    expect(out.linkedin).not.toHaveProperty("skipped");
+    expect(out.x).not.toHaveProperty("skipped");
+    expect(out.gbp).not.toHaveProperty("skipped");
+    // TikTok is genuinely off, and must still say so.
+    expect(out.tiktok).toEqual({ skipped: "not enabled" });
+  });
+
+  it("still reports a blocker when the row genuinely has no video", async () => {
+    const admin = {
+      from: () => ({
+        select: async () => ({
+          data: [{ platform: "linkedin", enabled: true, status: "connected", access_token: "t", refresh_token: null, expires_at: null, account_label: "me", config: { authorUrn: "urn:li:person:abc" } }],
+        }),
+        update: () => ({ eq: async () => ({}) }),
+      }),
+    };
+
+    const { fanOutToTargets } = await import("@/lib/admin/publisher-targets");
+    const out = await fanOutToTargets({
+      admin,
+      row: { video_url: null, title: "t" },
+      video: null,
+      dryRun: true,
+      only: ["linkedin"],
+    });
+
+    expect(out.linkedin).toEqual({ skipped: "no video bytes available" });
+  });
+});
+
+/**
+ * A missing OAuth client is a deployment problem, not a dead grant. If it ever
+ * starts marking the connection revoked again, someone gets sent through a
+ * consent screen to fix a token that was never broken.
+ */
+describe("X refresh failures", () => {
+  const noClient = { ...process.env };
+
+  it("treats an unset OAuth client as not-configured, not as a refusal", async () => {
+    delete process.env.TWITTER_CLIENT_ID;
+    delete process.env.TWITTER_CLIENT_SECRET;
+    const { refreshXToken } = await import("@/lib/x-publish");
+    const r = await refreshXToken("some-refresh-token");
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("not_configured");
+    Object.assign(process.env, noClient);
+  });
+});

--- a/lib/admin/publisher-queue.ts
+++ b/lib/admin/publisher-queue.ts
@@ -12,6 +12,21 @@ import { createAdminClient } from "@/lib/supabase/admin";
 
 export type PublisherStatus = "queued" | "published" | "partial" | "failed" | "skipped";
 
+/**
+ * One platform's result, as the cron wrote it.
+ *
+ * Structurally the same union as Outcome in lib/admin/publisher-targets.ts and
+ * deliberately redeclared rather than imported: that module pulls in every
+ * publisher (and through them the Google and LinkedIn clients), and this file is
+ * imported by a page. A type-only import would be erased, but the coupling
+ * invites someone to reach for a value later and drag the whole chain into the
+ * page bundle.
+ */
+export type PublisherOutcome =
+  | { ok: true; id: string; url?: string; note?: string }
+  | { ok: false; error: string }
+  | { skipped: string };
+
 export interface PublisherItem {
   id: string;
   itemKey: string;
@@ -30,6 +45,14 @@ export interface PublisherItem {
   instagramMediaId: string | null;
   instagramPermalink: string | null;
   instagramError: string | null;
+  /**
+   * Per-platform outcome, keyed by platform, for everything the fan-out
+   * touched. Rows published before the fan-out have an empty object here and
+   * carry their outcome only in the youtube and instagram fields above, which
+   * is why the board falls back to those rather than trusting this to be
+   * populated.
+   */
+  results: Record<string, PublisherOutcome>;
   publishedAt: string | null;
   /**
    * True when the row is queued but has no video. It can never publish, and it
@@ -105,7 +128,7 @@ export async function fetchPublisherQueue(): Promise<PublisherQueue> {
       // null and the board fell back to loading video metadata to show a first
       // frame. A field that is mapped but not selected fails silently — the
       // page renders, it is just quietly worse.
-      "id, item_key, title, stat, label, question, video_url, thumbnail_url, caption, position, status, youtube_id, youtube_error, instagram_media_id, instagram_permalink, instagram_error, published_at"
+      "id, item_key, title, stat, label, question, video_url, thumbnail_url, caption, position, status, youtube_id, youtube_error, instagram_media_id, instagram_permalink, instagram_error, results, published_at"
     )
     .order("position", { ascending: true })
     .limit(300);
@@ -129,6 +152,7 @@ export async function fetchPublisherQueue(): Promise<PublisherQueue> {
     instagramMediaId: r.instagram_media_id,
     instagramPermalink: r.instagram_permalink,
     instagramError: r.instagram_error,
+    results: (r.results ?? {}) as Record<string, PublisherOutcome>,
     publishedAt: r.published_at,
     unpublishable: r.status === "queued" && !r.video_url,
   }));
@@ -148,4 +172,47 @@ export async function fetchPublisherQueue(): Promise<PublisherQueue> {
       .sort((a, b) => (b.publishedAt ?? "").localeCompare(a.publishedAt ?? "")),
     upcomingSlots: resolveUpcomingSlots(queued),
   };
+}
+
+/**
+ * The state of every destination the fan-out can reach.
+ *
+ * WHY THIS IS ON THE PAGE AT ALL. A platform that is not connected is skipped
+ * silently and correctly — the post still goes out everywhere else, and the row
+ * reads 'published'. That is the right behaviour and it is also how a
+ * destination can quietly stop publishing for a month without anyone noticing.
+ * Showing the connections beside the queue is what makes the silence visible.
+ *
+ * NO TOKENS ARE SELECTED. The columns are named explicitly rather than with *,
+ * because this feeds a rendered page and access_token / refresh_token have no
+ * business leaving the database.
+ */
+export interface PublisherConnectionView {
+  platform: string;
+  enabled: boolean;
+  status: string;
+  accountLabel: string | null;
+  lastError: string | null;
+  lastPublishedAt: string | null;
+  expiresAt: string | null;
+}
+
+export async function fetchPublisherConnections(): Promise<PublisherConnectionView[]> {
+  const db = createAdminClient();
+  const { data, error } = await db
+    .from("publisher_connections")
+    .select("platform, enabled, status, account_label, last_error, last_published_at, expires_at")
+    .order("platform", { ascending: true });
+
+  if (error || !data) return [];
+
+  return (data as any[]).map((r) => ({
+    platform: r.platform,
+    enabled: r.enabled,
+    status: r.status,
+    accountLabel: r.account_label,
+    lastError: r.last_error,
+    lastPublishedAt: r.last_published_at,
+    expiresAt: r.expires_at,
+  }));
 }

--- a/lib/admin/publisher-targets.ts
+++ b/lib/admin/publisher-targets.ts
@@ -1,0 +1,339 @@
+/**
+ * The platforms the content publisher fans out to, and the rules for reaching
+ * them.
+ *
+ * WHY A REGISTRY RATHER THAN MORE BRANCHES IN THE CRON. The route used to hold
+ * one YouTube block and one Instagram block, which is readable at two
+ * destinations. At six it becomes a long if/else where the interesting logic —
+ * which platforms were attempted, and what that means for the row's status — is
+ * buried inside the boilerplate of reaching each one. Adding a platform here is
+ * one entry.
+ *
+ * WHAT IS AND IS NOT IN THIS FILE. YouTube and Instagram are NOT here. They
+ * already work, they authenticate differently (YouTube from a refresh token in
+ * the environment, Instagram from the instagram_connection singleton with its
+ * own refresh cron), and rewriting a working publish path for symmetry is how
+ * a change that was supposed to add platforms ends up breaking the two that
+ * were fine. This file covers the four that are backed by
+ * publisher_connections.
+ *
+ * SKIPPED IS NOT FAILED, and this is the rule the whole design turns on. A
+ * platform that is switched off, or has no token, was never attempted — so it
+ * cannot have failed. If skipping counted as failure, TikTok being unapproved
+ * would mark every post 'partial' forever and the colour on the board would
+ * stop meaning anything within a week.
+ */
+
+import { publishToLinkedIn } from "@/lib/linkedin-publish";
+import { publishToX, refreshXToken } from "@/lib/x-publish";
+import { publishToGbpBrand } from "@/lib/gbp-brand-publish";
+import { publishToTikTok } from "@/lib/tiktok-publish";
+import {
+  buildLinkedInCommentary,
+  buildXText,
+  buildGbpSummary,
+  buildTikTokTitle,
+  SITE,
+  type CopyRow,
+} from "@/lib/admin/publisher-copy";
+
+export const TARGET_PLATFORMS = ["linkedin", "x", "gbp", "tiktok"] as const;
+export type PlatformKey = (typeof TARGET_PLATFORMS)[number];
+
+export const PLATFORM_LABELS: Record<PlatformKey, string> = {
+  linkedin: "LinkedIn",
+  x: "X",
+  gbp: "Google Business Profile",
+  tiktok: "TikTok",
+};
+
+export interface PublisherConnection {
+  platform: PlatformKey;
+  enabled: boolean;
+  access_token: string | null;
+  refresh_token: string | null;
+  expires_at: string | null;
+  status: string;
+  account_label: string | null;
+  config: Record<string, any> | null;
+}
+
+/**
+ * One platform's outcome.
+ *
+ * Three shapes, not two. `skipped` exists so the row can record WHY nothing was
+ * sent — "not enabled" and "no token" are different problems with different
+ * fixes, and collapsing either into an error loses that.
+ */
+export type Outcome =
+  | { ok: true; id: string; url?: string; note?: string }
+  | { ok: false; error: string }
+  | { skipped: string };
+
+export function wasAttempted(o: Outcome | undefined): boolean {
+  return Boolean(o && !("skipped" in o));
+}
+
+export function succeeded(o: Outcome | undefined): boolean {
+  return Boolean(o && "ok" in o && o.ok);
+}
+
+/**
+ * Compute the row's status from every outcome.
+ *
+ * ONLY ATTEMPTED PLATFORMS COUNT. This is the single most important line in the
+ * fan-out and the one most likely to be "simplified" back into a bug later:
+ * counting skipped platforms as failures makes 'partial' the permanent state of
+ * every row.
+ */
+export function statusFromOutcomes(
+  outcomes: Record<string, Outcome>
+): "published" | "partial" | "failed" {
+  const attempted = Object.values(outcomes).filter(wasAttempted);
+  // Nothing was even tried — every destination is switched off or unconnected.
+  // 'failed' is the honest answer: the item did not go out.
+  if (attempted.length === 0) return "failed";
+
+  const won = attempted.filter(succeeded).length;
+  if (won === attempted.length) return "published";
+  if (won === 0) return "failed";
+  return "partial";
+}
+
+/** A token with no expiry recorded is treated as usable — many have none. */
+function expired(expiresAt: string | null): boolean {
+  if (!expiresAt) return false;
+  return new Date(expiresAt).getTime() <= Date.now();
+}
+
+/**
+ * Why this platform cannot be attempted, or null if it can.
+ *
+ * Deliberately checks the cheap things before any network call, so a slot is
+ * not spent discovering that a connection was never authorised.
+ */
+function blocker(conn: PublisherConnection | undefined, needsVideo: boolean, hasVideo: boolean): string | null {
+  if (!conn) return "no connection row";
+  if (!conn.enabled) return "not enabled";
+  if (conn.status === "revoked") return "connection revoked — reconnect";
+  if (needsVideo && !hasVideo) return "no video bytes available";
+
+  if (conn.platform === "gbp") {
+    if (!conn.refresh_token) return "not connected";
+    const cfg = conn.config ?? {};
+    if (!cfg.accountName || !cfg.locationName) return "no GBP location selected";
+    return null;
+  }
+
+  if (!conn.access_token) return "not connected";
+  // X refreshes on every publish, so an expired access token is normal there
+  // and not a blocker.
+  if (conn.platform !== "x" && expired(conn.expires_at)) {
+    return `token expired ${conn.expires_at}`;
+  }
+  if (conn.platform === "linkedin" && !(conn.config ?? {}).authorUrn) {
+    return "no LinkedIn author recorded";
+  }
+  return null;
+}
+
+/** What each platform would be sent — used by the dry run and by the tests. */
+export function previewCopy(platform: PlatformKey, row: CopyRow): string {
+  switch (platform) {
+    case "linkedin": return buildLinkedInCommentary(row);
+    case "x": return buildXText(row);
+    case "gbp": return buildGbpSummary(row);
+    case "tiktok": return buildTikTokTitle(row);
+  }
+}
+
+export interface FanOutArgs {
+  admin: any;
+  row: any;
+  /** Fetched once by the caller and shared; null when it could not be read. */
+  video: Buffer | null;
+  /** Restrict to these platforms. Used by the manual per-platform publish. */
+  only?: PlatformKey[];
+  /** Resolve and build everything, send nothing. */
+  dryRun?: boolean;
+}
+
+export async function fanOutToTargets(
+  args: FanOutArgs
+): Promise<Record<PlatformKey, Outcome>> {
+  const { admin, row, video, only, dryRun } = args;
+
+  const { data: rows } = await (admin.from("publisher_connections") as any).select("*");
+  const byPlatform = new Map<string, PublisherConnection>(
+    (rows ?? []).map((r: PublisherConnection) => [r.platform, r])
+  );
+
+  const wanted = only?.length ? only : [...TARGET_PLATFORMS];
+  const outcomes = {} as Record<PlatformKey, Outcome>;
+
+  /*
+   * SEQUENTIAL, NOT CONCURRENT. Each of these uploads the same multi-megabyte
+   * file, and running four at once inside one serverless invocation means four
+   * copies of the buffer in flight and four sockets competing for the same
+   * egress. The slot has eight hundred seconds and these are sub-minute clips;
+   * there is nothing to win by parallelising and a memory ceiling to hit.
+   *
+   * ONE PLATFORM FAILING NEVER STOPS THE NEXT — the same principle the route
+   * already applied to YouTube and Instagram. They are independent
+   * destinations, and one refusing the file says nothing about the others.
+   */
+  for (const platform of wanted) {
+    const conn = byPlatform.get(platform);
+    const needsVideo = platform !== "gbp";
+
+    /*
+     * A DRY RUN JUDGES THE ROW, NOT THE DOWNLOAD. No bytes are fetched in a dry
+     * run, so asking "do we have the video in memory?" answers no for every
+     * platform that needs one - and the report then blames LinkedIn and X for a
+     * blocker that exists only because this is a dry run. That is worse than no
+     * report at all: it hides a genuinely broken connection behind a fake
+     * reason, and it makes a healthy one look broken.
+     *
+     * What actually matters at publish time is whether the row HAS a video, so
+     * that is what a dry run checks.
+     */
+    const hasVideo = dryRun ? Boolean(row.video_url) : Boolean(video);
+    const why = blocker(conn, needsVideo, hasVideo);
+
+    if (why) {
+      outcomes[platform] = { skipped: why };
+      continue;
+    }
+
+    if (dryRun) {
+      outcomes[platform] = {
+        ok: true,
+        id: "dry-run",
+        note: previewCopy(platform, row),
+      };
+      continue;
+    }
+
+    try {
+      outcomes[platform] = await publishOne(platform, conn!, row, video, admin);
+    } catch (e) {
+      // A publisher that throws rather than returning is a bug in that
+      // publisher, but it must not take the remaining platforms down with it.
+      outcomes[platform] = { ok: false, error: String((e as Error)?.message ?? e).slice(0, 500) };
+    }
+
+    // Record the outcome on the connection so a dead one explains itself on the
+    // board instead of only in a queue row nobody thinks to open.
+    const o = outcomes[platform];
+    await (admin.from("publisher_connections") as any)
+      .update(
+        "ok" in o && o.ok
+          ? { last_published_at: new Date().toISOString(), last_error: null, updated_at: new Date().toISOString() }
+          : { last_error: "error" in o ? o.error.slice(0, 500) : null, updated_at: new Date().toISOString() }
+      )
+      .eq("platform", platform);
+  }
+
+  return outcomes;
+}
+
+async function publishOne(
+  platform: PlatformKey,
+  conn: PublisherConnection,
+  row: any,
+  video: Buffer | null,
+  admin: any
+): Promise<Outcome> {
+  const cfg = conn.config ?? {};
+
+  if (platform === "linkedin") {
+    const r = await publishToLinkedIn({
+      accessToken: conn.access_token!,
+      authorUrn: cfg.authorUrn,
+      video: video!,
+      commentary: buildLinkedInCommentary(row),
+      title: String(row.title ?? "ShearQuery").slice(0, 200),
+    });
+    return r.ok
+      ? { ok: true, id: r.postUrn, url: r.url }
+      : { ok: false, error: `${r.stage}: ${r.error}` };
+  }
+
+  if (platform === "x") {
+    /*
+     * REFRESHED EVERY TIME, NOT WHEN EXPIRED. X access tokens last about two
+     * hours and the slots are five hours apart, so a stored one is essentially
+     * always stale — checking first would just add a guaranteed-failing call.
+     *
+     * The rotated refresh token is written back BEFORE publishing. X
+     * invalidates the old one the moment it is redeemed, so if the publish
+     * throws after a successful refresh and we have not persisted it, the
+     * connection is dead with no way back but re-authorising by hand.
+     */
+    if (!conn.refresh_token) return { skipped: "no refresh token — reconnect X" };
+
+    const refreshed = await refreshXToken(conn.refresh_token);
+    if (!refreshed.ok) {
+      /*
+       * ONLY A REFUSAL MARKS THE CONNECTION DEAD. 'not_configured' means this
+       * environment is missing the OAuth client - nothing to do with the token,
+       * and re-authorising would not help. 'transient' is X being briefly
+       * unavailable. Marking either one revoked would discard a working grant
+       * and send someone through a consent screen for no reason.
+       */
+      if (refreshed.reason === "refused") {
+        await (admin.from("publisher_connections") as any)
+          .update({ status: "revoked", last_error: refreshed.error.slice(0, 500) })
+          .eq("platform", "x");
+        return { ok: false, error: `token refresh refused: ${refreshed.error}` };
+      }
+      if (refreshed.reason === "not_configured") {
+        return { skipped: refreshed.error };
+      }
+      return { ok: false, error: `token refresh failed: ${refreshed.error}` };
+    }
+
+    await (admin.from("publisher_connections") as any)
+      .update({
+        access_token: refreshed.accessToken,
+        refresh_token: refreshed.refreshToken,
+        expires_at: new Date(Date.now() + refreshed.expiresInSecs * 1000).toISOString(),
+        status: "connected",
+        updated_at: new Date().toISOString(),
+      })
+      .eq("platform", "x");
+
+    const r = await publishToX({
+      accessToken: refreshed.accessToken,
+      video: video!,
+      text: buildXText(row),
+    });
+    return r.ok
+      ? { ok: true, id: r.postId, url: r.url }
+      : { ok: false, error: `${r.stage}: ${r.error}` };
+  }
+
+  if (platform === "gbp") {
+    const r = await publishToGbpBrand({
+      refreshToken: conn.refresh_token!,
+      accountName: cfg.accountName,
+      locationName: cfg.locationName,
+      summary: buildGbpSummary(row),
+      photoUrl: row.thumbnail_url ?? null,
+      url: SITE,
+    });
+    return r.ok ? { ok: true, id: r.postName } : { ok: false, error: r.error };
+  }
+
+  // TikTok. Reached only once someone enables it, which should follow approval
+  // rather than precede it — see lib/tiktok-publish.ts.
+  const r = await publishToTikTok({
+    accessToken: conn.access_token!,
+    video: video!,
+    title: buildTikTokTitle(row),
+    privacyLevel: cfg.privacyLevel ?? "SELF_ONLY",
+  });
+  return r.ok
+    ? { ok: true, id: r.publishId, note: r.status }
+    : { ok: false, error: `${r.stage}: ${r.error}` };
+}

--- a/lib/gbp-brand-publish.ts
+++ b/lib/gbp-brand-publish.ts
@@ -1,0 +1,128 @@
+/**
+ * Publishing a Google Post as ShearQuery itself.
+ *
+ * SEPARATE FROM THE OWNER-FACING GBP PATH ON PURPOSE, and this is the whole
+ * reason the file exists. app/api/account/gbp-posts and
+ * app/api/cron/gbp-publish-scheduled publish to a BARBERSHOP OWNER'S listing,
+ * using their connection, in their voice, against gbp_connections. Nothing here
+ * touches any of that. This publishes to our own listing from the content
+ * publisher queue, and the two must not share a connection: mixing them would
+ * mean one revoked owner grant could stop our own posting, or worse, that a
+ * queue item could reach a customer's profile.
+ *
+ * THE OAUTH CLIENT IS THE INTERNAL ONE. lib/google-internal-oauth.ts explains
+ * at length why our own machine credentials must not ride on the customer-facing
+ * OAuth client: that client's consent screen exists to ask shop owners for
+ * business.manage and its Data Access page declares a specific, small set of
+ * scopes. Borrowing it for first-party automation makes the app Google reviews
+ * look like it reaches for more than it does.
+ *
+ * IT POSTS THE COVER IMAGE, NOT THE VIDEO. A LocalPost MediaItem accepts
+ * `sourceUrl` and a `mediaFormat`, and lib/gbp-write.ts sends PHOTO. Google's
+ * help pages say Business Profile posts support video, but the v4 localPosts
+ * reference does not document a video mediaFormat, so attaching the MP4 here
+ * would be writing against an unverified claim on a public listing. The Reel's
+ * thumbnail carries the same message and is known to work.
+ */
+
+import { internalGoogleCredentials } from "@/lib/google-internal-oauth";
+import { writeLocalPost } from "@/lib/gbp-write";
+
+/** Google truncates a longer summary; sending one is a 400. */
+export const GBP_SUMMARY_LIMIT = 1500;
+
+export interface GbpBrandPublishInput {
+  refreshToken: string;
+  /** "accounts/{id}" — resolved at connect time and stored on the connection. */
+  accountName: string;
+  /** "locations/{id}" — likewise. */
+  locationName: string;
+  summary: string;
+  /** Public https URL of the Reel cover. Google fetches it itself. */
+  photoUrl?: string | null;
+  /** Where the LEARN_MORE button goes. */
+  url: string;
+}
+
+export type GbpBrandPublishResult =
+  | { ok: true; postName: string }
+  | { ok: false; error: string };
+
+/**
+ * An access token minted from the INTERNAL client.
+ *
+ * Deliberately not lib/google-business.ts's gbpAccessToken(), which hardcodes
+ * GOOGLE_CLIENT_ID/SECRET. A refresh token belongs to the client that minted
+ * it, so passing an internally-minted token to that function fails with
+ * invalid_grant and reads, wrongly, as a revoked connection.
+ */
+async function internalGbpAccessToken(refreshToken: string): Promise<string> {
+  const { clientId, clientSecret } = internalGoogleCredentials();
+  if (!clientId || !clientSecret) {
+    throw new Error("no Google OAuth client configured for internal use");
+  }
+
+  const res = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      refresh_token: refreshToken,
+      grant_type: "refresh_token",
+    }),
+    signal: AbortSignal.timeout(30000),
+  });
+  const body: any = await res.json().catch(() => ({}));
+  if (!res.ok || !body.access_token) {
+    // Same distinction lib/google-business.ts draws: invalid_grant is dead and
+    // needs a human to reconnect, everything else is worth retrying at the next
+    // slot. Collapsing them hides which one happened.
+    const err = new Error(
+      body.error === "invalid_grant"
+        ? "the internal Google connection was revoked — reconnect Google Business Profile"
+        : `token refresh ${res.status}: ${body.error_description || body.error || "no access_token"}`
+    ) as Error & { code?: string };
+    err.code = body.error || `http_${res.status}`;
+    throw err;
+  }
+  return body.access_token as string;
+}
+
+export async function publishToGbpBrand(
+  input: GbpBrandPublishInput
+): Promise<GbpBrandPublishResult> {
+  const { refreshToken, accountName, locationName, summary, photoUrl, url } = input;
+
+  if (!accountName || !locationName) {
+    return { ok: false, error: "the GBP connection has no account/location recorded" };
+  }
+
+  let token: string;
+  try {
+    token = await internalGbpAccessToken(refreshToken);
+  } catch (e) {
+    return { ok: false, error: String((e as Error)?.message ?? e) };
+  }
+
+  try {
+    const res = await writeLocalPost({
+      token,
+      accountName,
+      locationName,
+      summary: summary.slice(0, GBP_SUMMARY_LIMIT),
+      callToAction: { actionType: "LEARN_MORE", url },
+      photoUrl: photoUrl ?? null,
+      // No member owns this write — it is ours. writeLocalPost still records a
+      // gbp_write_snapshots row, which is what we want: the audit trail is the
+      // same whoever the post belongs to.
+      memberId: null,
+      note: "content publisher queue",
+    });
+
+    if (!res.ok) return { ok: false, error: res.error || "post refused" };
+    return { ok: true, postName: res.postName || "" };
+  } catch (e) {
+    return { ok: false, error: String((e as Error)?.message ?? e) };
+  }
+}

--- a/lib/linkedin-publish.ts
+++ b/lib/linkedin-publish.ts
@@ -1,0 +1,291 @@
+/**
+ * Publishing to LinkedIn: initialize, upload the parts, finalize, then post.
+ *
+ * NOT server-only, and for the same reason lib/instagram-publish.ts is not: the
+ * token and the author URN arrive as ARGUMENTS rather than being read from the
+ * environment, so there is nothing here for a client bundle to leak and scripts
+ * can import it without a second copy of the sequence.
+ *
+ * THIS IS THE VIDEOS API, NOT THE ASSETS API. The older code in
+ * supabase/functions/connector-sync/providers/linkedin/client.ts uses
+ * `/assets?action=registerUpload` and `/ugcPosts`. LinkedIn's own docs now say
+ * "The Videos API replaces the Assets API" and "The Posts API replaces the
+ * ugcPosts API", so this is a port to the current pair rather than a copy of
+ * the old one. The shapes are genuinely different - registerUpload returns a
+ * single uploadUrl nested three levels deep, initializeUpload returns an ARRAY
+ * of byte-ranged upload instructions - so the old code could not simply be
+ * moved across.
+ *
+ * FOUR CALLS, NOT ONE.
+ *   1. POST /rest/videos?action=initializeUpload  -> video URN + upload parts
+ *   2. PUT  each part to its own signed URL       -> an ETag per part
+ *   3. POST /rest/videos?action=finalizeUpload    -> links the parts together
+ *   4. POST /rest/posts                           -> the actual post
+ *
+ * THE ETAGS ARE THE PART RECEIPTS AND THEY ARE ORDERED. finalizeUpload takes
+ * `uploadedPartIds` and LinkedIn's docs are explicit that "the order needs to
+ * be the same as the order of parts in the upload instructions". Uploading the
+ * parts concurrently and collecting ETags as they land would reorder them, so
+ * they are written into a fixed-length array at their own index rather than
+ * pushed.
+ *
+ * THE POST URN COMES BACK IN A HEADER, NOT THE BODY. A successful create is a
+ * 201 with an empty body and `x-restli-id` carrying the urn. Parsing the body
+ * for an id yields undefined and looks like a silent failure.
+ */
+
+const API = "https://api.linkedin.com/rest";
+
+/**
+ * LinkedIn versions its API by month and REQUIRES the header on every call.
+ *
+ * This is a live dependency, not a constant to set and forget: LinkedIn sunsets
+ * versions on a rolling schedule (the 202508 version was retired on
+ * 2026-08-17). If calls start failing with a version error, check the current
+ * supported range in LinkedIn's migration docs and move this forward - do not
+ * guess a newer month, because an unreleased version is rejected too.
+ */
+const LINKEDIN_VERSION = "202608";
+
+/** Documented part size for multipart video upload: `split -b 4194303`. */
+const PART_SIZE = 4 * 1024 * 1024;
+
+/** LinkedIn rejects a longer commentary with 400 FIELD_LENGTH_TOO_LONG. */
+const COMMENTARY_LIMIT = 3000;
+
+/** Documented video bounds: 75KB to 500MB, MP4, 3 seconds to 30 minutes. */
+const MIN_BYTES = 75 * 1024;
+const MAX_BYTES = 500 * 1024 * 1024;
+
+export interface LinkedInPublishInput {
+  accessToken: string;
+  /**
+   * `urn:li:person:{id}` for a member post, `urn:li:organization:{id}` for a
+   * company page. Passed in whole rather than assembled here - the old client
+   * defaulted a bare id to an ORGANISATION urn, which silently posts to the
+   * wrong place when a member id is handed to it.
+   */
+  authorUrn: string;
+  video: Buffer;
+  commentary: string;
+  /** Shown beside the video in the feed, not the post body. */
+  title: string;
+}
+
+export type LinkedInPublishResult =
+  | { ok: true; postUrn: string; videoUrn: string; url: string }
+  | { ok: false; error: string; stage: LinkedInStage };
+
+type LinkedInStage = "precheck" | "initialize" | "upload" | "finalize" | "post";
+
+function headers(accessToken: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${accessToken}`,
+    "X-Restli-Protocol-Version": "2.0.0",
+    "LinkedIn-Version": LINKEDIN_VERSION,
+    "Content-Type": "application/json",
+  };
+}
+
+interface UploadInstruction {
+  uploadUrl: string;
+  firstByte: number;
+  lastByte: number;
+}
+
+export async function publishToLinkedIn(
+  input: LinkedInPublishInput
+): Promise<LinkedInPublishResult> {
+  const { accessToken, authorUrn, video, commentary, title } = input;
+
+  /*
+   * CHECKED HERE RATHER THAN DISCOVERED AT UPLOAD. A file outside the
+   * documented range fails somewhere in the middle of a four-call sequence with
+   * an error that names neither the size nor the limit, after the bytes have
+   * already been pushed over the wire.
+   */
+  if (video.length < MIN_BYTES || video.length > MAX_BYTES) {
+    return {
+      ok: false,
+      stage: "precheck",
+      error: `video is ${Math.round(video.length / 1024)}KB, outside LinkedIn's 75KB-500MB range`,
+    };
+  }
+  if (!authorUrn.startsWith("urn:li:")) {
+    return { ok: false, stage: "precheck", error: `authorUrn is not a URN: ${authorUrn}` };
+  }
+
+  // 1. Initialize.
+  let videoUrn: string;
+  let uploadToken: string;
+  let instructions: UploadInstruction[];
+  try {
+    const res = await fetch(`${API}/videos?action=initializeUpload`, {
+      method: "POST",
+      headers: headers(accessToken),
+      body: JSON.stringify({
+        initializeUploadRequest: {
+          owner: authorUrn,
+          fileSizeBytes: video.length,
+          uploadCaptions: false,
+          uploadThumbnail: false,
+        },
+      }),
+      signal: AbortSignal.timeout(60000),
+    });
+    const body: any = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      return {
+        ok: false,
+        stage: "initialize",
+        error: `${res.status}: ${JSON.stringify(body).slice(0, 300)}`,
+      };
+    }
+    videoUrn = body?.value?.video;
+    uploadToken = body?.value?.uploadToken ?? "";
+    instructions = body?.value?.uploadInstructions ?? [];
+    if (!videoUrn || !instructions.length) {
+      return {
+        ok: false,
+        stage: "initialize",
+        error: `no video urn or upload instructions: ${JSON.stringify(body).slice(0, 300)}`,
+      };
+    }
+  } catch (e) {
+    return { ok: false, stage: "initialize", error: String((e as Error)?.message ?? e) };
+  }
+
+  /*
+   * 2. Upload each part, in order.
+   *
+   * The parts are uploaded SEQUENTIALLY. LinkedIn's byte ranges are 4MB and
+   * these Shorts are a handful of parts at most, so the wall-clock saving from
+   * parallelism is small - and the failure mode it introduces is not: a
+   * concurrent upload that half-succeeds leaves some ETags collected and others
+   * missing, with nothing to distinguish "not finished" from "will never
+   * finish".
+   */
+  const partIds: string[] = new Array(instructions.length);
+  for (let i = 0; i < instructions.length; i++) {
+    const part = instructions[i];
+    // lastByte is INCLUSIVE in LinkedIn's instructions; Buffer.subarray's end
+    // is exclusive. Off by one here truncates every part by a byte and the
+    // video finalizes into a corrupt file rather than an error.
+    const chunk = video.subarray(part.firstByte, part.lastByte + 1);
+    try {
+      const put = await fetch(part.uploadUrl, {
+        method: "PUT",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/octet-stream",
+        },
+        body: new Uint8Array(chunk),
+        signal: AbortSignal.timeout(180000),
+      });
+      if (!put.ok) {
+        return {
+          ok: false,
+          stage: "upload",
+          error: `part ${i + 1}/${instructions.length} HTTP ${put.status}: ${(await put.text()).slice(0, 200)}`,
+        };
+      }
+      const etag = put.headers.get("etag");
+      if (!etag) {
+        return {
+          ok: false,
+          stage: "upload",
+          error: `part ${i + 1} returned no ETag, so it cannot be finalized`,
+        };
+      }
+      // The docs show the ETag quoted in the response header and unquoted in
+      // the finalize payload.
+      partIds[i] = etag.replace(/^"|"$/g, "");
+    } catch (e) {
+      return {
+        ok: false,
+        stage: "upload",
+        error: `part ${i + 1}: ${String((e as Error)?.message ?? e)}`,
+      };
+    }
+  }
+
+  // 3. Finalize.
+  try {
+    const res = await fetch(`${API}/videos?action=finalizeUpload`, {
+      method: "POST",
+      headers: headers(accessToken),
+      body: JSON.stringify({
+        finalizeUploadRequest: { video: videoUrn, uploadToken, uploadedPartIds: partIds },
+      }),
+      signal: AbortSignal.timeout(60000),
+    });
+    if (!res.ok) {
+      return {
+        ok: false,
+        stage: "finalize",
+        error: `${res.status}: ${(await res.text()).slice(0, 300)}`,
+      };
+    }
+  } catch (e) {
+    return { ok: false, stage: "finalize", error: String((e as Error)?.message ?? e) };
+  }
+
+  /*
+   * 4. Create the post.
+   *
+   * NO POLLING FOR AVAILABLE. A finalized video sits in PROCESSING for a while,
+   * and the instinct is to wait for status AVAILABLE before posting. LinkedIn
+   * does not require it - the post is accepted against a processing video and
+   * renders when transcoding finishes - and polling would hold this slot open
+   * for minutes inside a cron that also has YouTube, Instagram and X to get
+   * through.
+   */
+  try {
+    const res = await fetch(`${API}/posts`, {
+      method: "POST",
+      headers: headers(accessToken),
+      body: JSON.stringify({
+        author: authorUrn,
+        commentary: commentary.slice(0, COMMENTARY_LIMIT),
+        visibility: "PUBLIC",
+        distribution: {
+          feedDistribution: "MAIN_FEED",
+          targetEntities: [],
+          thirdPartyDistributionChannels: [],
+        },
+        content: { media: { title: title.slice(0, 200), id: videoUrn } },
+        lifecycleState: "PUBLISHED",
+        isReshareDisabledByAuthor: false,
+      }),
+      signal: AbortSignal.timeout(60000),
+    });
+
+    if (!res.ok) {
+      return {
+        ok: false,
+        stage: "post",
+        error: `${res.status}: ${(await res.text()).slice(0, 300)}`,
+      };
+    }
+
+    const postUrn = res.headers.get("x-restli-id");
+    if (!postUrn) {
+      // The post very likely exists. Saying so matters: treating this as a
+      // plain failure invites a retry that posts the same video twice.
+      return {
+        ok: false,
+        stage: "post",
+        error: "post accepted but no x-restli-id header returned — check the feed before retrying",
+      };
+    }
+
+    return {
+      ok: true,
+      postUrn,
+      videoUrn,
+      url: `https://www.linkedin.com/feed/update/${postUrn}/`,
+    };
+  } catch (e) {
+    return { ok: false, stage: "post", error: String((e as Error)?.message ?? e) };
+  }
+}

--- a/lib/tiktok-publish.ts
+++ b/lib/tiktok-publish.ts
@@ -1,0 +1,169 @@
+/**
+ * Publishing to TikTok. WRITTEN BUT NOT YET USABLE — see the gate below.
+ *
+ * THIS CANNOT WORK UNTIL TWO THINGS HAPPEN, and both are outside the codebase:
+ *
+ *   1. The app must be granted the `video.publish` scope, and the connected
+ *      user must have authorised it. The tokens this project holds were minted
+ *      for user.info.basic / user.info.profile / user.info.stats / video.list —
+ *      read scopes only. Adding the scope means re-authorising; an existing
+ *      token does not gain it.
+ *   2. The app must pass TikTok's audit. Until it does, TikTok's own words are
+ *      "All content posted by unaudited clients will be restricted to private
+ *      viewing mode" — so a post would succeed and be invisible.
+ *
+ * That is why publisher_connections seeds tiktok with enabled = false. The code
+ * is here so that approval is a switch rather than a project.
+ *
+ * FILE_UPLOAD, NOT PULL_FROM_URL, and the reason is worth keeping. PULL_FROM_URL
+ * makes TikTok fetch the MP4 itself, which requires proving ownership of the URL
+ * prefix in the developer portal. Our videos are served from a Supabase storage
+ * domain we do not own and cannot verify. FILE_UPLOAD pushes the bytes and needs
+ * no verification at all.
+ *
+ * UNVERIFIED: the status-polling endpoint. The init and upload calls below are
+ * written from TikTok's direct-post reference. The reference page did not
+ * document a status endpoint, so `/v2/post/publish/status/fetch/` is an
+ * educated guess and is treated as best-effort — a failure to read status does
+ * NOT fail the publish. Confirm it against the docs when the app is approved,
+ * rather than trusting this comment.
+ */
+
+const API = "https://open.tiktokapis.com/v2";
+
+/** TikTok's documented title ceiling, in UTF-16 runes. */
+export const TIKTOK_TITLE_LIMIT = 2200;
+
+/**
+ * Chunk sizing, from TikTok's media transfer guide: each chunk at least 5MB and
+ * no more than 64MB, with the final chunk allowed to run over. A video under
+ * 5MB must go as a single chunk — which is what these vertical clips will be.
+ */
+const MIN_CHUNK = 5 * 1024 * 1024;
+const MAX_CHUNK = 64 * 1024 * 1024;
+
+export interface TikTokPublishInput {
+  accessToken: string;
+  video: Buffer;
+  title: string;
+  /**
+   * Defaults to SELF_ONLY, which is deliberate rather than cautious-by-habit:
+   * an unaudited client cannot post publicly anyway, so asking for
+   * PUBLIC_TO_EVERYONE before approval invites a refusal that reads like a bug.
+   */
+  privacyLevel?: "PUBLIC_TO_EVERYONE" | "MUTUAL_FOLLOW_FRIENDS" | "FOLLOWER_OF_CREATOR" | "SELF_ONLY";
+}
+
+export type TikTokPublishResult =
+  | { ok: true; publishId: string; status?: string }
+  | { ok: false; error: string; stage: "init" | "upload" };
+
+/** One chunk for anything small, otherwise even chunks inside the bounds. */
+function planChunks(size: number): { chunkSize: number; count: number } {
+  if (size <= MIN_CHUNK) return { chunkSize: size, count: 1 };
+  const chunkSize = Math.min(MAX_CHUNK, MIN_CHUNK);
+  // The last chunk absorbs the remainder rather than becoming a short chunk of
+  // its own, which TikTok rejects when it falls under the 5MB floor.
+  const count = Math.floor(size / chunkSize);
+  return { chunkSize, count };
+}
+
+export async function publishToTikTok(
+  input: TikTokPublishInput
+): Promise<TikTokPublishResult> {
+  const { accessToken, video, title, privacyLevel = "SELF_ONLY" } = input;
+  const { chunkSize, count } = planChunks(video.length);
+
+  // 1. Initialize.
+  let publishId: string;
+  let uploadUrl: string;
+  try {
+    const res = await fetch(`${API}/post/publish/video/init/`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json; charset=UTF-8",
+      },
+      body: JSON.stringify({
+        post_info: {
+          title: title.slice(0, TIKTOK_TITLE_LIMIT),
+          privacy_level: privacyLevel,
+          disable_duet: false,
+          disable_stitch: false,
+          disable_comment: false,
+        },
+        source_info: {
+          source: "FILE_UPLOAD",
+          video_size: video.length,
+          chunk_size: chunkSize,
+          total_chunk_count: count,
+        },
+      }),
+      signal: AbortSignal.timeout(60000),
+    });
+    const body: any = await res.json().catch(() => ({}));
+    publishId = body?.data?.publish_id;
+    uploadUrl = body?.data?.upload_url;
+    if (!res.ok || !publishId || !uploadUrl) {
+      return { ok: false, stage: "init", error: `${res.status}: ${JSON.stringify(body).slice(0, 300)}` };
+    }
+  } catch (e) {
+    return { ok: false, stage: "init", error: String((e as Error)?.message ?? e) };
+  }
+
+  // 2. Upload the chunks. Content-Range is required and its total is the whole
+  // file, not the chunk — getting that wrong is accepted at upload and fails
+  // later at assembly, which is much harder to diagnose.
+  for (let i = 0; i < count; i++) {
+    const first = i * chunkSize;
+    const last = i === count - 1 ? video.length - 1 : first + chunkSize - 1;
+    const chunk = video.subarray(first, last + 1);
+    try {
+      const put = await fetch(uploadUrl, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "video/mp4",
+          "Content-Length": String(chunk.length),
+          "Content-Range": `bytes ${first}-${last}/${video.length}`,
+        },
+        body: new Uint8Array(chunk),
+        signal: AbortSignal.timeout(180000),
+      });
+      if (!put.ok) {
+        return {
+          ok: false,
+          stage: "upload",
+          error: `chunk ${i + 1}/${count} HTTP ${put.status}: ${(await put.text()).slice(0, 200)}`,
+        };
+      }
+    } catch (e) {
+      return {
+        ok: false,
+        stage: "upload",
+        error: `chunk ${i + 1}/${count}: ${String((e as Error)?.message ?? e)}`,
+      };
+    }
+  }
+
+  // 3. Status, best-effort. The upload succeeded either way; an unreadable
+  // status is a reporting gap, not a failed post, and must not be turned into
+  // one.
+  let status: string | undefined;
+  try {
+    const res = await fetch(`${API}/post/publish/status/fetch/`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json; charset=UTF-8",
+      },
+      body: JSON.stringify({ publish_id: publishId }),
+      signal: AbortSignal.timeout(30000),
+    });
+    const body: any = await res.json().catch(() => ({}));
+    status = body?.data?.status;
+  } catch {
+    /* unverified endpoint — silence is expected here, not alarming */
+  }
+
+  return { ok: true, publishId, status };
+}

--- a/lib/x-publish.ts
+++ b/lib/x-publish.ts
@@ -1,0 +1,292 @@
+/**
+ * Publishing to X: chunked media upload, then a post.
+ *
+ * THE ENDPOINTS MOVED TO v2. The older code in
+ * supabase/functions/_shared/lib/providers/twitter.ts uploads to
+ * `https://upload.twitter.com/1.1/media/upload.json` in a single shot. X's
+ * current media documentation puts the whole chunked flow on
+ * `https://api.x.com/2/media/upload`, and a single-shot upload is not an option
+ * for video at all - INIT/APPEND/FINALIZE is the only documented path.
+ *
+ * FOUR STEPS, AND THE FOURTH IS NOT OPTIONAL FOR VIDEO:
+ *   1. INIT     - declares total_bytes and media_category, returns media_id
+ *   2. APPEND   - one call per chunk, each with its own segment_index
+ *   3. FINALIZE - returns processing_info when transcoding is still running
+ *   4. STATUS   - polled until state is 'succeeded'
+ *
+ * POSTING BEFORE PROCESSING FINISHES FAILS. Unlike LinkedIn, X will reject a
+ * post that references a media_id still being transcoded, so step 4 is a real
+ * dependency rather than a nicety. The response tells you how long to wait via
+ * check_after_secs; honouring it is better than a fixed interval because the
+ * value grows with the size of the file.
+ *
+ * THE REFRESH TOKEN ROTATES ON USE. X returns a NEW refresh token every time
+ * one is redeemed and invalidates the old one. Whatever calls this must persist
+ * the returned token immediately - dropping it means the next publish cannot
+ * authenticate and the connection has to be re-authorised by hand. That is why
+ * refreshXToken is exported separately rather than hidden inside the publish
+ * call: the caller owns the write.
+ */
+
+const API = "https://api.x.com/2";
+
+/** X counts a post in UTF-8-ish characters; anything longer is a 400. */
+export const X_TEXT_LIMIT = 280;
+
+/**
+ * 4MB chunks. X's documented ceiling per APPEND is 5MB; staying under it with a
+ * round number leaves room for the multipart envelope, which counts toward the
+ * request size and would otherwise make a 5MB chunk marginally too big.
+ */
+const CHUNK_SIZE = 4 * 1024 * 1024;
+
+export interface XPublishInput {
+  accessToken: string;
+  video: Buffer;
+  text: string;
+}
+
+export type XPublishResult =
+  | { ok: true; postId: string; url: string }
+  | { ok: false; error: string; stage: XStage };
+
+type XStage = "init" | "append" | "finalize" | "processing" | "post";
+
+/**
+ * Redeem a refresh token. Returns the NEW pair — persist both.
+ *
+ * Separate from publishing on purpose: the caller has the database handle and
+ * must write the rotated refresh token before the next publish, and burying
+ * that in the publish path makes it easy to lose on an error branch.
+ */
+export type XRefreshFailure = "not_configured" | "refused" | "transient";
+
+export async function refreshXToken(refreshToken: string): Promise<
+  | { ok: true; accessToken: string; refreshToken: string; expiresInSecs: number }
+  | { ok: false; error: string; reason: XRefreshFailure }
+> {
+  const clientId = process.env.TWITTER_CLIENT_ID;
+  const clientSecret = process.env.TWITTER_CLIENT_SECRET;
+  /*
+   * A MISSING CLIENT IS NOT A DEAD GRANT, and the difference decides what the
+   * caller does about it. Collapsing the two would let an unset environment
+   * variable mark a perfectly good connection 'revoked' - sending someone
+   * through a consent screen to re-authorise a token that was never the
+   * problem, and which would be marked revoked again on the next slot.
+   */
+  if (!clientId || !clientSecret) {
+    return {
+      ok: false,
+      reason: "not_configured",
+      error: "TWITTER_CLIENT_ID / TWITTER_CLIENT_SECRET are not set in this environment",
+    };
+  }
+
+  try {
+    const res = await fetch(`${API}/oauth2/token`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString("base64")}`,
+      },
+      body: new URLSearchParams({
+        client_id: clientId,
+        grant_type: "refresh_token",
+        refresh_token: refreshToken,
+      }).toString(),
+      signal: AbortSignal.timeout(30000),
+    });
+    const body: any = await res.json().catch(() => ({}));
+    if (!res.ok || !body?.access_token) {
+      /*
+       * Only a 4xx means X actually rejected the token. A 5xx or a rate limit
+       * is X having a bad minute and will very likely work at the next slot -
+       * treating it as a revoked grant would throw away a live connection over
+       * a transient blip.
+       */
+      const reason: XRefreshFailure =
+        res.status >= 400 && res.status < 500 && res.status !== 429 ? "refused" : "transient";
+      return { ok: false, reason, error: `${res.status}: ${JSON.stringify(body).slice(0, 300)}` };
+    }
+    return {
+      ok: true,
+      accessToken: body.access_token,
+      // If X ever omits it, keeping the old one is better than storing
+      // undefined and losing the connection outright.
+      refreshToken: body.refresh_token ?? refreshToken,
+      expiresInSecs: Number(body.expires_in ?? 7200),
+    };
+  } catch (e) {
+    // A thrown fetch is a network problem, never a verdict on the token.
+    return { ok: false, reason: "transient", error: String((e as Error)?.message ?? e) };
+  }
+}
+
+/**
+ * Trim to the post limit on a word boundary.
+ *
+ * Exported because it is the thing most worth testing: a caption one character
+ * over produces a 400 with no hint about which field, and every builder feeding
+ * this has to respect the same ceiling.
+ */
+export function fitToXLimit(text: string, limit: number = X_TEXT_LIMIT): string {
+  const clean = text.trim();
+  if (clean.length <= limit) return clean;
+  // One character is reserved for the ellipsis, so the result is always inside
+  // the limit rather than exactly on it.
+  const room = limit - 1;
+  const cut = clean.slice(0, room);
+  const lastSpace = cut.lastIndexOf(" ");
+  // Only break on a word if that does not throw away most of the text - a long
+  // unbroken string (a URL) has no space and should be cut where it lands.
+  const body = lastSpace > room * 0.6 ? cut.slice(0, lastSpace) : cut;
+  return `${body.trimEnd()}…`;
+}
+
+async function mediaCommand(
+  accessToken: string,
+  form: FormData,
+  timeoutMs = 120000
+): Promise<{ status: number; body: any }> {
+  const res = await fetch(`${API}/media/upload`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${accessToken}` },
+    body: form,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  return { status: res.status, body: await res.json().catch(() => ({})) };
+}
+
+export async function publishToX(input: XPublishInput): Promise<XPublishResult> {
+  const { accessToken, video, text } = input;
+
+  // 1. INIT
+  let mediaId: string;
+  {
+    const form = new FormData();
+    form.append("command", "INIT");
+    form.append("media_type", "video/mp4");
+    form.append("total_bytes", String(video.length));
+    // Without tweet_video X treats the upload as an image and FINALIZE rejects
+    // an MP4 with an error that does not mention the category.
+    form.append("media_category", "tweet_video");
+
+    try {
+      const { status, body } = await mediaCommand(accessToken, form, 30000);
+      // The v2 response nests under data; older shapes returned it flat, and
+      // reading only one of the two turns a success into "no media id".
+      mediaId = body?.data?.id ?? body?.media_id_string ?? body?.id;
+      if (status >= 400 || !mediaId) {
+        return { ok: false, stage: "init", error: `${status}: ${JSON.stringify(body).slice(0, 300)}` };
+      }
+    } catch (e) {
+      return { ok: false, stage: "init", error: String((e as Error)?.message ?? e) };
+    }
+  }
+
+  // 2. APPEND — sequential, because segment_index must be contiguous.
+  const chunks = Math.ceil(video.length / CHUNK_SIZE);
+  for (let i = 0; i < chunks; i++) {
+    const slice = video.subarray(i * CHUNK_SIZE, Math.min((i + 1) * CHUNK_SIZE, video.length));
+    const form = new FormData();
+    form.append("command", "APPEND");
+    form.append("media_id", mediaId);
+    form.append("segment_index", String(i));
+    form.append("media", new Blob([new Uint8Array(slice)], { type: "application/octet-stream" }));
+
+    try {
+      const { status, body } = await mediaCommand(accessToken, form);
+      // APPEND answers 204 with no body on success, so an empty parse is
+      // expected here rather than a problem.
+      if (status >= 400) {
+        return {
+          ok: false,
+          stage: "append",
+          error: `chunk ${i + 1}/${chunks} ${status}: ${JSON.stringify(body).slice(0, 200)}`,
+        };
+      }
+    } catch (e) {
+      return {
+        ok: false,
+        stage: "append",
+        error: `chunk ${i + 1}/${chunks}: ${String((e as Error)?.message ?? e)}`,
+      };
+    }
+  }
+
+  // 3. FINALIZE
+  let processing: any;
+  {
+    const form = new FormData();
+    form.append("command", "FINALIZE");
+    form.append("media_id", mediaId);
+    try {
+      const { status, body } = await mediaCommand(accessToken, form, 60000);
+      if (status >= 400) {
+        return { ok: false, stage: "finalize", error: `${status}: ${JSON.stringify(body).slice(0, 300)}` };
+      }
+      processing = body?.data?.processing_info ?? body?.processing_info;
+    } catch (e) {
+      return { ok: false, stage: "finalize", error: String((e as Error)?.message ?? e) };
+    }
+  }
+
+  /*
+   * 4. STATUS — only when FINALIZE said transcoding is still running.
+   *
+   * Bounded at roughly five minutes. These are sub-minute vertical clips; a
+   * file still pending after that is stuck, and an unbounded loop inside a cron
+   * slot is how one bad upload eats the whole invocation.
+   */
+  if (processing && processing.state !== "succeeded") {
+    const deadline = Date.now() + 5 * 60 * 1000;
+    let waitSecs = Number(processing.check_after_secs ?? 5);
+
+    while (Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, Math.max(1, waitSecs) * 1000));
+      try {
+        const res = await fetch(
+          `${API}/media/upload?command=STATUS&media_id=${encodeURIComponent(mediaId)}`,
+          { headers: { Authorization: `Bearer ${accessToken}` }, signal: AbortSignal.timeout(30000) }
+        );
+        const body: any = await res.json().catch(() => ({}));
+        const info = body?.data?.processing_info ?? body?.processing_info;
+        const state = info?.state;
+
+        if (state === "succeeded") { processing = info; break; }
+        if (state === "failed") {
+          return {
+            ok: false,
+            stage: "processing",
+            error: `transcode failed: ${JSON.stringify(info?.error ?? info).slice(0, 250)}`,
+          };
+        }
+        waitSecs = Number(info?.check_after_secs ?? waitSecs);
+      } catch {
+        /* a transient read is not a verdict — keep polling until the deadline */
+      }
+    }
+
+    if (processing?.state !== "succeeded") {
+      return { ok: false, stage: "processing", error: "media never finished processing within 5 minutes" };
+    }
+  }
+
+  // 5. The post itself.
+  try {
+    const res = await fetch(`${API}/tweets`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ text: fitToXLimit(text), media: { media_ids: [mediaId] } }),
+      signal: AbortSignal.timeout(60000),
+    });
+    const body: any = await res.json().catch(() => ({}));
+    const postId = body?.data?.id;
+    if (!res.ok || !postId) {
+      return { ok: false, stage: "post", error: `${res.status}: ${JSON.stringify(body).slice(0, 300)}` };
+    }
+    return { ok: true, postId, url: `https://x.com/i/web/status/${postId}` };
+  } catch (e) {
+    return { ok: false, stage: "post", error: String((e as Error)?.message ?? e) };
+  }
+}

--- a/scripts/publisher_connect.js
+++ b/scripts/publisher_connect.js
@@ -1,0 +1,469 @@
+/**
+ * One-time interactive connect for the content publisher's destinations.
+ *
+ *   node scripts/publisher_connect.js linkedin
+ *   node scripts/publisher_connect.js x
+ *   node scripts/publisher_connect.js gbp
+ *   node scripts/publisher_connect.js tiktok
+ *   node scripts/publisher_connect.js status
+ *
+ * WHY A SCRIPT AND NOT OAUTH ROUTES. These are FIRST-PARTY MACHINE CREDENTIALS,
+ * the same category as YOUTUBE_REFRESH_TOKEN: one account per platform, ours,
+ * authorised once by a person at a keyboard. They are not a customer consent
+ * surface, so the app does not need to host a consent flow, a callback route or
+ * a state store for them — that would be more code and more attack surface for
+ * a button pressed roughly once a year. lib/google-internal-oauth.ts makes the
+ * same argument for Search Console and Ads, and scripts/gsc_oauth_setup.js is
+ * the pattern this follows.
+ *
+ * THE TOKENS LAND IN publisher_connections, NOT .env. Two of these rotate: X
+ * issues a new refresh token on every use, and its access token lasts about two
+ * hours. A value that changes three times a day cannot live in an environment
+ * variable — the cron has to be able to write it back.
+ *
+ * REDIRECT URIS MUST MATCH WHAT IS REGISTERED. Each platform's developer portal
+ * holds a fixed list, and the value sent here has to be one of them, character
+ * for character. The existing scripts/get-linkedin-tokens.js and
+ * scripts/get-tiktok-tokens.js still point at agency.innergcomplete.com, which
+ * this project migrated away from — so do not copy a redirect URI from them
+ * without checking the portal first. Override with REDIRECT_URI=... if needed.
+ */
+
+require("dotenv").config({ path: ".env.local" });
+const readline = require("readline");
+const crypto = require("crypto");
+const { internalEnv } = require("./_google_internal_oauth");
+
+const SITE = process.env.REDIRECT_BASE || "https://shearquery.com";
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+function ask(question) {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => rl.question(question, (a) => { rl.close(); resolve(a.trim()); }));
+}
+
+/**
+ * Pull the authorization code out of whatever got pasted.
+ *
+ * WHY THIS EXISTS. The first version told the operator to "copy everything
+ * after code= up to the next &" and then sent the result verbatim. Paste one
+ * character too many - the trailing `&state=...`, which sits immediately after
+ * the code in every one of these redirects - and the provider answers
+ * "authorization code not found", which reads like an expired or rejected code
+ * rather than a copy-paste artefact. That cost a round trip through a consent
+ * screen to diagnose.
+ *
+ * Asking a person to do string surgery on a 300-character token and then
+ * trusting the result was the mistake. This accepts any of:
+ *   - the bare code
+ *   - code&state=...
+ *   - the whole redirect URL
+ *   - ?code=...&state=... 
+ */
+function extractCode(pasted) {
+  let raw = (pasted || "").trim().replace(/^["']|["']$/g, "");
+
+  // A full URL, or any query string: read the code parameter properly rather
+  // than slicing, so an encoded value survives.
+  if (raw.includes("code=")) {
+    try {
+      const qs = raw.slice(raw.indexOf("code="));
+      const params = new URLSearchParams(qs);
+      const fromParams = params.get("code");
+      if (fromParams) return fromParams.trim();
+    } catch { /* fall through to the cruder cut below */ }
+  }
+
+  // Bare code that still carries a trailing &state= or #fragment.
+  raw = raw.split("&")[0].split("#")[0];
+  return raw.trim();
+}
+
+async function saveConnection(platform, patch) {
+  if (!SUPABASE_URL || !SERVICE_KEY) {
+    console.error("\nMissing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY in .env.local.");
+    console.error("The tokens above are valid — rerun once those are set, or paste them in by hand.");
+    process.exit(1);
+  }
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/publisher_connections?platform=eq.${platform}`, {
+    method: "PATCH",
+    headers: {
+      apikey: SERVICE_KEY,
+      Authorization: `Bearer ${SERVICE_KEY}`,
+      "Content-Type": "application/json",
+      Prefer: "return=representation",
+    },
+    body: JSON.stringify({ ...patch, status: "connected", connected_at: new Date().toISOString(), updated_at: new Date().toISOString(), last_error: null }),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok || !Array.isArray(body) || body.length === 0) {
+    console.error(`\nCould not save the connection: ${res.status} ${JSON.stringify(body).slice(0, 300)}`);
+    console.error("Has migration 20260820090000_publisher_fanout.sql been applied?");
+    process.exit(1);
+  }
+  console.log(`\n✓ ${platform} saved to publisher_connections (${body[0].account_label || "no label"}).`);
+  if (!body[0].enabled) {
+    console.log(`  NOTE: ${platform} is stored but NOT ENABLED, so the cron will skip it.`);
+  }
+}
+
+/* ------------------------------------------------------------------ LinkedIn */
+
+async function connectLinkedIn() {
+  const clientId = process.env.LINKEDIN_CLIENT_ID;
+  const clientSecret = process.env.LINKEDIN_CLIENT_SECRET;
+  if (!clientId || !clientSecret) throw new Error("LINKEDIN_CLIENT_ID / _SECRET missing");
+
+  const redirectUri = process.env.REDIRECT_URI || `${SITE}/linkedin/callback`;
+  // Posting as the member needs w_member_social; openid+profile is how we learn
+  // WHICH member, which becomes the author URN. Asking for the organisation
+  // scopes here would be requesting more than this connection uses.
+  const scopes = "openid profile w_member_social";
+
+  const authUrl = new URL("https://www.linkedin.com/oauth/v2/authorization");
+  authUrl.searchParams.set("response_type", "code");
+  authUrl.searchParams.set("client_id", clientId);
+  authUrl.searchParams.set("redirect_uri", redirectUri);
+  authUrl.searchParams.set("scope", scopes);
+  authUrl.searchParams.set("state", crypto.randomBytes(8).toString("hex"));
+
+  console.log(`\nRedirect URI in use: ${redirectUri}`);
+  console.log("  ^ this EXACT string must be in the LinkedIn app's Auth tab -> Authorized redirect URLs.");
+  console.log("\n1. Open this and approve as the LinkedIn account that should author the posts:\n");
+  console.log(authUrl.toString());
+  console.log(`\n2. You will land on ${redirectUri}?code=...  — copy everything after code= up to the next &\n`);
+
+  const code = extractCode(await ask("Paste the code (the whole redirected URL is fine): "));
+
+  const tokenRes = await fetch("https://www.linkedin.com/oauth/v2/accessToken", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: redirectUri,
+      client_id: clientId,
+      client_secret: clientSecret,
+    }),
+  });
+  const token = await tokenRes.json();
+  if (!token.access_token) throw new Error(`token exchange failed: ${JSON.stringify(token)}`);
+
+  // The author URN comes from the OIDC subject. Guessing it from a profile id
+  // is how a member post ends up addressed to an organisation URN and refused.
+  const meRes = await fetch("https://api.linkedin.com/v2/userinfo", {
+    headers: { Authorization: `Bearer ${token.access_token}` },
+  });
+  const me = await meRes.json();
+  if (!me.sub) throw new Error(`could not read userinfo: ${JSON.stringify(me)}`);
+
+  await saveConnection("linkedin", {
+    access_token: token.access_token,
+    refresh_token: token.refresh_token || null,
+    expires_at: new Date(Date.now() + Number(token.expires_in || 5184000) * 1000).toISOString(),
+    account_label: `${me.name || me.email || me.sub} (member)`,
+    config: { authorUrn: `urn:li:person:${me.sub}` },
+  });
+
+  console.log(`\nLinkedIn access tokens last about 60 days. Rerun this before ${new Date(Date.now() + Number(token.expires_in || 5184000) * 1000).toDateString()}.`);
+}
+
+/* ------------------------------------------------------------------------- X */
+
+async function connectX() {
+  const clientId = process.env.TWITTER_CLIENT_ID;
+  const clientSecret = process.env.TWITTER_CLIENT_SECRET;
+  if (!clientId || !clientSecret) throw new Error("TWITTER_CLIENT_ID / _SECRET missing");
+
+  const redirectUri = process.env.REDIRECT_URI || `${SITE}/x/callback`;
+  /*
+   * offline.access is what yields a refresh token; without it the connection
+   * dies in two hours and there is nothing to renew it with.
+   *
+   * media.write is documented as a valid scope ("Upload media") but is NOT what
+   * the previous connection here requested - components/social/twitter-login-button.tsx
+   * asks for the other four and nothing else. If the authorize screen refuses
+   * the whole request, drop it and find out whether the scope or the callback
+   * URL is the problem:
+   *
+   *   X_SCOPES="tweet.read tweet.write users.read offline.access" node scripts/publisher_connect.js x
+   *
+   * A connection without media.write can still post text; the chunked upload in
+   * lib/x-publish.ts is what would fail.
+   */
+  const scopes = process.env.X_SCOPES || "tweet.read tweet.write users.read media.write offline.access";
+
+  const verifier = crypto.randomBytes(48).toString("base64url");
+  const challenge = crypto.createHash("sha256").update(verifier).digest("base64url");
+
+  const authUrl = new URL("https://x.com/i/oauth2/authorize");
+  authUrl.searchParams.set("response_type", "code");
+  authUrl.searchParams.set("client_id", clientId);
+  authUrl.searchParams.set("redirect_uri", redirectUri);
+  authUrl.searchParams.set("scope", scopes);
+  authUrl.searchParams.set("state", crypto.randomBytes(8).toString("hex"));
+  authUrl.searchParams.set("code_challenge", challenge);
+  authUrl.searchParams.set("code_challenge_method", "S256");
+
+  console.log(`\nRedirect URI in use: ${redirectUri}`);
+  console.log("  ^ this EXACT string must be in the X app's \"Callback URI / Redirect URL\" list.");
+  console.log(`  Scopes: ${scopes}`);
+  console.log("\n1. Open this and approve as the X account that should post:\n");
+  console.log(authUrl.toString());
+  console.log(`\n2. You will land on ${redirectUri}?code=... — copy everything after code= up to the next &\n`);
+
+  const code = extractCode(await ask("Paste the code (the whole redirected URL is fine): "));
+
+  const tokenRes = await fetch("https://api.x.com/2/oauth2/token", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString("base64")}`,
+    },
+    body: new URLSearchParams({
+      grant_type: "authorization_code",
+      code,
+      redirect_uri: redirectUri,
+      client_id: clientId,
+      code_verifier: verifier,
+    }),
+  });
+  const token = await tokenRes.json();
+  if (!token.access_token) throw new Error(`token exchange failed: ${JSON.stringify(token)}`);
+  if (!token.refresh_token) {
+    throw new Error("X returned no refresh token — offline.access was not granted, so this connection would die in two hours");
+  }
+
+  const meRes = await fetch("https://api.x.com/2/users/me", {
+    headers: { Authorization: `Bearer ${token.access_token}` },
+  });
+  const me = await meRes.json().catch(() => ({}));
+
+  await saveConnection("x", {
+    access_token: token.access_token,
+    refresh_token: token.refresh_token,
+    expires_at: new Date(Date.now() + Number(token.expires_in || 7200) * 1000).toISOString(),
+    account_label: me?.data?.username ? `@${me.data.username}` : "X account",
+    config: { userId: me?.data?.id || null },
+  });
+}
+
+/* ----------------------------------------------------------------------- GBP */
+
+async function connectGbp() {
+  const clientId = internalEnv().GOOGLE_CLIENT_ID;
+  const clientSecret = internalEnv().GOOGLE_CLIENT_SECRET;
+  if (!clientId || !clientSecret) throw new Error("No internal Google OAuth client configured");
+
+  // Same already-registered redirect the other internal scripts use. The page
+  // does not need to exist; only the address bar matters.
+  const redirectUri = process.env.REDIRECT_URI || "http://localhost:3000/youtube/callback";
+
+  const authUrl = new URL("https://accounts.google.com/o/oauth2/v2/auth");
+  authUrl.searchParams.set("client_id", clientId);
+  authUrl.searchParams.set("redirect_uri", redirectUri);
+  authUrl.searchParams.set("response_type", "code");
+  authUrl.searchParams.set("scope", "https://www.googleapis.com/auth/business.manage");
+  authUrl.searchParams.set("access_type", "offline");
+  // Without prompt=consent a re-authorisation returns no refresh token, and the
+  // connection silently becomes unrenewable.
+  authUrl.searchParams.set("prompt", "consent");
+
+  console.log("\n1. Open this and approve as the Google account that owns the ShearQuery Business Profile:\n");
+  console.log(authUrl.toString());
+  console.log(`\n2. The browser lands on ${redirectUri} and probably shows an error page. That is fine —`);
+  console.log("   read the address bar and copy everything after code= up to the next &\n");
+
+  const code = extractCode(await ask("Paste the code (the whole redirected URL is fine): "));
+
+  const tokenRes = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_id: clientId, client_secret: clientSecret, code,
+      grant_type: "authorization_code", redirect_uri: redirectUri,
+    }),
+  });
+  const token = await tokenRes.json();
+  if (!token.refresh_token) {
+    throw new Error(`no refresh token returned: ${JSON.stringify(token)} — revoke the app at myaccount.google.com/permissions and retry`);
+  }
+
+  // The account list is the entry point: a Business Profile location always
+  // hangs off an account, and there is no way to query locations without one.
+  const accRes = await fetch("https://mybusinessaccountmanagement.googleapis.com/v1/accounts", {
+    headers: { Authorization: `Bearer ${token.access_token}` },
+  });
+  const accPayload = await accRes.json().catch(() => ({}));
+  if (!accRes.ok) {
+    throw new Error(
+      `could not list Business Profile accounts: ${accRes.status} ${JSON.stringify(accPayload).slice(0, 300)}\n` +
+      "  A 403 here usually means the Business Profile APIs are not enabled on this Google Cloud project."
+    );
+  }
+  const accounts = accPayload.accounts || [];
+  if (!accounts.length) {
+    throw new Error(
+      "this Google login manages no Business Profile accounts at all.\n" +
+      "  Check which account owns the listing at business.google.com, then rerun and approve as that one."
+    );
+  }
+
+  /*
+   * EVERY ACCOUNT, NOT JUST THE FIRST.
+   *
+   * This originally read accounts[0] and listed only that account's locations,
+   * which is wrong in the common case: a Google login usually carries a
+   * PERSONAL account AND any LOCATION_GROUP or ORGANIZATION accounts the
+   * business is managed under. A brand managed through a location group is
+   * invisible to accounts[0], so the listing you are looking for simply never
+   * appears in the picker and the flow looks like the business does not exist.
+   *
+   * Every account is listed with its type, so if the one you want still is not
+   * here the answer is visible rather than inferred: either this Google login
+   * has no access to it, or it is not a verified Business Profile.
+   */
+  const accountList = accounts.map((a) => `${a.name}  ${a.accountName || "unnamed"}  [${a.type || "?"}]`);
+  console.log(`\nBusiness Profile accounts on this Google login (${accounts.length}):`);
+  accountList.forEach((a) => console.log(`  ${a}`));
+
+  const choices = [];
+  for (const account of accounts) {
+    const locRes = await fetch(
+      `https://mybusinessbusinessinformation.googleapis.com/v1/${account.name}/locations?readMask=name,title,storefrontAddress&pageSize=100`,
+      { headers: { Authorization: `Bearer ${token.access_token}` } }
+    );
+    const payload = await locRes.json().catch(() => ({}));
+    if (!locRes.ok) {
+      // One account refusing must not hide the others - a location group can
+      // 403 while the personal account lists fine.
+      console.log(`  (could not read locations for ${account.name}: ${locRes.status} ${JSON.stringify(payload).slice(0, 120)})`);
+      continue;
+    }
+    for (const loc of payload.locations || []) {
+      choices.push({
+        accountName: account.name,
+        accountLabel: account.accountName || account.name,
+        locationName: loc.name,
+        title: loc.title,
+        city: loc.storefrontAddress?.locality || "",
+      });
+    }
+  }
+
+  if (!choices.length) {
+    throw new Error(
+      "no locations found on ANY account for this Google login.\n" +
+      "  Either this login does not manage the listing, or the listing is not a verified Business Profile.\n" +
+      "  Check which Google account owns it at business.google.com, then rerun and approve as that account."
+    );
+  }
+
+  console.log("\nLocations you can post to:");
+  choices.forEach((c, i) =>
+    console.log(`  ${i + 1}. ${c.title}${c.city ? ` — ${c.city}` : ""}   [${c.accountLabel}]`)
+  );
+
+  const pick = Number(await ask("\nWhich number should the publisher post to? ")) - 1;
+  const chosen = choices[pick];
+  if (!chosen) throw new Error("no location chosen");
+
+  await saveConnection("gbp", {
+    refresh_token: token.refresh_token,
+    access_token: null,
+    expires_at: null,
+    account_label: chosen.title,
+    config: { accountName: chosen.accountName, locationName: chosen.locationName },
+  });
+}
+
+/* -------------------------------------------------------------------- TikTok */
+
+async function connectTikTok() {
+  const clientKey = process.env.TIKTOK_PRODUCTION_CLIENT_KEY;
+  const clientSecret = process.env.TIKTOK_PRODUCTION_CLIENT_SECRET;
+  if (!clientKey || !clientSecret) throw new Error("TIKTOK_PRODUCTION_CLIENT_KEY / _SECRET missing");
+
+  const redirectUri = process.env.REDIRECT_URI || `${SITE}/tiktok/callback`;
+  // video.publish is the whole point of this connection and the app must be
+  // APPROVED for it first — an unapproved scope is simply dropped from the
+  // grant, and the failure only shows up at publish time.
+  const scopes = "user.info.basic,video.publish";
+
+  const authUrl = new URL("https://www.tiktok.com/v2/auth/authorize/");
+  authUrl.searchParams.set("client_key", clientKey);
+  authUrl.searchParams.set("scope", scopes);
+  authUrl.searchParams.set("response_type", "code");
+  authUrl.searchParams.set("redirect_uri", redirectUri);
+  authUrl.searchParams.set("state", crypto.randomBytes(8).toString("hex"));
+
+  console.log(`\nRedirect URI in use: ${redirectUri}`);
+  console.log("  ^ this EXACT string must be registered in the TikTok app's redirect URI list.");
+  console.log("\n1. Open this and approve as the TikTok account that should post:\n");
+  console.log(authUrl.toString());
+  console.log(`\n2. You will land on ${redirectUri}?code=... — copy everything after code= up to the next &\n`);
+
+  const code = extractCode(await ask("Paste the code (the whole redirected URL is fine): "));
+
+  const tokenRes = await fetch("https://open.tiktokapis.com/v2/oauth/token/", {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      client_key: clientKey, client_secret: clientSecret, code,
+      grant_type: "authorization_code", redirect_uri: redirectUri,
+    }),
+  });
+  const token = await tokenRes.json();
+  if (!token.access_token) throw new Error(`token exchange failed: ${JSON.stringify(token)}`);
+
+  const granted = String(token.scope || "");
+  if (!granted.includes("video.publish")) {
+    console.warn("\n⚠ video.publish was NOT granted. The app is not approved for it yet.");
+    console.warn("  Saving the connection anyway, but leave tiktok disabled until it is.");
+  }
+
+  await saveConnection("tiktok", {
+    access_token: token.access_token,
+    refresh_token: token.refresh_token || null,
+    expires_at: new Date(Date.now() + Number(token.expires_in || 86400) * 1000).toISOString(),
+    account_label: token.open_id ? `open_id ${String(token.open_id).slice(0, 12)}…` : "TikTok account",
+    config: { openId: token.open_id || null, privacyLevel: "SELF_ONLY" },
+  });
+}
+
+/* -------------------------------------------------------------------- status */
+
+async function showStatus() {
+  const res = await fetch(`${SUPABASE_URL}/rest/v1/publisher_connections?select=*`, {
+    headers: { apikey: SERVICE_KEY, Authorization: `Bearer ${SERVICE_KEY}` },
+  });
+  const rows = await res.json();
+  if (!Array.isArray(rows)) return console.error(rows);
+  console.log("\nplatform   enabled  status        account");
+  console.log("-".repeat(64));
+  for (const r of rows) {
+    console.log(
+      `${r.platform.padEnd(10)} ${String(r.enabled).padEnd(8)} ${String(r.status).padEnd(13)} ${r.account_label || "—"}${r.last_error ? `\n           last error: ${r.last_error}` : ""}`
+    );
+  }
+  console.log("");
+}
+
+const HANDLERS = { linkedin: connectLinkedIn, x: connectX, gbp: connectGbp, tiktok: connectTikTok, status: showStatus };
+
+(async () => {
+  const platform = (process.argv[2] || "").toLowerCase();
+  const handler = HANDLERS[platform];
+  if (!handler) {
+    console.log(`Usage: node scripts/publisher_connect.js <${Object.keys(HANDLERS).join("|")}>`);
+    process.exit(1);
+  }
+  try {
+    await handler();
+  } catch (e) {
+    console.error(`\n✗ ${e.message}`);
+    process.exit(1);
+  }
+})();

--- a/supabase/functions/publish-social-post/index.ts
+++ b/supabase/functions/publish-social-post/index.ts
@@ -8,10 +8,13 @@
  */
 
 import { createHandler, z, Logger, okResponse } from "../_shared/lib/index.ts"
-import { LinkedInClient } from "../connector-sync/providers/linkedin/client.ts"
-import { MetaClient } from "../connector-sync/providers/meta/client.ts"
-import { TwitterProvider } from "../_shared/lib/providers/twitter.ts"
 import { GhlProvider } from "../_shared/lib/providers/ghl.ts"
+
+/**
+ * Platforms this function no longer publishes to — see the branch below.
+ * GHL stays, because nothing has replaced it.
+ */
+const RETIRED_PLATFORMS = new Set(["linkedin", "x", "twitter", "facebook", "instagram"])
 
 const PublishSchema = z.object({
     draft_id: z.string().uuid(),
@@ -95,148 +98,38 @@ export default createHandler(async ({ adminClient, body, user }) => {
                 continue
             }
 
-            // If multiple connections, intelligently select. 
-            // For LinkedIn, prefer organization/page over individual if available.
-            let connection = connections[0]
-            if (platform.toLowerCase() === "linkedin" && connections.length > 1) {
-                const pageConn = connections.find((c: any) => (c.sync_config as any).page_id || c.label.toLowerCase().includes("page") || c.label.toLowerCase().includes("agency"))
-                if (pageConn) connection = pageConn
-            }
+            const connection = connections[0]
 
             logger.info(`Found ${connections.length} connections for ${platform}. Selected: ${connection.label} (${connection.id})`)
 
             const config = connection.sync_config as any
             const pLower = platform.toLowerCase()
 
-            if (pLower === "linkedin") {
-                const client = new LinkedInClient(config.access_token)
-                let authorUrn = ""
-                
-                if (config.page_id) {
-                    authorUrn = config.page_id.startsWith('urn:li:') ? config.page_id : `urn:li:organization:${config.page_id}`
-                } else if (config.person_id) {
-                    authorUrn = config.person_id.startsWith('urn:li:') ? config.person_id : `urn:li:person:${config.person_id}`
+            /*
+             * RETIRED: linkedin, x/twitter, facebook and instagram.
+             *
+             * These four now publish from the content publisher line
+             * (app/api/cron/publish-content) against publisher_connections,
+             * not from here against client_db_connections. Two systems that can
+             * both post to the same account is how the same video goes out
+             * twice, and how a token refreshed by one is invalidated under the
+             * other — X in particular rotates its refresh token on every use,
+             * so two writers race and whichever loses leaves a dead connection.
+             *
+             * REFUSED, NOT SILENTLY DROPPED. Returning success for a platform
+             * nothing was sent to is worse than an error: the draft would be
+             * marked published and nobody would look again.
+             *
+             * The publishing code that used to live here is not lost — it was
+             * ported to lib/linkedin-publish.ts and lib/x-publish.ts, both of
+             * which target the current APIs rather than the deprecated ones
+             * this used (LinkedIn's Assets/ugcPosts, X's v1.1 media upload).
+             */
+            if (RETIRED_PLATFORMS.has(pLower)) {
+                results[platform] = {
+                    success: false,
+                    error: `${platform} is published from the content publisher now, not from here. Queue it at /admin/content-publisher.`,
                 }
-                
-                if (!authorUrn) throw new Error("LinkedIn connection is missing author ID")
-
-                let mediaAsset = undefined
-                if (draft.media_url) {
-                    const isVideo = draft.media_url.includes(".mp4") || draft.media_url.includes(".mov")
-                    const mediaRes = await fetch(draft.media_url)
-                    if (mediaRes.ok) {
-                        const blob = await mediaRes.blob()
-                        if (isVideo) {
-                            mediaAsset = await client.uploadVideo(authorUrn, blob, blob.type || "video/mp4")
-                        } else {
-                            mediaAsset = await client.uploadImage(authorUrn, blob, blob.type || "image/png")
-                        }
-                    }
-                }
-                
-                const postResult = await client.createPost(authorUrn, draft.content_text, mediaAsset)
-                logger.info(`Successfully published to LinkedIn`, { post_id: postResult.id })
-                results[platform] = { success: true, post_id: postResult.id }
-                lastExternalPostId = postResult.id
-            } 
-            else if (pLower === "instagram") {
-                if (!draft.media_url) {
-                    throw new Error("Instagram requires an image or video for posting.")
-                }
-                
-                const igUserId = config.instagram_business_account_id || config.page_id
-                if (!igUserId) throw new Error("Missing IG Business Account ID")
-                
-                const metaClient = new MetaClient(config.access_token)
-                const isVideo = draft.media_url.includes(".mp4") || draft.media_url.includes(".mov")
-
-                let postResult
-                if (isVideo) {
-                    postResult = await metaClient.createInstagramVideoPost(igUserId, draft.content_text, draft.media_url)
-                } else {
-                    postResult = await metaClient.createInstagramPost(igUserId, draft.content_text, draft.media_url)
-                }
-                
-                logger.info(`Successfully published to Instagram`, { post_id: postResult.id })
-                results[platform] = { success: true, post_id: postResult.id }
-                lastExternalPostId = postResult.id
-            }
-            else if (pLower === "twitter" || pLower === "x") {
-                const client = new TwitterProvider()
-                let token = config.access_token
-                let postResult
-                let mediaId: string | undefined = undefined
-
-                const performXPublish = async (currentReqToken: string) => {
-                    // Stage Media if present
-                    if (draft.media_url) {
-                        try {
-                            const mediaRes = await fetch(draft.media_url)
-                            if (mediaRes.ok) {
-                                const blob = await mediaRes.blob()
-                                logger.info(`Staging media for X...`, { type: blob.type, size: blob.size })
-                                mediaId = await client.uploadMedia(currentReqToken, blob)
-                            }
-                        } catch (mediaErr: any) {
-                            logger.warn(`X Media staging failed, attempting text-only fallback: ${mediaErr.message}`)
-                        }
-                    }
-                    return await client.createTweet(currentReqToken, draft.content_text, mediaId)
-                }
-                
-                try {
-                    postResult = await performXPublish(token)
-                } catch (err: any) {
-                    const isAuthError = err.message.toLowerCase().includes("unauthorized") || 
-                                       err.message.includes("401") || 
-                                       err.message.toLowerCase().includes("forbidden") || 
-                                       err.message.includes("403") || 
-                                       err.message.toLowerCase().includes("not permitted")
-                    
-                    if (isAuthError && config.refresh_token) {
-                        logger.info(`Twitter token issue identified. Attempting forced refresh...`)
-                        const refreshData = await client.refreshToken(config.refresh_token)
-                        if (refreshData.access_token) {
-                            token = refreshData.access_token
-                            // Update the connection config
-                            const { error: updateErr } = await adminClient
-                                .from("client_db_connections")
-                                .update({ 
-                                    sync_config: { 
-                                        ...config, 
-                                        access_token: token,
-                                        refresh_token: refreshData.refresh_token || config.refresh_token
-                                    } 
-                                })
-                                .eq("id", connection.id)
-                            
-                            if (!updateErr) {
-                                logger.info(`Token refreshed. Retrying publish...`)
-                                postResult = await performXPublish(token)
-                            } else {
-                                throw new Error(`Refresh succeeded but failed to update DB: ${updateErr.message}`)
-                            }
-                        } else {
-                            throw err
-                        }
-                    } else {
-                        throw err
-                    }
-                }
-
-                logger.info(`Successfully published to X (Twitter)`, { post_id: postResult.id, has_media: !!mediaId })
-                results[platform] = { success: true, post_id: postResult.id }
-                lastExternalPostId = postResult.id
-            }
-            else if (pLower === "facebook") {
-                const metaClient = new MetaClient(config.access_token)
-                const pageId = config.page_id || config.instagram_business_account_id
-                if (!pageId) throw new Error("Missing Facebook Page ID")
-                
-                const postResult = await metaClient.createFacebookPost(pageId, draft.content_text)
-                logger.info(`Successfully published to Facebook`, { post_id: postResult.id })
-                results[platform] = { success: true, post_id: postResult.id }
-                lastExternalPostId = postResult.id
             }
             else if (pLower === "ghl") {
                 const ghl = new GhlProvider(config.access_token || config.apiKey)

--- a/supabase/migrations/20260820090000_publisher_fanout.sql
+++ b/supabase/migrations/20260820090000_publisher_fanout.sql
@@ -1,0 +1,101 @@
+-- The content publisher grows from two destinations to several.
+--
+-- WHY A JSONB COLUMN AND NOT MORE COLUMNS. publisher_queue already carries
+-- youtube_id / youtube_error / youtube_published_at and the Instagram triple
+-- beside them. That shape is readable at two platforms and unmanageable at
+-- seven - it would mean roughly twenty more columns, every one of them null on
+-- most rows, and a migration every time a destination is added.
+--
+-- results holds one entry per platform:
+--   {"linkedin": {"ok": true,  "id": "urn:li:share:123", "url": "..."},
+--    "x":        {"ok": false, "error": "401 unauthorized"},
+--    "tiktok":   {"skipped": "not enabled"}}
+--
+-- THE LEGACY COLUMNS STAY AND KEEP BEING WRITTEN. Every row published before
+-- this migration has its outcome only in those columns, and the publisher board
+-- reads them today. Dual-writing YouTube and Instagram costs two lines in the
+-- cron and avoids both a backfill and a board regression; new platforms live in
+-- results alone.
+alter table public.publisher_queue
+  add column if not exists results jsonb not null default '{}'::jsonb;
+
+comment on column public.publisher_queue.results is
+  'Per-platform publish outcome, keyed by platform. YouTube and Instagram are also written to their legacy columns for rows that predate this.';
+
+
+-- Credentials for the platforms this line publishes to.
+--
+-- WHY NOT client_db_connections. That table backs the older agency connector
+-- system, which this line is replacing for social publishing. It is multi-tenant
+-- (project_id, client_id, is_shared) and its rows are managed by a different UI
+-- with different assumptions. Pointing the daily publisher at it would tie the
+-- one publishing line to a system we are retiring, and a row edited over there
+-- would silently change what goes out here.
+--
+-- WHY INSTAGRAM AND YOUTUBE ARE NOT IN HERE. They already work. Instagram lives
+-- in instagram_connection (a singleton with its own refresh cron) and YouTube
+-- runs off YOUTUBE_REFRESH_TOKEN in the environment. Moving either into this
+-- table would be a rewrite of a working path for symmetry alone.
+create table if not exists public.publisher_connections (
+  -- One row per destination. The primary key IS the platform, because there is
+  -- exactly one account per platform on this line - a second LinkedIn would be
+  -- a different feature, not a second row.
+  platform text primary key
+    check (platform in ('linkedin', 'x', 'gbp', 'tiktok')),
+
+  -- THE SWITCH THAT KEEPS AN UNAVAILABLE PLATFORM HARMLESS. TikTok ships here
+  -- disabled because the app is not audited and the token carries no
+  -- video.publish scope; attempting it every slot would mark every post
+  -- 'partial' forever and train everyone to ignore the colour. A disabled
+  -- platform is SKIPPED, and skipped never counts against a post's status.
+  enabled boolean not null default false,
+
+  access_token text,
+  -- X rotates its refresh token on every use, so this column is written back on
+  -- each publish rather than only at connect time. Losing that write means the
+  -- next publish cannot authenticate and the connection has to be redone by
+  -- hand.
+  refresh_token text,
+  expires_at timestamptz,
+
+  status text not null default 'disconnected'
+    check (status in ('disconnected', 'connected', 'revoked', 'error')),
+  -- What went wrong last, kept so a dead connection explains itself on the
+  -- board instead of just failing quietly at the next slot.
+  last_error text,
+
+  -- Human-readable, for the connections panel: "Lamont Evans (Member)".
+  -- Which account a token belongs to is invisible otherwise, and posting to the
+  -- wrong one is a mistake made in public.
+  account_label text,
+
+  -- Platform-specific identifiers resolved at connect time and needed at
+  -- publish time: LinkedIn's author URN, GBP's accounts/{a}/locations/{l},
+  -- TikTok's open id. Kept as json because no two platforms agree on shape.
+  config jsonb not null default '{}'::jsonb,
+
+  connected_at timestamptz,
+  last_published_at timestamptz,
+  updated_at timestamptz not null default now()
+);
+
+comment on table public.publisher_connections is
+  'Credentials for the content-publisher line. Service-role only - it holds live access and refresh tokens.';
+
+-- LIVE TOKENS. No policy is defined, so with RLS on, the anon and authenticated
+-- roles can read nothing; the service-role key used by the cron bypasses RLS.
+-- That is the whole access model and it is deliberate: nothing in the browser
+-- ever needs a row from this table, only the server-rendered admin page does.
+alter table public.publisher_connections enable row level security;
+
+-- Seed every platform as a known-but-unconnected row, so the connections panel
+-- can render the full set without inventing placeholders for the ones nobody
+-- has authorised yet.
+insert into public.publisher_connections (platform, enabled, status)
+values
+  ('linkedin', true,  'disconnected'),
+  ('x',        true,  'disconnected'),
+  ('gbp',      true,  'disconnected'),
+  -- Off until the TikTok app passes audit and the token carries video.publish.
+  ('tiktok',   false, 'disconnected')
+on conflict (platform) do nothing;


### PR DESCRIPTION
The content publisher line published to YouTube Shorts and Instagram Reels. It now also reaches LinkedIn, X and our own Google Business Profile. TikTok is written and switched off until the app passes audit.

## The rule the design turns on

**A platform that is off or unconnected is skipped, never failed.** With six destinations the old published/partial/failed scheme collapses — TikTok being unapproved would mark every row `partial` forever and the colour on the board would stop meaning anything within a week. Status counts only platforms that were actually attempted. There is a test on it.

## What is in here

- **Four publishers** — `lib/linkedin-publish.ts`, `lib/x-publish.ts`, `lib/gbp-brand-publish.ts`, `lib/tiktok-publish.ts`
- **A registry** (`lib/admin/publisher-targets.ts`) so the next platform is one array entry rather than another branch in the cron
- **Per-platform copy** (`lib/admin/publisher-copy.ts`) — X's builder reserves 23 characters for the link because X rewrites every URL to a fixed-length t.co shortlink
- **The board is results-driven** — it walks `results` instead of hardcoding two platforms, and falls back to the legacy columns for rows published before this
- **A connect script** (`scripts/publisher_connect.js`) for the first-party machine credentials, following the pattern of `scripts/gsc_oauth_setup.js`

## Decisions worth reviewing

**Both ports target the current APIs, not the ones the old code used.** LinkedIn's docs state the Videos API replaces the Assets API and the Posts API replaces ugcPosts; X's chunked upload moved to `api.x.com/2`. Copying `supabase/functions/publish-social-post` would have shipped against deprecated endpoints.

**GBP gets the cover image, not the MP4.** A LocalPost MediaItem takes `sourceUrl` with `mediaFormat: PHOTO`, and the v4 reference does not document a video format. Google's help pages say posts support video, but that is an unverified claim to write against on a public listing.

**The video is fetched once** and shared across the four platforms that need bytes.

**linkedin/x/facebook/instagram retired from `publish-social-post`.** Two systems that can both post to the same account is how the same video goes out twice, and how a token refreshed by one is invalidated under the other — X rotates its refresh token on every use. GHL stays; nothing has replaced it. Checked first: one project, one test record from May, so nothing live was using it.

**Facebook is not in this build** — deliberate. It needs its own connection and `pages_manage_posts`; the current Instagram token is an Instagram Login token and cannot post to a Page.

## Before merging

`TWITTER_CLIENT_ID` and `TWITTER_CLIENT_SECRET` are **not in Vercel** (production or preview). Without them X is skipped cleanly — it will not break a slot — but it will not publish either.

The migration `20260820090000_publisher_fanout.sql` is **already applied** to the database.

## Verification

- `?dryRun=1` against a dev server: all five destinations resolve and build their copy, TikTok skips. The dry run sends nothing and does not claim the slot.
- 17 tests covering the status rule, the 280-character X budget, the GBP summary cap, and the dry run not inventing blockers.
- Typecheck and `npm run build` clean. The two failing tests in `components/layout/navbar.test.tsx` are pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8HYmmaiSi1yXYBrQ64jgc