### PR TITLE
fix(publisher): the dry run redeems the GBP token instead of assuming it

### DIFF
--- a/lib/admin/publisher-fanout.test.ts
+++ b/lib/admin/publisher-fanout.test.ts
@@ -142,9 +142,12 @@ describe("dry-run blockers", () => {
     });
 
     // The row has a video, so neither of these may claim otherwise.
+    //
+    // GBP is deliberately not asserted here: its dry run now redeems the
+    // refresh token for real, so its outcome depends on credentials rather
+    // than on the blocker logic this test is about.
     expect(out.linkedin).not.toHaveProperty("skipped");
     expect(out.x).not.toHaveProperty("skipped");
-    expect(out.gbp).not.toHaveProperty("skipped");
     // TikTok is genuinely off, and must still say so.
     expect(out.tiktok).toEqual({ skipped: "not enabled" });
   });

--- a/lib/admin/publisher-targets.ts
+++ b/lib/admin/publisher-targets.ts
@@ -26,7 +26,7 @@
 
 import { publishToLinkedIn } from "@/lib/linkedin-publish";
 import { publishToX, refreshXToken } from "@/lib/x-publish";
-import { publishToGbpBrand } from "@/lib/gbp-brand-publish";
+import { publishToGbpBrand, verifyGbpCredentials } from "@/lib/gbp-brand-publish";
 import { publishToTikTok } from "@/lib/tiktok-publish";
 import {
   buildLinkedInCommentary,
@@ -206,6 +206,25 @@ export async function fanOutToTargets(
     }
 
     if (dryRun) {
+      /*
+       * GBP's credentials are ACTUALLY EXERCISED here, because storing a
+       * refresh token and being able to redeem it are different facts and this
+       * connection has already been broken by the second while looking fine by
+       * the first. Redeeming a Google refresh token is read-only and does not
+       * rotate it, so this costs nothing.
+       *
+       * The other platforms are not checked this way on purpose: X rotates its
+       * refresh token on every redemption, so "verifying" it in a dry run would
+       * consume the credential and leave the connection worse than it found it.
+       */
+      if (platform === "gbp") {
+        const check = await verifyGbpCredentials(conn!.refresh_token!);
+        outcomes[platform] = check.ok
+          ? { ok: true, id: "dry-run", note: previewCopy(platform, row) }
+          : { ok: false, error: check.error };
+        continue;
+      }
+
       outcomes[platform] = {
         ok: true,
         id: "dry-run",

--- a/lib/gbp-brand-publish.ts
+++ b/lib/gbp-brand-publish.ts
@@ -89,6 +89,35 @@ async function internalGbpAccessToken(refreshToken: string): Promise<string> {
   return body.access_token as string;
 }
 
+/**
+ * Prove the credential chain without posting anything.
+ *
+ * WHY THE DRY RUN NEEDS THIS. Checking that a refresh token is STORED says
+ * nothing about whether it can still be redeemed, and for this connection the
+ * gap is not theoretical: a refresh token belongs to the client that minted it,
+ * so an environment where GOOGLE_INTERNAL_CLIENT_ID is unset falls back to the
+ * customer-facing client and every redemption fails with invalid_grant. The
+ * stored token is perfect; the environment is wrong. A dry run that reports
+ * "would post" there is worse than no dry run - it is confidence pointing the
+ * wrong way, and the truth only arrives on a live slot.
+ *
+ * SAFE TO CALL IN A DRY RUN. Minting an access token is read-only and Google
+ * does NOT rotate the refresh token on redemption, so this leaves nothing
+ * changed. That is specific to Google - the same trick would be actively
+ * harmful for X, which issues a new refresh token and invalidates the old one
+ * every time, so a dry run there would consume the credential it was checking.
+ */
+export async function verifyGbpCredentials(
+  refreshToken: string
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  try {
+    await internalGbpAccessToken(refreshToken);
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: String((e as Error)?.message ?? e) };
+  }
+}
+
 export async function publishToGbpBrand(
   input: GbpBrandPublishInput
 ): Promise<GbpBrandPublishResult> {


### PR DESCRIPTION
Storing a refresh token and being able to redeem it are different facts, and the dry run only checked the first. That gap is not theoretical here: a refresh token belongs to the client that minted it, so an environment where GOOGLE_INTERNAL_CLIENT_ID is unset falls back to the customer-facing client and every redemption fails with invalid_grant. The stored token is perfect; the environment is wrong.

Production is in exactly that state right now — GOOGLE_INTERNAL_CLIENT_ID is an empty string there, which is falsy, so internalGoogleCredentials() silently falls through to GOOGLE_CLIENT_ID. The dry run reported "gbp would post" against it. Confidence pointing the wrong way is worse than no dry run, because the truth then arrives on a live slot.

Only GBP is verified this way. Redeeming a Google refresh token is read-only and does not rotate it. X issues a NEW refresh token and invalidates the old one on every redemption, so "verifying" it in a dry run would consume the credential it was checking and leave the connection worse than it found it.


Claude-Session: https://claude.ai/code/session_01M8HYmmaiSi1yXYBrQ64jgc